### PR TITLE
fix: require click 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     zip_safe=False,
     platforms=["any"],
     install_requires=[
-        "click>=7.0,!=8.0.2",
+        "click>=8.0.3",
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",


### PR DESCRIPTION
This PR bumps the minimum acceptable version of `click` to `8.0.3`, as some of the newer parts of the API require it.
