### PR TITLE
copy: add slug_perm to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `cloudsmith copy` now prints `Copied: owner/repo/slug (slug_perm)` after a successful copy and includes `slug_perm` in `-F json` output, matching `push`.
+
 ## [1.25.0] - 2026-08-24
 
 ### Added

--- a/cloudsmith_cli/cli/commands/copy.py
+++ b/cloudsmith_cli/cli/commands/copy.py
@@ -71,14 +71,26 @@ def copy(
         ),
         maybe_spinner(opts),
     ):
-        _, new_slug = copy_package(
+        slug_perm, new_slug = copy_package(
             owner=owner, repo=source, identifier=slug, destination=destination
         )
 
     click.secho("OK", fg="green", err=use_stderr)
 
+    click.echo(
+        "Copied: {owner}/{repo}/{slug} ({slug_perm})".format(
+            owner=click.style(owner, fg="magenta"),
+            repo=click.style(destination, fg="magenta"),
+            slug=click.style(new_slug, fg="green"),
+            slug_perm=click.style(slug_perm, bold=True),
+        ),
+        err=use_stderr,
+    )
+
     if no_wait_for_sync:
-        utils.maybe_print_status_json(opts, {"slug": new_slug, "status": "OK"})
+        utils.maybe_print_status_json(
+            opts, {"slug": new_slug, "slug_perm": slug_perm, "status": "OK"}
+        )
         return
 
     wait_for_package_sync(
@@ -92,4 +104,6 @@ def copy(
         attempts=sync_attempts,
     )
 
-    utils.maybe_print_status_json(opts, {"slug": new_slug, "status": "OK"})
+    utils.maybe_print_status_json(
+        opts, {"slug": new_slug, "slug_perm": slug_perm, "status": "OK"}
+    )


### PR DESCRIPTION
When using the copy command to copy packages between repositories, the unique ID
(slug_perm) of the package wasn't being printed to stdout.  As with other commands
(such as 'push') which did, the output of this could then be parsed to further operate
on the specific package.

Therefore, make the output from 'copy' behave in the same way.