### PR TITLE
eng-2352: Add Python 2 deprecation message

### DIFF
--- a/cloudsmith_cli/cli/commands/main.py
+++ b/cloudsmith_cli/cli/commands/main.py
@@ -12,7 +12,7 @@ from .. import command, decorators
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
-PY2_DEPRECATION_WARNING_MSG = "DEPRECATION: Please upgrade your Python as Python 2.7 is no longer maintained. Python 2.7 support will end as of cloudsmith-cli v0.40.0."
+PY2_DEPRECATION_WARNING_MSG = "DEPRECATION: Please upgrade your Python as Python 2.7 is no longer maintained. Python 2.7 support will end as of cloudsmith-cli v1.0.0."
 
 
 def print_version():

--- a/cloudsmith_cli/cli/commands/main.py
+++ b/cloudsmith_cli/cli/commands/main.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import click
+import six
 
 from ...core.api.version import get_version as get_api_version
 from ...core.utils import get_github_website, get_help_website
@@ -10,6 +11,8 @@ from ...core.version import get_version as get_cli_version
 from .. import command, decorators
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+PY2_DEPRECATION_WARNING_MSG = "DEPRECATION: Please upgrade your Python as Python 2.7 is no longer maintained. Python 2.7 support will end as of cloudsmith-cli v0.40.0."
 
 
 def print_version():
@@ -53,11 +56,21 @@ For issues/contributing: %(github_website)s
     is_flag=True,
     is_eager=True,
 )
+@click.option(
+    "--no-python-version-warning",
+    is_flag=True,
+    help="Silence deprecation warnings for upcoming unsupported Pythons.",
+)
 @decorators.common_cli_config_options
 @click.pass_context
-def main(ctx, opts, version):
+def main(ctx, opts, version, no_python_version_warning):
     """Handle entrypoint to CLI."""
     # pylint: disable=unused-argument
+
+    if not no_python_version_warning:
+        if six.PY2:
+            click.echo(click.style(PY2_DEPRECATION_WARNING_MSG, fg="yellow"))
+
     if version:
         print_version()
     elif ctx.invoked_subcommand is None:

--- a/cloudsmith_cli/cli/tests/commands/test_main.py
+++ b/cloudsmith_cli/cli/tests/commands/test_main.py
@@ -32,7 +32,7 @@ class TestMainCommand(object):
         expected = (
             six.PY2
             and (not suppress_warning)
-            and (not (get_version_info() >= parse_version("0.40.0")))
+            and (not (get_version_info() >= parse_version("1.0.0")))
         )
         args = []
         if suppress_warning:

--- a/cloudsmith_cli/cli/tests/commands/test_main.py
+++ b/cloudsmith_cli/cli/tests/commands/test_main.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 import pytest
+import six
 
-from ...commands.main import main
+from ....core.version import get_version_info, parse_version
+from ...commands.main import PY2_DEPRECATION_WARNING_MSG, main
 
 
 class TestMainCommand(object):
     @pytest.mark.parametrize("option", ["-V", "--version"])
     def test_main_version(self, runner, option):
         """Test the output of `cloudsmith --version`."""
-        result = runner.invoke(main, [option])
+        result = runner.invoke(main, [option, "--no-python-version-warning"])
         assert result.exit_code == 0
         assert (
             result.output == "Versions:\n"
@@ -23,3 +25,19 @@ class TestMainCommand(object):
         assert result.exit_code == 0
         # TODO: assert something specific about output
         assert result.output
+
+    @pytest.mark.parametrize("suppress_warning", [True, False])
+    def test_py2_deprecation_warning(self, runner, suppress_warning):
+        """Test Python 2 support deprecation warning."""
+        expected = (
+            six.PY2
+            and (not suppress_warning)
+            and (not (get_version_info() >= parse_version("0.40.0")))
+        )
+        args = []
+        if suppress_warning:
+            args.append("--no-python-version-warning")
+
+        result = runner.invoke(main, args=args)
+
+        assert (PY2_DEPRECATION_WARNING_MSG in result.output) is expected


### PR DESCRIPTION
Add a deprecation message to output under Python 2.

The approach here is loosely based on that of pip, more in terms of UX than the implementation.

Users can silence the warning with the `--no-python-version-warning` flag.

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/12284065/236154478-a4ff8bac-f813-4060-8f6c-819126063059.png">
