### PR TITLE
Changed display/enforcement of rate-limiting

### DIFF
--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -317,7 +317,7 @@ class Options(object):
     @property
     def rate_limit_warning(self):
         """Get value for rate limiting warning (in seconds)."""
-        return self._get_option("rate_limit_warning", default=30)
+        return self._get_option("rate_limit_warning", default=10)
 
     @rate_limit_warning.setter
     def rate_limit_warning(self, value):

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -10,6 +10,15 @@ from ..core.api.init import initialise_api as _initialise_api
 from . import config, utils, validators
 
 
+def report_retry(seconds, context=None):
+    if context == "retry-after":
+        click.echo()
+        click.echo(
+            "Requested was throttled (429): Retrying after %(seconds)s second(s) ... "
+            % {"seconds": click.style(str(seconds), bold=True)}
+        )
+
+
 def common_package_action_options(f):
     """Add common options for package actions."""
 
@@ -277,9 +286,10 @@ def initialise_api(f):
         opts.error_retry_max = kwargs.pop("error_retry_max")
         opts.error_retry_backoff = kwargs.pop("error_retry_backoff")
         opts.error_retry_codes = kwargs.pop("error_retry_codes")
+        opts.error_retry_cb = report_retry
 
-        def call_print_rate_limit_info_with_opts(rate_info, atexit=False):
-            utils.print_rate_limit_info(opts, rate_info, atexit=atexit)
+        def call_print_rate_limit_info_with_opts(rate_info):
+            utils.print_rate_limit_info(opts, rate_info)
 
         opts.api_config = _initialise_api(
             debug=opts.debug,
@@ -294,6 +304,7 @@ def initialise_api(f):
             error_retry_max=opts.error_retry_max,
             error_retry_backoff=opts.error_retry_backoff,
             error_retry_codes=opts.error_retry_codes,
+            error_retry_cb=opts.error_retry_cb,
         )
 
         kwargs["opts"] = opts

--- a/cloudsmith_cli/cli/utils.py
+++ b/cloudsmith_cli/cli/utils.py
@@ -81,15 +81,13 @@ def pretty_print_table_instance(table):
         pretty_print_row(row, table.plain_rows[k])
 
 
-def print_rate_limit_info(opts, rate_info, atexit=False):
+def print_rate_limit_info(opts, rate_info):
     """Tell the user when we're being rate limited."""
     if not rate_info:
         return
 
     show_info = (
-        opts.always_show_rate_limit
-        or atexit
-        or rate_info.interval > opts.rate_limit_warning
+        opts.always_show_rate_limit or rate_info.interval > opts.rate_limit_warning
     )
 
     if not show_info:

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -26,6 +26,7 @@ def initialise_api(
     error_retry_cb=None,
 ):
     """Initialise the API."""
+    # FIXME: pylint: disable=too-many-arguments
     config = cloudsmith_api.Configuration()
     config.debug = debug
     config.host = host if host else config.host

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -23,6 +23,7 @@ def initialise_api(
     error_retry_max=None,
     error_retry_backoff=None,
     error_retry_codes=None,
+    error_retry_cb=None,
 ):
     """Initialise the API."""
     config = cloudsmith_api.Configuration()
@@ -36,6 +37,7 @@ def initialise_api(
     config.error_retry_max = error_retry_max
     config.error_retry_backoff = error_retry_backoff
     config.error_retry_codes = error_retry_codes
+    config.error_retry_cb = error_retry_cb
     config.verify_ssl = ssl_verify
 
     if headers:
@@ -54,7 +56,10 @@ def get_api_client(cls):
     config = cloudsmith_api.Configuration()
     client = cls()
     client.config = config
-    client.api_client.rest_client = RestClient()
+    client.api_client.rest_client = RestClient(
+        error_retry_cb=getattr(config, "error_retry_cb", None),
+        respect_retry_after_header=getattr(config, "rate_limit", True),
+    )
 
     user_agent = getattr(config, "user_agent", None)
     if user_agent:


### PR DESCRIPTION
# What Changed?

- Changed display of rate-limiting, to report upfront when it occurs.
- Removed rate-limiting atexit; it makes more sense to handle this per API call instead.
- Added exception to ignore `Retry-After` headers if `--without-rate-limit` is used (will result in a hard error instead).

For the `atexit` removal; it turns out that `urlib3` handles the `Retry-After` headers sent by the API anyway.