### PR TITLE
fix: support new swagger-codegen format for cloudsmith-api

### DIFF
--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -48,7 +48,11 @@ def initialise_api(
             values = decoded.decode("utf-8")
             config.username, config.password = values.split(":")
 
-    set_api_key(config, key)
+    if key:
+        config.api_key["X-Api-Key"] = key
+
+    if hasattr(cloudsmith_api.Configuration, "set_default"):
+        cloudsmith_api.Configuration.set_default(config)
     return config
 
 
@@ -74,9 +78,14 @@ def get_api_client(cls):
     return client
 
 
-def set_api_key(config, key):
-    """Configure a new API key."""
-    if not key and "X-Api-Key" in config.api_key:
+def unset_api_key():
+    """Unset the API key."""
+    config = cloudsmith_api.Configuration()
+
+    try:
         del config.api_key["X-Api-Key"]
-    else:
-        config.api_key["X-Api-Key"] = key
+    except KeyError:
+        pass
+
+    if hasattr(cloudsmith_api.Configuration, "set_default"):
+        cloudsmith_api.Configuration.set_default(config)

--- a/cloudsmith_cli/core/api/user.py
+++ b/cloudsmith_cli/core/api/user.py
@@ -6,7 +6,7 @@ import cloudsmith_api
 
 from .. import ratelimits
 from .exceptions import catch_raise_api_exception
-from .init import get_api_client, set_api_key
+from .init import get_api_client, unset_api_key
 
 
 def get_user_api():
@@ -19,8 +19,7 @@ def get_user_token(login, password):
     client = get_user_api()
 
     # Never use API key for the token endpoint
-    config = cloudsmith_api.Configuration()
-    set_api_key(config, None)
+    unset_api_key()
 
     with catch_raise_api_exception():
         data, _, headers = client.user_token_create_with_http_info(


### PR DESCRIPTION
This PR adjusts the CLI to support `swagger-codegen`'s newer `Configuration()` style (without the global singleton).

Upstream change was made here https://github.com/swagger-api/swagger-codegen/pull/9130

This change is required due to an upgrade in the `swagger-codegen` version we use to generate our API client libs over in https://github.com/cloudsmith-io/cloudsmith-api/pull/27
