### PR TITLE
[ENG-199] Include optional space in config replacement regex

### DIFF
--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -115,7 +115,7 @@ class ConfigReader(ConfigFileReader):
         for k, v in six.iteritems(data):
             v = v or ""
             config = re.sub(
-                r"^(%(key)s) =[ ]*$" % {"key": k},
+                r"^(%(key)s)\s?=[ ]*$" % {"key": k},
                 "%(key)s = %(value)s" % {"key": k, "value": v},
                 config,
                 flags=re.MULTILINE,

--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -115,7 +115,7 @@ class ConfigReader(ConfigFileReader):
         for k, v in six.iteritems(data):
             v = v or ""
             config = re.sub(
-                r"^(%(key)s)\s?=[ ]*$" % {"key": k},
+                r"^(%(key)s)\s*=\s*$" % {"key": k},
                 "%(key)s = %(value)s" % {"key": k, "value": v},
                 config,
                 flags=re.MULTILINE,


### PR DESCRIPTION
[Jira ticket]()

# What changed?

This PR fixes a bug in the CLI's `login` command where config values weren't being automatically inserted into the config files.

This seems to be due to both [config](https://github.com/cloudsmith-io/cloudsmith-cli/blob/master/cloudsmith_cli/data/config.ini) and [credentials](https://github.com/cloudsmith-io/cloudsmith-cli/blob/master/cloudsmith_cli/data/credentials.ini) template files no longer have spaces before the assignment of their values, causing the regex to no longer match those lines, meaning those lines were never replaced.

![cloudsmith cli populating config](https://user-images.githubusercontent.com/2609244/77680591-182e1800-6f8c-11ea-8f52-774e4d72be03.gif)
