### PR TITLE
HAM-135 - add '.' to config search paths

### DIFF
--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -71,7 +71,7 @@ class ConfigReader(ConfigFileReader):
 
     config_files = ["config.ini"]
     config_name = "standard"
-    config_searchpath = [get_default_config_path()]
+    config_searchpath = [".", get_default_config_path()]
     config_section_schemas = [ConfigSchema.Default, ConfigSchema.Profile]
 
     @classmethod
@@ -199,7 +199,7 @@ class CredentialsReader(ConfigReader):
 
     config_files = ["credentials.ini"]
     config_name = "credentials"
-    config_searchpath = [get_default_config_path()]
+    config_searchpath = [".", get_default_config_path()]
     config_section_schemas = [CredentialsSchema.Default, CredentialsSchema.Profile]
 
 


### PR DESCRIPTION
Per readme, need to search the current working directory for `config.ini` or `credentials.ini`.

Found that given the cli tool is using the library click-config, I see that it's test cases include a test case that specify '.' in the search path: https://github.com/click-contrib/click-configfile/blob/main/tests/functional/test_basics.py#L89

```python
# -----------------------------------------------------------------------------
# TEST CANDIDATE 3: With config_searchpath
# -----------------------------------------------------------------------------
class ConfigFileProcessor3(ConfigFileReader):
    config_files = ["hello3.ini"]
    config_searchpath = [".", "config/profile"]
    config_section_schemas = [
        ConfigSectionSchema1.Hello,
    ]
```

Thus I added that to the same appropriate place in this repo. I tested this change locally by trying `cloudsmith whoami` and `cloudsmith check service` on master with config files in place. Master did not pick up the values in the config files. I then switched to this branch, repeated the test, and this branch does pickup values from the config files.
