### PR TITLE
Bump cloudsmith-api minimum version to version supporting all required methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
-        "cloudsmith-api>=0.0,<1.0",  # Compatible with 0.* upto (but excluding) 1.0+
+        "cloudsmith-api>=0.49.118,<1.0",  # Compatible with 0.49.118 upto (but excluding) 1.0+
         "colorama>=0.3.9",
         "future>=0.16.0",
         "requests>=2.18.4",


### PR DESCRIPTION
# What changed?

This PR increases the minimum version for `cloudsmith-api` to `0.49.118`, which is required for the repos subcommands to be able to function.

Without this minimum version, users updating the cli will not be updated to the appropriate version of the API bindings, meaning they'll be unable to use the repository subcommands unless manually updating the dependency