### PR TITLE
Fix Python 2 support for the metrics API

### DIFF
--- a/cloudsmith_cli/cli/commands/metrics/entitlements.py
+++ b/cloudsmith_cli/cli/commands/metrics/entitlements.py
@@ -39,7 +39,8 @@ def _print_metrics_table(opts, data):
         "Total": "total",
     }
 
-    headers = ["Metric", *six.iterkeys(metrics_keys)]
+    headers = ["Metric"]
+    headers.extend(six.iterkeys(metrics_keys))
     rows = []
 
     for category_header, category_key in six.iteritems(category_keys):

--- a/cloudsmith_cli/cli/commands/metrics/packages.py
+++ b/cloudsmith_cli/cli/commands/metrics/packages.py
@@ -39,7 +39,8 @@ def _print_metrics_table(opts, data):
         "Total": "total",
     }
 
-    headers = ["Metric", *six.iterkeys(metrics_keys)]
+    headers = ["Metric"]
+    headers.extend(six.iterkeys(metrics_keys))
     rows = []
 
     for category_header, category_key in six.iteritems(category_keys):


### PR DESCRIPTION
# What changed?

Addresses the following error:
```
  File "/home/circleci/.local/lib/python2.7/site-packages/cloudsmith_cli/cli/commands/metrics/entitlements.py", line 42
    headers = ["Metric", *six.iterkeys(metrics_keys)]
                         ^
SyntaxError: invalid syntax
```