### PR TITLE
fix: Update generation of format parameter descriptions.

### DIFF
--- a/cloudsmith_cli/core/api/packages.py
+++ b/cloudsmith_cli/core/api/packages.py
@@ -254,7 +254,9 @@ def get_package_formats():
 
         for k, v in six.iteritems(cls.swagger_types):
             attr = getattr(cls, k)
-            docs = [doc.strip() for doc in attr.__doc__.strip().split("\n") if doc.strip()]
+            docs = [
+                doc.strip() for doc in attr.__doc__.strip().split("\n") if doc.strip()
+            ]
             doc = (docs[1] if docs[1] else docs[0]).strip()
 
             try:

--- a/cloudsmith_cli/core/api/packages.py
+++ b/cloudsmith_cli/core/api/packages.py
@@ -254,8 +254,8 @@ def get_package_formats():
 
         for k, v in six.iteritems(cls.swagger_types):
             attr = getattr(cls, k)
-            docs = attr.__doc__.strip().split("\n")
-            doc = (docs[2].lstrip() if docs[2] else docs[0]).strip()
+            docs = [doc.lstrip() for  doc in attr.__doc__.strip().split("\n") if doc]
+            doc = (docs[1] if docs[1] else docs[0]).strip()
 
             try:
                 setattr(instance, k, None)

--- a/cloudsmith_cli/core/api/packages.py
+++ b/cloudsmith_cli/core/api/packages.py
@@ -254,7 +254,7 @@ def get_package_formats():
 
         for k, v in six.iteritems(cls.swagger_types):
             attr = getattr(cls, k)
-            docs = [doc.lstrip() for  doc in attr.__doc__.strip().split("\n") if doc]
+            docs = [doc.strip() for doc in attr.__doc__.strip().split("\n") if doc.strip()]
             doc = (docs[1] if docs[1] else docs[0]).strip()
 
             try:

--- a/cloudsmith_cli/core/api/packages.py
+++ b/cloudsmith_cli/core/api/packages.py
@@ -255,7 +255,7 @@ def get_package_formats():
         for k, v in six.iteritems(cls.swagger_types):
             attr = getattr(cls, k)
             docs = attr.__doc__.strip().split("\n")
-            doc = (docs[1] if docs[1] else docs[0]).strip()
+            doc = (docs[2].lstrip() if docs[2] else docs[0]).strip()
 
             try:
                 setattr(instance, k, None)


### PR DESCRIPTION
- Recent changes have contributed to a minor difference in `docstring` formatting.
- This change takes into account the new difference. 

For example: 
```
>>> attr = getattr(MavenPackageUploadRequest, "artifact_id")
>>> attr.__doc__
'Gets the artifact_id of this MavenPackageUploadRequest.\n\n        The ID of the artifact.\n\n        :return: The artifact_id of this MavenPackageUploadRequest.\n        :rtype: str\n        '
>>> docs = attr.__doc__.strip().split("\n")
>>> docs[1]
''
```