### PR TITLE
[ENG-39] Add repository CRUD to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.21.0] - 2020-04-03
+## [0.21.0] - 2020-04-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.21.0] - 2020-04-03
+
+### Added
+
+- Support for repositories API and subcommands (`list`, `create`, `retrieve`, `update` and `delete`).
+
 ## [0.20.1] - 2020-03-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,46 +27,51 @@ Please see the [changelog](https://github.com/cloudsmith-io/cloudsmith-cli/blob/
 
 The CLI currently supports the following commands (and sub-commands):
 
-- `check`:               Check rate limits and service status.
-- `copy`|`cp`:           Copy a package to another repository.
-- `delete`|`rm`:         Delete a package from a repository.
-- `docs`:                Launch the help website in your browser.
-- `entitlements`|`ents`: Manage the entitlements for a repository.
-  - `create`|`new`:        Create a new entitlement in a repository.
-  - `delete`|`rm`:         Delete an entitlement from a repository.
-  - `list`|`ls`:           List entitlements for a repository.
-  - `refresh`:             Refresh an entitlement in a repository.
-  - `sync`:                Sync entitlements from another repository.
-  - `update`|`set`:        Update (patch) a entitlement in a repository.
-- `help`:                Display the delightful help message and exit.
-- `list`|`ls`:           List distros, packages, repos and entitlements.
-  - `distros`:             List available distributions.
-  - `entitlements`:        List entitlements for a repository.
-  - `packages`:            List packages for a repository.
-  - `repos`:               List repositories for a namespace (owner).
-- `login`|`token`:       Retrieve your API authentication token/key via login.
-- `move`|`mv`:           Move (promote) a package to another repo.
-- `push`|`upload`:       Push (upload) a new package to a repository.
-  - `alpine`:              Push (upload) a new Alpine package upstream.
-  - `cargo`:               Push (upload) a new Cargo package upstream.
-  - `composer`:            Push (upload) a new Composer package upstream.
-  - `cran`:                Push (upload) a new R/CRAN package upstream.
-  - `deb`:                 Push (upload) a new Debian package upstream.
-  - `docker`:              Push (upload) a new Docker image upstream.
-  - `go`:                  Push (upload) a new Go module upstream.
-  - `helm`:                Push (upload) a new Helm package upstream.
-  - `luarocks`:            Push (upload) a new Lua module upstream.
-  - `maven`:               Push (upload) a new Maven package upstream.
-  - `npm`:                 Push (upload) a new Npm package upstream.
-  - `nuget`:               Push (upload) a new NuGet package upstream.
-  - `python`:              Push (upload) a new Python package upstream.
-  - `raw`:                 Push (upload) a new Raw package upstream.
-  - `rpm`:                 Push (upload) a new RedHat package upstream.
-  - `ruby`:                Push (upload) a new Ruby package upstream.
-  - `vagrant`:             Push (upload) a new Vagrant package upstream.
-- `resync`:              Resynchronise a package in a repository.
-- `status`:              Get the synchronisation status for a package.
-- `whoami`:              Retrieve your current authentication status.
+- `check`:                Check rate limits and service status.
+- `copy`|`cp`:            Copy a package to another repository.
+- `delete`|`rm`:          Delete a package from a repository.
+- `docs`:                 Launch the help website in your browser.
+- `entitlements`|`ents`:  Manage the entitlements for a repository.
+  - `create`|`new`:         Create a new entitlement in a repository.
+  - `delete`|`rm`:          Delete an entitlement from a repository.
+  - `list`|`ls`:            List entitlements for a repository.
+  - `refresh`:              Refresh an entitlement in a repository.
+  - `sync`:                 Sync entitlements from another repository.
+  - `update`|`set`:         Update (patch) a entitlement in a repository.
+- `help`:                 Display the delightful help message and exit.
+- `list`|`ls`:            List distros, packages, repos and entitlements.
+  - `distros`:              List available distributions.
+  - `entitlements`:         List entitlements for a repository.
+  - `packages`:             List packages for a repository. (Aliases `repos list`)
+  - `repos`:                List repositories for a namespace (owner).
+- `login`|`token`:        Retrieve your API authentication token/key via login.
+- `move`|`mv`:            Move (promote) a package to another repo.
+- `push`|`upload`:        Push (upload) a new package to a repository.
+  - `alpine`:               Push (upload) a new Alpine package upstream.
+  - `cargo`:                Push (upload) a new Cargo package upstream.
+  - `composer`:             Push (upload) a new Composer package upstream.
+  - `cran`:                 Push (upload) a new R/CRAN package upstream.
+  - `deb`:                  Push (upload) a new Debian package upstream.
+  - `docker`:               Push (upload) a new Docker image upstream.
+  - `go`:                   Push (upload) a new Go module upstream.
+  - `helm`:                 Push (upload) a new Helm package upstream.
+  - `luarocks`:             Push (upload) a new Lua module upstream.
+  - `maven`:                Push (upload) a new Maven package upstream.
+  - `npm`:                  Push (upload) a new Npm package upstream.
+  - `nuget`:                Push (upload) a new NuGet package upstream.
+  - `python`:               Push (upload) a new Python package upstream.
+  - `raw`:                  Push (upload) a new Raw package upstream.
+  - `rpm`:                  Push (upload) a new RedHat package upstream.
+  - `ruby`:                 Push (upload) a new Ruby package upstream.
+  - `vagrant`:              Push (upload) a new Vagrant package upstream.
+- `repositories`|`repos`: Manage repositories.
+  - `create`|`new`:         Create a new repository in a namespace.
+  - `get`|`list`|`ls`:      List repositories for a user, in a namespace or get details for a specific repository.
+  - `update`:               Update a repository in a namespace.
+  - `delete`|`rm`:          Delete a repository from a namespace.
+- `resync`:               Resynchronise a package in a repository.
+- `status`:               Get the synchronisation status for a package.
+- `whoami`:               Retrieve your current authentication status.
 
 
 ## Installation

--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -12,6 +12,7 @@ from . import list_  # noqa
 from . import login  # noqa
 from . import move  # noqa
 from . import push  # noqa
+from . import repos  # noqa
 from . import resync  # noqa
 from . import status  # noqa
 from . import whoami  # noqa

--- a/cloudsmith_cli/cli/commands/list_.py
+++ b/cloudsmith_cli/cli/commands/list_.py
@@ -6,11 +6,9 @@ import functools
 from operator import itemgetter
 
 import click
-import six
 
 from ...core.api.distros import list_distros
 from ...core.api.packages import get_package_format_names_with_distros, list_packages
-from ...core.api.repos import list_repos
 from .. import command, decorators, utils, validators
 from ..exceptions import handle_api_exceptions
 from ..utils import maybe_spinner

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -153,15 +153,14 @@ def create(ctx, opts, owner, repo_config_file):
     - REPO_CONFIG_FILE: Config file specifying the settings for the
       repository to be created.
 
+        \b
         Example:
-        ```json
         {
           "name": "your-repo",
           "description": "your repo description",
           "repository_type_str": "Private",
           "slug": "your-repo-slug"
         }
-        ```
 
     Full CLI example:
 
@@ -219,13 +218,12 @@ def update(ctx, opts, owner_repo, repo_config_file):
     - REPO_CONFIG_FILE: Config file specifying the settings to
       update on the repository.
 
+        \b
         Example:
-        ```json
         {
           "description": "your updated repo description",
           "repository_type_str": "Open-Source",
         }
-        ```
 
     Full CLI example:
 

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -258,7 +258,7 @@ def update(ctx, opts, owner_repo, repo_config_file):
     print_repositories(opts=opts, data=[repository], show_list_info=False)
 
 
-@repositories.command()
+@repositories.command(aliases=["rm"])
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -113,10 +113,10 @@ def get(ctx, opts, owner_repo, page, page_size):
     if isinstance(owner_repo, str):
         repo = None
 
-        if len(str) == 0:
-            owner = None
-        else:
+        if owner_repo:
             owner = owner_repo
+        else:
+            owner = None
 
     context_msg = "Failed to get list of repositories!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -223,7 +223,7 @@ def update(ctx, opts, owner_repo, repo_config_file):
         ```json
         {
           "description": "your updated repo description",
-          "repository_type_str": "Open Source",
+          "repository_type_str": "Open-Source",
         }
         ```
 
@@ -251,7 +251,7 @@ def update(ctx, opts, owner_repo, repo_config_file):
     context_msg = "Failed to update the repository!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            repository = api.update_repository(owner=owner, repo=repo, **repo_config)
+            repository = api.update_repo(owner, repo, repo_config)
 
     click.secho("OK", fg="green", err=use_stderr)
 

--- a/cloudsmith_cli/cli/commands/repositories.py
+++ b/cloudsmith_cli/cli/commands/repositories.py
@@ -73,20 +73,25 @@ def repositories(ctx, opts):  # pylink: disable=unused-argument
     """
 
 
-@repositories.command(name="list", aliases=["ls"])
+@repositories.command(name="get", aliases=["list", "ls"])
 @decorators.common_cli_config_options
 @decorators.common_cli_list_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
 @decorators.initialise_api
-@click.argument("owner", default=None, required=False)
+@click.argument(
+    "owner_repo", metavar="OWNER/REPO", callback=validators.validate_owner_optional_repo
+)
 @click.pass_context
-def list_(ctx, opts, owner, page, page_size):
+def get(ctx, opts, owner_repo, page, page_size):
     """
     List repositories for a namespace (owner).
 
-    OWNER: Specify the OWNER namespace (i.e user or org) to list the
+    OWNER/REPO: Specify the OWNER namespace (i.e user or org) to list the
     repositories for that namespace.
+
+    If REPO isn't specified, all repositories will be retrieved from the
+    OWNER namespace.
 
     If OWNER isn't specified it'll default to the currently authenticated user
     (if any). If you're unauthenticated, no results will be returned.
@@ -96,10 +101,14 @@ def list_(ctx, opts, owner, page, page_size):
 
     click.echo("Getting list of repositories ... ", nl=False, err=use_stderr)
 
+    owner, repo = owner_repo
+
     context_msg = "Failed to get list of repositories!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            repos_, page_info = list_repos(owner=owner, page=page, page_size=page_size)
+            repos_, page_info = list_repos(
+                owner=owner, repo=repo, page=page, page_size=page_size
+            )
 
     click.secho("OK", fg="green", err=use_stderr)
 

--- a/cloudsmith_cli/cli/commands/repositories.py
+++ b/cloudsmith_cli/cli/commands/repositories.py
@@ -1,0 +1,286 @@
+# -*- coding: utf8 -*-
+"""CLI/Commands - create, retrieve, update or delete repositories."""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+from operator import itemgetter
+
+import click
+import six
+
+from ...core.api import repositories as api
+from ...core.api.repos import list_repos
+from .. import command, decorators, utils, validators
+from ..exceptions import handle_api_exceptions
+from ..utils import maybe_spinner
+from .main import main
+
+
+def print_repositories(opts, data, page_info=None, show_list_info=True):
+    """Print repositories as a table or output in another format."""
+    headers = [
+        "Name",
+        "Type",
+        "Packages",
+        "Groups",
+        "Downloads",
+        "Size",
+        "Owner / Repository (Identifier)",
+    ]
+
+    rows = []
+    for repo in sorted(data, key=itemgetter("namespace", "slug")):
+        rows.append(
+            [
+                click.style(repo["name"], fg="cyan"),
+                click.style(repo["repository_type_str"], fg="yellow"),
+                click.style(six.text_type(repo["package_count"]), fg="blue"),
+                click.style(six.text_type(repo["package_group_count"]), fg="blue"),
+                click.style(six.text_type(repo["num_downloads"]), fg="blue"),
+                click.style(six.text_type(repo["size_str"]), fg="blue"),
+                "%(owner_slug)s/%(slug)s"
+                % {
+                    "owner_slug": click.style(repo["namespace"], fg="magenta"),
+                    "slug": click.style(repo["slug"], fg="green"),
+                },
+            ]
+        )
+
+    if data:
+        click.echo()
+        utils.pretty_print_table(headers, rows)
+
+    click.echo()
+
+    num_results = len(data)
+    list_suffix = "repositor%s visible" % ("ies" if num_results != 1 else "y")
+    utils.pretty_print_list_info(
+        num_results=num_results, page_info=page_info, suffix=list_suffix
+    )
+
+
+@main.group(cls=command.AliasGroup, name="repositories", aliases=["repos"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.pass_context
+def repositories(ctx, opts):  # pylink: disable=unused-argument
+    """
+    Manage Repositories.
+
+    See the help for subommands for more information on each.
+    """
+
+
+@repositories.command(name="list", aliases=["ls"])
+@decorators.common_cli_config_options
+@decorators.common_cli_list_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument("owner", default=None, required=False)
+@click.pass_context
+def list_(ctx, opts, owner, page, page_size):
+    """
+    List repositories for a namespace (owner).
+
+    OWNER: Specify the OWNER namespace (i.e user or org) to list the
+    repositories for that namespace.
+
+    If OWNER isn't specified it'll default to the currently authenticated user
+    (if any). If you're unauthenticated, no results will be returned.
+    """
+    # Use stderr for messages if the output is something else (e.g.  # JSON)
+    use_stderr = opts.output != "pretty"
+
+    click.echo("Getting list of repositories ... ", nl=False, err=use_stderr)
+
+    context_msg = "Failed to get list of repositories!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            repos_, page_info = list_repos(owner=owner, page=page, page_size=page_size)
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, repos_, page_info):
+        return
+
+    print_repositories(opts=opts, data=repos_, show_list_info=False)
+
+
+@repositories.command(aliases=["new"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument("owner", default=None, required=True)
+@click.argument("repo_config_file", type=click.File("rb"), required=True)
+@click.pass_context
+def create(ctx, opts, owner, repo_config_file):
+    """
+    Create a new repository in a namespace.
+
+    - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
+      to create a repository.
+
+        Example: 'your-org'
+
+    - REPO_CONFIG_FILE: Config file specifying the settings for the
+      repository to be created.
+
+        Example:
+        ```json
+        {
+          "name": "your-repo",
+          "description": "your repo description",
+          "repository_type_str": "Private",
+          "slug": "your-repo-slug"
+        }
+        ```
+
+    Full CLI example:
+
+      $ cloudsmith repos create your-org repo-config-file.json
+    """
+    # Use stderr for messages if the output is something else (e.g. JSON)
+    use_stderr = opts.output != "pretty"
+    repo_config = json.load(repo_config_file)
+
+    repo_name = repo_config.get("name", None)
+    if repo_name is None:
+        raise click.BadParameter(
+            "Name is a required field for creating a repository.", param="name"
+        )
+
+    click.secho(
+        "Creating %(name)s repository for the %(owner)s namespace ..."
+        % {
+            "name": click.style(repo_name, bold=True),
+            "owner": click.style(owner, bold=True),
+        },
+        nl=False,
+        err=use_stderr,
+    )
+
+    context_msg = "Failed to create the repository!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            repository = api.create_repository(owner=owner, **repo_config)
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    print_repositories(opts=opts, data=[repository], show_list_info=False)
+
+
+@repositories.command()
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument(
+    "owner_repo", metavar="OWNER/REPO", callback=validators.validate_owner_repo
+)
+@click.argument("repo_config_file", type=click.File("rb"), required=True)
+@click.pass_context
+def update(ctx, opts, owner_repo, repo_config_file):
+    """
+    Update a repository.
+
+    - OWNER/REPO: Specify the OWNER namespace (i.e. user or org),
+      and the REPO name to be updated. All separated by a slash.
+
+        Example: 'your-org/your-repo'
+
+    - REPO_CONFIG_FILE: Config file specifying the settings to
+      update on the repository.
+
+        Example:
+        ```json
+        {
+          "description": "your updated repo description",
+          "repository_type_str": "Open Source",
+        }
+        ```
+
+    Full CLI example:
+
+      $ cloudsmith repos update your-org/your-repo repo-config-file.json
+
+    """
+    # Use stderr for message if the output is something else (e.g. JSON)
+    use_stderr = opts.output != "pretty"
+
+    owner, repo = owner_repo
+    repo_config = json.load(repo_config_file)
+
+    click.secho(
+        "Updating %(name)s repository in the %(owner)s namespace ..."
+        % {
+            "name": click.style(repo, bold=True),
+            "owner": click.style(owner, bold=True),
+        },
+        nl=False,
+        err=use_stderr,
+    )
+
+    context_msg = "Failed to update the repository!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            repository = api.update_repository(owner=owner, repo=repo, **repo_config)
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    print_repositories(opts=opts, data=[repository], show_list_info=False)
+
+
+@repositories.command()
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument(
+    "owner_repo", metavar="OWNER/REPO", callback=validators.validate_owner_repo
+)
+@click.option(
+    "-y",
+    "--yes",
+    default=False,
+    is_flag=True,
+    help="Assume yes as default answer to questions (this is dangerous!)",
+)
+@click.pass_context
+def delete(ctx, opts, owner_repo, yes):
+    """
+    Delete a repository from a namespace.
+
+    - OWNER/REPO: Specify the OWNER namespace (i.e. user or org), and the name of the REPO
+      to be deleted, separated by a slash.
+
+        Example: 'your-org/your-repo'
+
+    Full CLI example:
+
+      $ cloudsmith repos delete your-org/your-repo
+    """
+    owner, repo = owner_repo
+    delete_args = {
+        "namespace": click.style(owner, bold=True),
+        "repository": click.style(repo, bold=True),
+    }
+
+    prompt = "delete the %(repository)s from the %(namespace)s namespace" % delete_args
+    if not utils.confirm_operation(prompt, assume_yes=yes):
+        return
+
+    click.secho(
+        "Deleting %(repository)s from the %(namespace)s namespace ... " % delete_args,
+        nl=False,
+    )
+
+    context_msg = "Failed to delete the repository!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            api.delete_repository(owner=owner, repo=repo)
+
+    click.secho("OK", fg="green")

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -87,6 +87,13 @@ def validate_slashes(param, value, minimum=2, maximum=None, form=None):
     return value
 
 
+def validate_owner_optional_repo(ctx, param, value):
+    """Ensure that owner/repo is formatted correctly, where repo is optional."""
+    # pylint: disable=unused-argument
+    form = "OWNER/REPO"
+    return validate_slashes(param, value, minimum=1, maximum=2, form=form)
+
+
 def validate_owner_repo(ctx, param, value):
     """Ensure that owner/repo is formatted correctly."""
     # pylint: disable=unused-argument

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -61,7 +61,9 @@ def validate_api_headers(param, value):
     return headers
 
 
-def validate_slashes(param, value, minimum=2, maximum=None, form=None, optional=False):
+def validate_slashes(
+    param, value, minimum=2, maximum=None, form=None, allow_blank=False
+):
     """Ensure that parameter has slashes and minimum parts."""
     try:
         value = value.split("/")
@@ -81,7 +83,7 @@ def validate_slashes(param, value, minimum=2, maximum=None, form=None, optional=
         )
 
     value = [v.strip() for v in value]
-    if not optional and not all(value):
+    if not allow_blank and not all(value):
         raise click.BadParameter("Individual values cannot be blank", param=param)
 
     return value
@@ -91,8 +93,9 @@ def validate_optional_owner_repo(ctx, param, value):
     """Ensure that owner/repo is formatted correctly, where owner and repo are optional."""
     # pylint: disable=unused-argument
     form = "OWNER/REPO"
+
     return validate_slashes(
-        param, value, minimum=0, maximum=2, form=form, optional=True
+        param, value, minimum=0, maximum=2, form=form, allow_blank=True
     )
 
 

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -61,7 +61,7 @@ def validate_api_headers(param, value):
     return headers
 
 
-def validate_slashes(param, value, minimum=2, maximum=None, form=None):
+def validate_slashes(param, value, minimum=2, maximum=None, form=None, optional=False):
     """Ensure that parameter has slashes and minimum parts."""
     try:
         value = value.split("/")
@@ -81,17 +81,19 @@ def validate_slashes(param, value, minimum=2, maximum=None, form=None):
         )
 
     value = [v.strip() for v in value]
-    if not all(value):
+    if not optional and not all(value):
         raise click.BadParameter("Individual values cannot be blank", param=param)
 
     return value
 
 
-def validate_owner_optional_repo(ctx, param, value):
-    """Ensure that owner/repo is formatted correctly, where repo is optional."""
+def validate_optional_owner_repo(ctx, param, value):
+    """Ensure that owner/repo is formatted correctly, where owner and repo are optional."""
     # pylint: disable=unused-argument
     form = "OWNER/REPO"
-    return validate_slashes(param, value, minimum=1, maximum=2, form=form)
+    return validate_slashes(
+        param, value, minimum=0, maximum=2, form=form, optional=True
+    )
 
 
 def validate_owner_repo(ctx, param, value):

--- a/cloudsmith_cli/core/api/repos.py
+++ b/cloudsmith_cli/core/api/repos.py
@@ -64,7 +64,7 @@ def update_repo(owner, repo, repo_config):
 
     with catch_raise_api_exception():
         data, _, headers = client.repos_partial_update_with_http_info(
-            owner, repo=repo, data=repo_config
+            owner, repo, data=repo_config
         )
 
     ratelimits.maybe_rate_limit(client, headers)

--- a/cloudsmith_cli/core/api/repos.py
+++ b/cloudsmith_cli/core/api/repos.py
@@ -25,9 +25,7 @@ def list_repos(owner=None, **kwargs):
     if owner:
         repo = kwargs.get("repo", None)
         if repo is not None:
-
             if hasattr(client, "repos_read_with_http_info"):
-                print(f"Owner: {owner}, Repo: {repo}")
                 with catch_raise_api_exception():
                     res, _, headers = client.repos_read_with_http_info(owner, repo)
                     res = [res]
@@ -66,7 +64,7 @@ def update_repo(owner, repo, repo_config):
 
     with catch_raise_api_exception():
         data, _, headers = client.repos_partial_update_with_http_info(
-            owner=owner, repo=repo, data=repo_config
+            owner, repo=repo, data=repo_config
         )
 
     ratelimits.maybe_rate_limit(client, headers)
@@ -78,8 +76,6 @@ def delete_repo(owner, repo):
     client = get_repos_api()
 
     with catch_raise_api_exception():
-        _, _, headers = client.entitlements_delete_with_http_info(
-            owner=owner, repo=repo
-        )
+        _, _, headers = client.repos_delete_with_http_info(owner, repo)
 
     ratelimits.maybe_rate_limit(client, headers)

--- a/cloudsmith_cli/core/api/repos.py
+++ b/cloudsmith_cli/core/api/repos.py
@@ -22,24 +22,64 @@ def list_repos(owner=None, **kwargs):
     api_kwargs = {}
     api_kwargs.update(utils.get_page_kwargs(**kwargs))
 
-    # pylint: disable=fixme
-    # FIXME: Compatibility code until we work out how to conflate
-    # the overlapping repos_list methods into one.
-    repos_list = client.repos_list_with_http_info
+    if owner:
+        repo = kwargs.get("repo", None)
+        if repo is not None:
 
-    if owner is not None:
-        api_kwargs["owner"] = owner
-        if hasattr(client, "repos_list0_with_http_info"):
-            # pylint: disable=no-member
-            repos_list = client.repos_list0_with_http_info
+            if hasattr(client, "repos_read_with_http_info"):
+                print(f"Owner: {owner}, Repo: {repo}")
+                with catch_raise_api_exception():
+                    res, _, headers = client.repos_read_with_http_info(owner, repo)
+                    res = [res]
+        else:
+            api_kwargs["owner"] = owner
+
+            if hasattr(client, "repos_list_with_http_info"):
+                with catch_raise_api_exception():
+                    res, _, headers = client.repos_list_with_http_info(**api_kwargs)
     else:
         if hasattr(client, "repos_all_list_with_http_info"):
-            # pylint: disable=no-member
-            repos_list = client.repos_all_list_with_http_info
-
-    with catch_raise_api_exception():
-        res, _, headers = repos_list(**api_kwargs)
+            with catch_raise_api_exception():
+                res, _, headers = client.repos_all_list_with_http_info(**api_kwargs)
 
     ratelimits.maybe_rate_limit(client, headers)
     page_info = PageInfo.from_headers(headers)
     return [x.to_dict() for x in res], page_info
+
+
+def create_repo(owner, repo_config):
+    """Create a repository in a namespace."""
+    client = get_repos_api()
+
+    with catch_raise_api_exception():
+        data, _, headers = client.repos_create_with_http_info(
+            owner=owner, data=repo_config
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return data.to_dict()
+
+
+def update_repo(owner, repo, repo_config):
+    """Update a repo in a namespace."""
+    client = get_repos_api()
+
+    with catch_raise_api_exception():
+        data, _, headers = client.repos_partial_update_with_http_info(
+            owner=owner, repo=repo, data=repo_config
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return data.to_dict()
+
+
+def delete_repo(owner, repo):
+    """Delete a repo from a namespace."""
+    client = get_repos_api()
+
+    with catch_raise_api_exception():
+        _, _, headers = client.entitlements_delete_with_http_info(
+            owner=owner, repo=repo
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)


### PR DESCRIPTION
# What changed?

This PR adds support for creating, retrieving, updating and deleting repositories via the CLI, and aliases the `ls repos` command to `repos ls`.

Examples of commands:
 - `cloudsmith repositories list`
 - `cloudsmith repos ls namespace`
 - `cloudsmith repos get namespace/repo`
 - `cloudsmith repos create namespace repo-config.json`
 - `cloudsmith repos update namespace/repo repo-config.json`
 - `cloudsmith repos rm namespace/repo`