### PR TITLE
Fix CircleCI auto publishing of versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,17 @@ jobs:
       password:
         description: Twine password
         type: string
-    environment:
-      TWINE_REPOSITORY_URL: <<parameters.registry_url>>
-      TWINE_USERNAME: <<parameters.username>>
-      TWINE_PASSWORD: <<parameters.password>>
     steps:
       - checkout
       - run: pip install --user --upgrade setuptools twine wheel
       - run: |
+          echo -e "[repository]" >> ~/.pypirc
+          echo -e "repository = <<parameters.registry_url>>" >> ~/.pypirc
+          echo -e "username = <<parameters.username>>" >> ~/.pypirc
+          echo -e "password = <<parameters.password>>" >> ~/.pypirc
+      - run: |
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+          twine upload --repository repository --verbose dist/*
 
 orbs:
   cloudsmith_ci:


### PR DESCRIPTION
# What changed?

Writes the twine configuration out to the `~/.pypirc` config file, as it seems CircleCI [doesn't support passing environment variables as parameters](https://discuss.circleci.com/t/passing-in-env-variables-to-orb-jobs/30782/11) 😞 