### PR TITLE
skip click-8.0.2 but allow patched versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     zip_safe=False,
     platforms=["any"],
     install_requires=[
-        "click>=7.0,<8.0.2",
+        "click>=7.0,!=8.0.2",
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",


### PR DESCRIPTION
A couple of days ago the `click` dependency was constrained to `<8.0.2` because of a bug in that version (#57). The bug has since been fixed and released as `click-8.0.3` (pallets/click#2088, pallets/click#2094, https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-3). I believe the constraint could now be loosened to only disallow 8.0.2.