### PR TITLE
[ENG-518] Updated support for Conan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.22.1] - 2020-06-10
+
+### Added
+
+- Update for (C/C++) Conan packages.
+
+**Note:** This release pins the Cloudsmith API library to version 0.51 due to
+changes in the versioning of the library. If you're having issues with an older
+version of the CLI that installs the latest API, please upgrade your CLI
+version, or install `cloudsmith-api==0.51.34`.
+
 ## [0.22.0] - 2020-06-05
 
 ### Added
@@ -18,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 **Note:** This release pins the Cloudsmith API library to version 0.51 due to
 changes in the versioning of the library. If you're having issues with an older
 version of the CLI that installs the latest API, please upgrade your CLI
-version, or install `cloudsmith-api==0.51.22`.
+version, or install `cloudsmith-api==0.51.34`.
 
 ## [0.21.0] - 2020-04-16
 

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -4,7 +4,7 @@ click>=7.0
 click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
-cloudsmith-api>=0.51.22
+cloudsmith-api>=0.51.34
 colorama==0.3.9
 future>=0.16.0,<1.0.0
 requests>=2.18.4,<3.0.0

--- a/requirements/development.py2.txt
+++ b/requirements/development.py2.txt
@@ -20,7 +20,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.51.22
+cloudsmith-api==0.51.34
 codecov==2.0.15
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile, entrypoints, flake8, importlib-metadata, pylint

--- a/requirements/development.py3.txt
+++ b/requirements/development.py3.txt
@@ -21,7 +21,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.51.22
+cloudsmith-api==0.51.34
 codecov==2.0.15
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile

--- a/requirements/production.py2.txt
+++ b/requirements/production.py2.txt
@@ -12,7 +12,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.51.22
+cloudsmith-api==0.51.34
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile
 future==0.17.1

--- a/requirements/production.py3.txt
+++ b/requirements/production.py3.txt
@@ -12,7 +12,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.51.22
+cloudsmith-api==0.51.34
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile
 future==0.17.1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
-        "cloudsmith-api>=0.51.22,<1.0",  # Compatible with 0.51.22 upto (but excluding) 1.0+
+        "cloudsmith-api>=0.51.34,<1.0",  # Compatible with 0.51.34 upto (but excluding) 1.0+
         "colorama>=0.3.9",
         "future>=0.16.0",
         "requests>=2.18.4",


### PR DESCRIPTION
### What's Changed

Bumps API version to use latest (contains updated support for Conan)

depends on https://github.com/cloudsmith-io/cloudsmith-api/pull/8