### PR TITLE
Fixed locations of config/credential files in docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ The following maintainers manage the project and are reponsible for reviewing/me
 The following contributors (in alphabetical order) are held in eternal high esteem and gratitude for their glorious contributions to the project:
 
 - Patrick McClory ([@mcclory](https://github.com/mcclory))
+- Jamie Brynes ([@jamiebrynes7](https://github.com/jamiebrynes7))

--- a/README.md
+++ b/README.md
@@ -99,8 +99,17 @@ By default, the CLI will look for these in the following locations:
 
 - The current working directory.
 - A directory called `cloudsmith` in the OS-defined application directory. For example:
-  - Linux: `$HOME/.config/cloudsmith`
-    - Windows: `C:\Users\YourName\AppData\cloudsmith`
+  - Linux:
+    - `$HOME/.config/cloudsmith`
+    - `$HOME/.cloudsmith`
+  - Mac OS:
+    - `$HOME/Library/Application Support/cloudsmith`
+    - `$HOME/.cloudsmith`
+  - Windows:
+    - `C:\Users\<user>\AppData\Local\cloudsmith` (Win7+, not roaming)
+    - `C:\Users\<user>\AppData\Roaming\cloudsmith` (Win7+, roaming)
+    - `C:\Documents and Settings\<user>\Application Data\cloudsmith` (WinXP, not roaming)
+    - `C:\Documents and Settings\<user>\Local Settings\Application Data\cloudsmith` (WinXP, roaming)
 
 Both configuration files use the simple INI format, such as:
 


### PR DESCRIPTION
Based on #16 to extend for Mac OS X and different flavours of Window stoo.