### PR TITLE
Fix default config location for Windows in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ By default, the CLI will look for these in the following locations:
 - The current working directory.
 - A directory called `cloudsmith` in the OS-defined application directory. For example:
   - Linux: `$HOME/.config/cloudsmith`
-    - Windows: `C:\Users\YourName\AppData\cloudsmith`
+  - Windows: `C:\Users\YourName\AppData\Roaming\cloudsmith`
 
 Both configuration files use the simple INI format, such as:
 


### PR DESCRIPTION
Noticed that the given location the config directory for Windows machines wasn't quite correct in the docs.

In https://github.com/cloudsmith-io/cloudsmith-cli/blob/master/cloudsmith_cli/cli/config.py#L16 we use the following to find the default configuration directory:

```python
def get_default_config_path():
    """Get the default path to cloudsmith config files."""
    return click.get_app_dir("cloudsmith")
```

Running this command manually in my REPL returns: 

```
λ python3
Python 3.7.3 (v3.7.3:ef4ec6ed12, Mar 25 2019, 22:22:05) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import click
>>> click.get_app_dir("cloudsmith")
'C:\\Users\\Jamie Byrnes\\AppData\\Roaming\\cloudsmith'
>>> exit()
```

I've just adjusted the docs to reflect this 😄 