### PR TITLE
Update CircleCI docker image to circleci/python:3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 jobs:
   publish:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.9
     parameters:
       registry_url:
         description: Registry URL to upload the CLI to


### PR DESCRIPTION
# What changed?

Updates our CircleCI docker image to python 3.9, which addresses [this failure](https://app.circleci.com/pipelines/github/cloudsmith-io/cloudsmith-cli/223/workflows/c205d521-fe14-41b8-82bf-deed59fd0fdd/jobs/1010) installing the [`cryptography` package, which now relies on `setuptools_rust`](https://github.com/pyca/cryptography/issues/5753)