### PR TITLE
Add Quota Command's for limits and history

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.24.2
+current_version = 0.25.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<revision>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.25.0] - 2020-09-16
+
+Note: This release requires `cloudsmith-api` >= `0.53.3`.
+
+### Added
+
+- Support for Quota API limits & history
+
 ## [0.24.2] - 2020-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The CLI currently supports the following commands (and sub-commands):
   - `ruby`:                 Push (upload) a new Ruby package upstream.
   - `terraform`:            Push (upload) a new Terraform package upstream.
   - `vagrant`:              Push (upload) a new Vagrant package upstream.
+- `quota`:                Quota limits and history for a organisation.
+  - `limits`:               Display the Quota (bandwidth & storage usage/limits) for a specific organisation.
+  - `history`:              Display the Quota History (upload, download, and storage usage/limits) for a specific organisation.
 - `repositories`|`repos`: Manage repositories.
   - `create`|`new`:         Create a new repository in a namespace.
   - `get`|`list`|`ls`:      List repositories for a user, in a namespace or get details for a specific repository.

--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -13,6 +13,7 @@ from . import login  # noqa
 from . import metrics  # noqa
 from . import move  # noqa
 from . import push  # noqa
+from . import quota  # noqa
 from . import repos  # noqa
 from . import resync  # noqa
 from . import status  # noqa

--- a/cloudsmith_cli/cli/commands/quota/__init__.py
+++ b/cloudsmith_cli/cli/commands/quota/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from .history import usage as history_usage  # noqa
+from .quota import usage as quota_usage  # noqa

--- a/cloudsmith_cli/cli/commands/quota/command.py
+++ b/cloudsmith_cli/cli/commands/quota/command.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""CLI/Commands - Import all Quota commands."""
+
+import click
+
+from ... import command, decorators
+from ..main import main
+
+
+@main.group(cls=command.AliasGroup, name="quota", aliases=["quota"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.pass_context
+def quota(ctx, opts):  # pylink: disable=unused-argument
+    """
+    Display Quota limits and history for a organisation.
+
+    See the help for subcommands for more information on each.
+    """

--- a/cloudsmith_cli/cli/commands/quota/history.py
+++ b/cloudsmith_cli/cli/commands/quota/history.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""CLI/Commands - List Quota History for Namespace."""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import click
+
+from ....core.api import quota as api
+from ... import decorators, utils, validators
+from ...exceptions import handle_api_exceptions
+from ...utils import maybe_spinner
+from .command import quota
+
+
+def display_history(opts, data):
+    histories = data.history
+
+    click.echo()
+    click.echo(click.style("Quota History", bold=True, fg="white"))
+    click.echo(
+        "---------------------------------------------------------------", nl=False
+    )
+
+    headers = [
+        "Plan",
+        "Start",
+        "End",
+        "Days",
+        "Uploaded",
+        "Downloaded",
+        "Download Limit",
+        "Download Used",
+        "Storage",
+        "Storage Limit",
+        "Storage Used",
+    ]
+
+    rows = []
+    for history in histories:
+
+        uploaded = history.display.get("uploaded", {})
+        uploaded_used = uploaded.get("used", "")
+
+        downloaded = history.display.get("downloaded", {})
+        downloaded_used = downloaded.get("used", "")
+        downloaded_limit = downloaded.get("limit", "")
+        downloaded_percentage = downloaded.get("percentage", "")
+
+        storage = history.display.get("storage_used", {})
+        storage_used = storage.get("used", "")
+        storage_limit = storage.get("limit", "")
+        storage_percentage = storage.get("percentage", "")
+
+        rows.append(
+            [
+                click.style(str(history.plan), fg="green"),
+                click.style(str(history.start[0:10]), fg="white"),
+                click.style(str(history.end[0:10]), fg="white"),
+                click.style(str(history.days), fg="white"),
+                click.style(str(uploaded_used), fg="yellow"),
+                click.style(str(downloaded_used), fg="cyan"),
+                click.style(str(downloaded_limit), fg="white"),
+                click.style(str(downloaded_percentage), fg="white"),
+                click.style(str(storage_used), fg="magenta"),
+                click.style(str(storage_limit), fg="white"),
+                click.style(str(storage_percentage), fg="white"),
+            ]
+        )
+
+    click.echo()
+    utils.pretty_print_table(headers, rows)
+
+
+@quota.command(name="history", aliases=["history"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument(
+    "owner", metavar="OWNER", callback=validators.validate_owner, required=True
+)
+@click.option(
+    "-oss",
+    "--oss",
+    default=False,
+    is_flag=True,
+    help="Shows the open source quota for a namespace",
+)
+@click.pass_context
+def usage(ctx, opts, owner, oss):
+    """
+    Retrieve Quota history for namespace.
+
+    This requires appropriate permissions for the owner (a member of the
+    organisation and a valid API key).
+
+    - OWNER: Specify the OWNER namespace (i.e. org)
+
+      Example: 'your-org'
+
+    Full CLI example:
+
+      $ cloudsmith quota history your-org
+    """
+
+    # Use stderr for messages if the output is something else (e.g.  # JSON)
+    use_stderr = opts.output != "pretty"
+    click.echo("Getting quota ... ", nl=False, err=use_stderr)
+
+    owner = owner[0]
+
+    context_msg = "Failed to get quota!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            quota_ = api.quota_history(owner=owner, oss=oss)
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, quota_):
+        return
+
+    display_history(opts=opts, data=quota_)

--- a/cloudsmith_cli/cli/commands/quota/quota.py
+++ b/cloudsmith_cli/cli/commands/quota/quota.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""CLI/Commands - Display Quota for Namespace."""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import click
+
+from ....core.api import quota as api
+from ... import decorators, utils, validators
+from ...exceptions import handle_api_exceptions
+from ...utils import maybe_spinner
+from .command import quota
+
+
+def display_quota(opts, data):
+    """ Display Quota usage as a table. """
+    bandwidth = data.usage.get("display", {}).get("bandwidth", {})
+    storage = data.usage.get("display", {}).get("storage", {})
+
+    click.echo()
+    click.echo(click.style("Bandwidth Quota", bold=True, fg="white"))
+    click.echo(
+        "---------------------------------------------------------------", nl=False
+    )
+
+    headers = ["Bandwidth Used", "Configured", "Plan Limit", "Total Used"]
+    rows = []
+    rows.append(
+        [
+            click.style(str(bandwidth.get("used", "")), fg="white"),
+            click.style(str(bandwidth.get("configured", "")), fg="white"),
+            click.style(str(bandwidth.get("plan_limit", "")), fg="white"),
+            click.style(str(bandwidth.get("percentage_used", "")), fg="white"),
+        ]
+    )
+    click.echo()
+    utils.pretty_print_table(headers, rows)
+
+    click.echo()
+    click.echo(click.style("Storage Quota", bold=True, fg="white"))
+    click.echo(
+        "---------------------------------------------------------------", nl=False
+    )
+
+    headers = ["Storage Used", "Configured", "Plan Limit", "Total Used"]
+    rows = []
+    rows.append(
+        [
+            click.style(str(storage.get("configured", "")), fg="white"),
+            click.style(str(storage.get("plan_limit", "")), fg="white"),
+            click.style(str(storage.get("used", "")), fg="white"),
+            click.style(str(storage.get("percentage_used", "")), fg="white"),
+        ]
+    )
+    click.echo()
+    utils.pretty_print_table(headers, rows)
+
+    click.echo()
+
+
+@quota.command(name="limits", aliases=["limits"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument(
+    "owner", metavar="OWNER", callback=validators.validate_owner, required=True
+)
+@click.option(
+    "-oss",
+    "--oss",
+    default=False,
+    is_flag=True,
+    help="Shows the open source quota for a namespace",
+)
+@click.pass_context
+def usage(ctx, opts, owner, oss):
+    """
+    Retrieve Quota limits.
+
+    This requires appropriate permissions for the owner (a member of the
+    organisation and a valid API key).
+
+    - OWNER: Specify the OWNER namespace (i.e. org)
+
+      Example: 'your-org'
+
+    Full CLI example:
+
+      $ cloudsmith quota limits your-org
+    """
+
+    # Use stderr for messages if the output is something else (e.g.  # JSON)
+    use_stderr = opts.output != "pretty"
+    click.echo("Getting quota ... ", nl=False, err=use_stderr)
+
+    owner = owner[0]
+
+    context_msg = "Failed to get quota!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            quota_ = api.quota_limits(owner=owner, oss=oss)
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, quota_):
+        return
+
+    display_quota(opts=opts, data=quota_)

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -100,6 +100,13 @@ def validate_optional_owner_repo(ctx, param, value):
     )
 
 
+def validate_owner(ctx, param, value):
+    """Ensure that owner is formatted correctly."""
+    # pylint: disable=unused-argument
+    form = "OWNER"
+    return validate_slashes(param, value, minimum=1, maximum=1, form=form)
+
+
 def validate_owner_repo(ctx, param, value):
     """Ensure that owner/repo is formatted correctly."""
     # pylint: disable=unused-argument

--- a/cloudsmith_cli/core/api/quota.py
+++ b/cloudsmith_cli/core/api/quota.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""API - Quota endpoints."""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import cloudsmith_api
+
+from .. import ratelimits
+from .exceptions import catch_raise_api_exception
+from .init import get_api_client
+
+
+def get_quota_api():
+    """Get the Quota API client."""
+    return get_api_client(cloudsmith_api.QuotaApi)
+
+
+def quota_limits(owner=None, oss=False, **kwargs):
+    """Get Quota for namespace"""
+    client = get_quota_api()
+
+    api_kwargs = {}
+    api_kwargs.update(
+        {param: value for param, value in kwargs.items() if value is not None}
+    )
+
+    if oss:
+        if hasattr(client, "quota_oss_read_with_http_info"):
+            with catch_raise_api_exception():
+                res, _, headers = client.quota_oss_read_with_http_info(
+                    owner=owner, **api_kwargs
+                )
+    elif not oss:
+        if hasattr(client, "quota_read_with_http_info"):
+            with catch_raise_api_exception():
+                res, _, headers = client.quota_read_with_http_info(
+                    owner=owner, **api_kwargs
+                )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return res if not res else res
+
+
+def quota_history(owner=None, oss=False, **kwargs):
+    """Get Quota history for namespace"""
+    client = get_quota_api()
+
+    api_kwargs = {}
+    api_kwargs.update(
+        {param: value for param, value in kwargs.items() if value is not None}
+    )
+
+    if oss:
+        if hasattr(client, "quota_oss_history_read_with_http_info"):
+            with catch_raise_api_exception():
+                res, _, headers = client.quota_oss_history_read_with_http_info(
+                    owner=owner, **api_kwargs
+                )
+    elif not oss:
+        if hasattr(client, "quota_history_read_with_http_info"):
+            with catch_raise_api_exception():
+                res, _, headers = client.quota_history_read_with_http_info(
+                    owner=owner, **api_kwargs
+                )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return res if not res else res

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -4,7 +4,7 @@ click>=7.0
 click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
-cloudsmith-api>=0.52.92
+cloudsmith-api>=0.53.3
 colorama==0.3.9
 future>=0.16.0,<1.0.0
 requests>=2.18.4,<3.0.0

--- a/requirements/development.py2.txt
+++ b/requirements/development.py2.txt
@@ -20,7 +20,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.52.92
+cloudsmith-api==0.53.3
 codecov==2.0.15
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile, entrypoints, flake8, importlib-metadata, pylint

--- a/requirements/development.py3.txt
+++ b/requirements/development.py3.txt
@@ -21,7 +21,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.52.92
+cloudsmith-api==0.53.3
 codecov==2.0.15
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile

--- a/requirements/production.py2.txt
+++ b/requirements/production.py2.txt
@@ -12,7 +12,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.52.92
+cloudsmith-api==0.53.3
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile
 future==0.17.1

--- a/requirements/production.py3.txt
+++ b/requirements/production.py3.txt
@@ -12,7 +12,7 @@ click-configfile==0.2.3
 click-didyoumean==0.0.3
 click-spinner==0.1.7
 click==7.0
-cloudsmith-api==0.52.92
+cloudsmith-api==0.53.3
 colorama==0.3.9
 configparser==3.7.4       # via click-configfile
 future==0.17.1


### PR DESCRIPTION
### What's Changed

Adds commands for quota limits and history (with oss usage available with the -oss flag) for an organisation. 

##### Example Usage

```bash
cloudsmith quota limits example-org

cloudsmith quota limits example-org -oss
```

<img width="536" alt="Screenshot 2020-09-17 at 15 46 05" src="https://user-images.githubusercontent.com/1443700/93487192-ea071080-f8fc-11ea-884b-f6d02e08b020.png">

```bash
cloudsmith quota history example-org

cloudsmith quota history example-org -oss
```

<img width="1049" alt="Screenshot 2020-09-17 at 15 46 30" src="https://user-images.githubusercontent.com/1443700/93487239-f8edc300-f8fc-11ea-9a67-5a9cfdbb9db0.png">