### PR TITLE
Added support for turning off SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog16
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 
 ## [Unreleased]
+
+- Added support for --without-api-ssl-verify to turn off SSL verification.
 
 ## [0.13.0] - 2019-08-20
 

--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -28,6 +28,7 @@ class ConfigSchema(object):
         api_headers = Param(type=str)
         api_host = Param(type=str)
         api_proxy = Param(type=str)
+        api_ssl_verify = Param(type=bool)
         api_user_agent = Param(type=str)
 
     @matches_section("profile:*")
@@ -240,6 +241,16 @@ class Options(object):
     def api_proxy(self, value):
         """Set value for API proxy."""
         self._set_option("api_proxy", value)
+
+    @property
+    def api_ssl_verify(self):
+        """Get value for API SSL verify."""
+        return self._get_option("api_ssl_verify")
+
+    @api_ssl_verify.setter
+    def api_ssl_verify(self, value):
+        """Set value for API SSL verify."""
+        self._set_option("api_ssl_verify", value)
 
     @property
     def api_user_agent(self):

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -25,7 +25,7 @@ def common_package_action_options(f):
         "--no-wait-for-sync",
         default=False,
         is_flag=True,
-        help="Don't wait for package synchronisation to complete before " "exiting.",
+        help="Don't wait for package synchronisation to complete before exiting.",
     )
     @click.option(
         "-I",
@@ -194,6 +194,16 @@ def initialise_api(f):
         help="The API proxy to connect through.",
     )
     @click.option(
+        "-S",
+        "--without-api-ssl-verify",
+        default=False,
+        is_flag=True,
+        envvar="CLOUDSMITH_WITHOUT_API_SSL_VERIFY",
+        help="Don't verify the SSL connection for the API. This is dangerous and "
+        "should only be used in an old/broken environment that doesn't support the "
+        "same secure ciphers as Cloudsmith.",
+    )
+    @click.option(
         "--api-user-agent",
         envvar="CLOUDSMITH_API_USER_AGENT",
         help="The user agent to use for requests.",
@@ -248,9 +258,10 @@ def initialise_api(f):
         opts = config.get_or_create_options(ctx)
         opts.api_host = kwargs.pop("api_host")
         opts.api_proxy = kwargs.pop("api_proxy")
+        opts.api_ssl_verify = not kwargs.pop("without_api_ssl_verify") is True
         opts.api_user_agent = kwargs.pop("api_user_agent")
         opts.api_headers = kwargs.pop("api_headers")
-        opts.rate_limit = not kwargs.pop("without_rate_limit")
+        opts.rate_limit = not kwargs.pop("without_rate_limit") is True
         opts.rate_limit_warning = kwargs.pop("rate_limit_warning")
         opts.error_retry_max = kwargs.pop("error_retry_max")
         opts.error_retry_backoff = kwargs.pop("error_retry_backoff")
@@ -264,6 +275,7 @@ def initialise_api(f):
             host=opts.api_host,
             key=opts.api_key,
             proxy=opts.api_proxy,
+            ssl_verify=opts.api_ssl_verify,
             user_agent=opts.api_user_agent,
             headers=opts.api_headers,
             rate_limit=opts.rate_limit,

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -15,6 +15,7 @@ def initialise_api(
     host=None,
     key=None,
     proxy=None,
+    ssl_verify=True,
     user_agent=None,
     headers=None,
     rate_limit=True,
@@ -35,6 +36,7 @@ def initialise_api(
     config.error_retry_max = error_retry_max
     config.error_retry_backoff = error_retry_backoff
     config.error_retry_codes = error_retry_codes
+    config.verify_ssl = ssl_verify
 
     if headers:
         if "Authorization" in config.headers:

--- a/cloudsmith_cli/data/config.ini
+++ b/cloudsmith_cli/data/config.ini
@@ -1,12 +1,15 @@
 # Default configuration
 [default]
-# The API host to connect to.
+# The API host to connect to (default: api.cloudsmith.io).
 api_host =
 
-# The API proxy to connect through.
+# The API proxy to connect through (default: None).
 api_proxy =
 
-# The user agent to use for requests.
+# Whether to verify SSL connection to the API (default: True)
+api_ssl_verify =
+
+# The user agent to use for requests (default: calculated).
 api_user_agent =
 
 


### PR DESCRIPTION
Useful when running in an old/broken environment that doesn't support the latest version of TLS that is required by the Cloudsmith service. Should be used with care.

For example:

`python -m cloudsmith_cli ls packages your-account/your-repo -S`

or

`python -m cloudsmith_cli ls packages your-account/your-repo --without-api-ssl-verify`