### PR TITLE
Allow cloudsmith-api <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
-        "cloudsmith-api>=0.0.0,<1.0",  # Compatible upto (but excluding) 1.0+
+        "cloudsmith-api>=0.0.0,<2.0",  # Compatible upto (but excluding) 2.0+
         "colorama>=0.3.9",
         "future>=0.16.0",
         "requests>=2.18.4",


### PR DESCRIPTION
Relax API restrictions to allow installation of newer versions of our API clients.