### PR TITLE
Automate publishing of cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@
 #
 version: 2.1
 
+parameters:
+  should_publish:
+    description: Whether the CLI should be published to repositories
+    type: boolean
+    default: false
+
 jobs:
   publish:
     docker:
@@ -24,10 +30,13 @@ jobs:
       TWINE_USERNAME: <<parameters.username>>
       TWINE_PASSWORD: <<parameters.password>>
     steps:
-      - checkout
-      - run: pip install --user --upgrade setuptools twine wheel
-      - run: setup.py sdist bdist_wheel
-      - run: twine upload dist/*
+      - when:
+          condition: <<pipeline.parameters.should_publish>>
+          steps:
+            - checkout
+            - run: pip install --user --upgrade setuptools twine wheel
+            - run: setup.py sdist bdist_wheel
+            - run: twine upload dist/*
 
 orbs:
   cloudsmith_ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,31 @@
 #
 version: 2.1
 
+jobs:
+  publish:
+    docker:
+      - image: circleci/python:3.6.1
+    parameters:
+      registry_url:
+        description: Registry URL to upload the CLI to
+        type: string
+        default: https://upload.pypi.org/legacy/
+      username:
+        description: Twine username
+        type: string
+      password:
+        description: Twine password
+        type: string
+    environment:
+      TWINE_REPOSITORY_URL: <<parameters.registry_url>>
+      TWINE_USERNAME: <<parameters.username>>
+      TWINE_PASSWORD: <<parameters.password>>
+    steps:
+      - checkout
+      - run: pip install --user --upgrade setuptools twine wheel
+      - run: setup.py sdist bdist_wheel
+      - run: twine upload dist/*
+
 orbs:
   cloudsmith_ci:
     jobs:
@@ -110,3 +135,32 @@ workflows:
           service_name: pytest
           command: pytest --cov-report xml:./reports/coverage.xml --junitxml ./reports/pytest.xml
           is_test_suite: true
+      - publish:
+          requires:
+            - isort
+            - black
+            - pyflakes
+            - pylint
+            - pytest
+          filters:
+            branches:
+              only:
+                - master
+          name: cloudsmith
+          registry_url: https://python.cloudsmith.io/cloudsmith/api/
+          username: ${CLOUDSMITH_USERNAME}
+          password: ${CLOUDSMITH_PASSWORD}
+      - publish:
+          requires:
+            - isort
+            - black
+            - pyflakes
+            - pylint
+            - pytest
+          filters:
+            branches:
+              only:
+                - master
+          name: pypi
+          username: ${PYPI_USERNAME}
+          password: ${PYPI_PASSWORD}

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+curl -X POST https://circleci.com/api/v2/project/cloudsmith-cli/pipeline \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H "Circle-Token: $CIRCLE_TOKEN" \
+  --data '{"branch": "master", "parameters": {"should_publish": true}}'


### PR DESCRIPTION
# What changed?

This PR adds the ability into the CircleCI config for us to publish the CLI, with a guard to prevent us from publishing on each merge into master.

We can then use the `bin/publish` script to trigger the pipeline, overriding the `should_publish` parameter, pubishing to pypi and cloudsmith.

## To Do
 - [ ] Add appropriate environment variables to the pipeline settings