### PR TITLE
skip click-8.0.2 but allow patched versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     zip_safe=False,
     platforms=["any"],
     install_requires=[
-        "click>=7.0,<8.0.2",
+        "click>=7.0,!=8.0.2",
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",


### PR DESCRIPTION
Re-created https://github.com/cloudsmith-io/cloudsmith-cli/pull/60 by pushing the forked branch into our repo so that CircleCI will run