### PR TITLE
feat(eng-2261): License policy CLI

### DIFF
--- a/cloudsmith_cli/cli/commands/policy/__init__.py
+++ b/cloudsmith_cli/cli/commands/policy/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
+from .licence import licence as policy_licence  # noqa
 from .vulnerability import vulnerability as policy_vulnerability  # noqa
-from .license import license  as policy_license # noqa

--- a/cloudsmith_cli/cli/commands/policy/__init__.py
+++ b/cloudsmith_cli/cli/commands/policy/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-from .licence import licence as policy_licence  # noqa
+from .license import licence as policy_license  # noqa
 from .vulnerability import vulnerability as policy_vulnerability  # noqa

--- a/cloudsmith_cli/cli/commands/policy/__init__.py
+++ b/cloudsmith_cli/cli/commands/policy/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from .vulnerability import vulnerability as policy_vulnerability  # noqa
+from .license import license  as policy_license # noqa

--- a/cloudsmith_cli/cli/commands/policy/licence.py
+++ b/cloudsmith_cli/cli/commands/policy/licence.py
@@ -20,11 +20,11 @@ def print_licence_policies(policies):
     headers = [
         "Name",
         "Description",
-        "Allow Unknown licences",
+        "Allow Unknown Licences",
         "Quarantine On Violation",
         "SPDX Identifiers",
-        "Created At",
-        "Updated At",
+        "Created",
+        "Updated",
         "Identifier",
     ]
 
@@ -33,7 +33,7 @@ def print_licence_policies(policies):
             click.style(policy["name"], fg="cyan"),
             click.style(policy["description"], fg="yellow"),
             click.style(fmt_bool(policy["allow_unknown_licenses"]), fg="yellow"),
-            click.style(six.text_type(policy["on_violation_quarantine"]), fg="blue"),
+            click.style(fmt_bool(policy["on_violation_quarantine"]), fg="yellow"),
             click.style(six.text_type(policy["spdx_identifiers"]), fg="blue"),
             click.style(fmt_datetime(policy["created_at"]), fg="blue"),
             click.style(fmt_datetime(policy["updated_at"]), fg="blue"),
@@ -163,6 +163,11 @@ def create(ctx, opts, owner, policy_config_file):
             param="spdx_identifiers",
         )
 
+    if len(spdx_identifiers) > len(set(spdx_identifiers)):
+        raise click.BadParameter(
+            "SPDX Identifiers must be unique.", param="spdx_identifiers"
+        )
+
     click.secho(
         "Creating %(name)s licence policy for the %(owner)s namespace ..."
         % {
@@ -172,6 +177,12 @@ def create(ctx, opts, owner, policy_config_file):
         nl=False,
         err=use_stderr,
     )
+
+    # Convert `allow_unknown_licences` to `allow_unknown_licenses` (avoiding license keyword)
+    if "allow_unknown_licences" in policy_config:
+        policy_config["allow_unknown_licenses"] = policy_config.pop(
+            "allow_unknown_licences"
+        )
 
     context_msg = "Failed to create the licence policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
@@ -240,6 +251,18 @@ def update(ctx, opts, owner, identifier, policy_config_file):
         nl=False,
         err=use_stderr,
     )
+
+    spdx_identifiers = policy_config.get("spdx_identifiers", None)
+    if len(spdx_identifiers) > len(set(spdx_identifiers)):
+        raise click.BadParameter(
+            "SPDX Identifiers must be unique.", param="spdx_identifiers"
+        )
+
+    # Convert `allow_unknown_licences` to `allow_unknown_licenses` (avoiding license keyword)
+    if "allow_unknown_licences" in policy_config:
+        policy_config["allow_unknown_licenses"] = policy_config.pop(
+            "allow_unknown_licences"
+        )
 
     context_msg = "Failed to update the licence policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):

--- a/cloudsmith_cli/cli/commands/policy/licence.py
+++ b/cloudsmith_cli/cli/commands/policy/licence.py
@@ -1,4 +1,5 @@
-"""CLI/Commands - create, retrieve, update or delete license policies."""
+# -*- coding: utf-8 -*-
+"""CLI/Commands - create, retrieve, update or delete licence policies."""
 from __future__ import absolute_import, print_function, unicode_literals
 
 import json
@@ -13,13 +14,13 @@ from ...utils import fmt_bool, fmt_datetime, maybe_spinner
 from .command import policy
 
 
-def print_license_policies(policies):
-    """Print license policies as a table or output in another format."""
+def print_licence_policies(policies):
+    """Print licence policies as a table or output in another format."""
 
     headers = [
         "Name",
         "Description",
-        "Allow Unknown Licenses",
+        "Allow Unknown licences",
         "Quarantine On Violation",
         "SPDX Identifiers",
         "Created At",
@@ -46,25 +47,25 @@ def print_license_policies(policies):
     click.echo()
 
     num_results = len(rows)
-    list_suffix = "vulnerability polic%s" % ("y" if num_results == 1 else "ies")
+    list_suffix = "licence polic%s" % ("y" if num_results == 1 else "ies")
     utils.pretty_print_list_info(num_results=num_results, suffix=list_suffix)
 
 
-@policy.group(cls=command.AliasGroup, name="license", aliases=[])
+@policy.group(cls=command.AliasGroup, name="licence", aliases=[])
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
 @decorators.initialise_api
 @click.pass_context
-def license(*args, **kwargs):
+def licence(*args, **kwargs):
     """
-    Manage license policies for an organization.
+    Manage licence policies for an organization.
 
     See the help for subcommands for more information on each.
     """
 
 
-@license.command(name="list", aliases=["ls"])
+@licence.command(name="list", aliases=["ls"])
 @decorators.common_cli_config_options
 @decorators.common_cli_list_options
 @decorators.common_cli_output_options
@@ -76,7 +77,7 @@ def license(*args, **kwargs):
 @click.pass_context
 def ls(ctx, opts, owner, page, page_size):
     """
-    List vulnerability policies.
+    List licence policies.
 
     This requires appropriate permissions for the owner (a member of the
     organisation and a valid API key).
@@ -87,19 +88,19 @@ def ls(ctx, opts, owner, page, page_size):
 
     Full CLI example:
 
-      $ cloudsmith policy license list your-org
+      $ cloudsmith policy licence list your-org
     """
     owner = owner[0]
 
     # Use stderr for messages if the output is something else (e.g.  # JSON)
     use_stderr = opts.output != "pretty"
 
-    click.echo("Getting license policies ... ", nl=False, err=use_stderr)
+    click.echo("Getting licence policies ... ", nl=False, err=use_stderr)
 
-    context_msg = "Failed to get license policies!"
+    context_msg = "Failed to get licence policies!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies, page_info = api.list_license_policies(
+            policies, page_info = api.list_licence_policies(
                 owner=owner, page=page, page_size=page_size
             )
 
@@ -108,10 +109,10 @@ def ls(ctx, opts, owner, page, page_size):
     if utils.maybe_print_as_json(opts, policies, page_info):
         return
 
-    print_license_policies(policies)
+    print_licence_policies(policies)
 
 
-@license.command(aliases=["new"])
+@licence.command(aliases=["new"])
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
@@ -121,29 +122,29 @@ def ls(ctx, opts, owner, page, page_size):
 @click.pass_context
 def create(ctx, opts, owner, policy_config_file):
     """
-    Create a new license policy in a namespace.
+    Create a new licence policy in a namespace.
 
     - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
-      to create a license policy.
+      to create a licence policy.
 
         Example: 'your-org'
 
     - POLICY_CONFIG_FILE: Config file specifying the settings for the
-      license policy to be created.
+      licence policy to be created.
 
         \b
         Example:
         {
-          "name": "your-license-policy",
-          "description": "your license policy description",
-          "spdx_identifiers" : ["your_licenses"],
-          "allow_unknown_licenses": false,
+          "name": "your-licence-policy",
+          "description": "your licence policy description",
+          "spdx_identifiers" : ["your_licences"],
+          "allow_unknown_licences": false,
           "quarantine_on_violation": true
         }
 
     Full CLI example:
 
-      $ cloudsmith policy license create your-org policy-config-file.json
+      $ cloudsmith policy licence create your-org policy-config-file.json
     """
     # Use stderr for messages if the output is something else (e.g. JSON)
     use_stderr = opts.output != "pretty"
@@ -152,20 +153,18 @@ def create(ctx, opts, owner, policy_config_file):
     policy_name = policy_config.get("name", None)
     if policy_name is None:
         raise click.BadParameter(
-            "Name is a required field for creating a license policy.",
-            param="name",
+            "Name is a required field for creating a licence policy.", param="name"
         )
 
     spdx_identifiers = policy_config.get("spdx_identifiers", None)
     if spdx_identifiers is None:
         raise click.BadParameter(
-            "SPDX Identifiers is a required field for creating a license policy.",
+            "SPDX Identifiers is a required field for creating a licence policy.",
             param="spdx_identifiers",
         )
 
-
     click.secho(
-        "Creating %(name)s license policy for the %(owner)s namespace ..."
+        "Creating %(name)s licence policy for the %(owner)s namespace ..."
         % {
             "name": click.style(policy_name, bold=True),
             "owner": click.style(owner, bold=True),
@@ -174,20 +173,20 @@ def create(ctx, opts, owner, policy_config_file):
         err=use_stderr,
     )
 
-    context_msg = "Failed to create the license policy!"
+    context_msg = "Failed to create the licence policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies = [api.create_license_policy(owner, policy_config)]
+            policies = [api.create_licence_policy(owner, policy_config)]
 
     click.secho("OK", fg="green", err=use_stderr)
 
     if utils.maybe_print_as_json(opts, policies):
         return
 
-    print_license_policies(policies)
+    print_licence_policies(policies)
 
 
-@license.command()
+@licence.command()
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
@@ -198,34 +197,34 @@ def create(ctx, opts, owner, policy_config_file):
 @click.pass_context
 def update(ctx, opts, owner, identifier, policy_config_file):
     """
-    Update a license policy.
+    Update a licence policy.
 
     - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
-      to update a license policy.
+      to update a licence policy.
 
         Example: 'your-org'
 
-    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
-      for the license policy which you wish to update.
+    - IDENTIFIER: Specify the licence policy IDENTIFIER (i.e. slug_perm)
+      for the licence policy which you wish to update.
 
-        Example: 'your-license-policy'
+        Example: 'your-licence-policy'
 
     - POLICY_CONFIG_FILE: Config file specifying the settings for the
-      license policy to be updated.
+      licence policy to be updated.
 
         \b
         Example:
         {
-          "name": "your-license-policy",
-          "description": "your license policy description",
-          "spdx_identifiers" : ["your_licenses"],
-          "allow_unknown_licenses": false,
+          "name": "your-licence-policy",
+          "description": "your licence policy description",
+          "spdx_identifiers" : ["your_licences"],
+          "allow_unknown_licences": false,
           "quarantine_on_violation": true
         }
 
     Full CLI example:
 
-      $ cloudsmith policy license update your-org your-license-policy policy-config-file.json
+      $ cloudsmith policy licence update your-org your-licence-policy policy-config-file.json
     """
     # Use stderr for message if the output is something else (e.g. JSON)
     use_stderr = opts.output != "pretty"
@@ -233,7 +232,7 @@ def update(ctx, opts, owner, identifier, policy_config_file):
     policy_config = json.load(policy_config_file)
 
     click.secho(
-        "Updating %(slug_perm)s license policy in the %(owner)s namespace ..."
+        "Updating %(slug_perm)s licence policy in the %(owner)s namespace ..."
         % {
             "slug_perm": click.style(identifier, bold=True),
             "owner": click.style(owner, bold=True),
@@ -242,22 +241,20 @@ def update(ctx, opts, owner, identifier, policy_config_file):
         err=use_stderr,
     )
 
-    context_msg = "Failed to update the license policy!"
+    context_msg = "Failed to update the licence policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies = [
-                api.update_license_policy(owner, identifier, policy_config)
-            ]
+            policies = [api.update_licence_policy(owner, identifier, policy_config)]
 
     click.secho("OK", fg="green", err=use_stderr)
 
     if utils.maybe_print_as_json(opts, policies):
         return
 
-    print_license_policies(policies)
+    print_licence_policies(policies)
 
 
-@license.command(aliases=["rm"])
+@licence.command(aliases=["rm"])
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
@@ -274,20 +271,20 @@ def update(ctx, opts, owner, identifier, policy_config_file):
 @click.pass_context
 def delete(ctx, opts, owner, identifier, yes):
     """
-    Delete a license policy from a namespace.
+    Delete a licence policy from a namespace.
 
     - OWNER: Specify the OWNER namespace (i.e. org).
 
         Example: 'your-org'
 
-    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
-      for the license policy which you wish to delete.
+    - IDENTIFIER: Specify the licence policy IDENTIFIER (i.e. slug_perm)
+      for the licence policy which you wish to delete.
 
-        Example: 'your-license-policy'
+        Example: 'your-licence-policy'
 
     Full CLI example:
 
-      $ cloudsmith policy license delete your-org your-license-policy
+      $ cloudsmith policy licence delete your-org your-licence-policy
     """
 
     delete_args = {
@@ -296,7 +293,7 @@ def delete(ctx, opts, owner, identifier, yes):
     }
 
     prompt = (
-        "delete the %(slug_perm)s license policy from the %(namespace)s namespace"
+        "delete the %(slug_perm)s licence policy from the %(namespace)s namespace"
         % delete_args
     )
 
@@ -308,9 +305,9 @@ def delete(ctx, opts, owner, identifier, yes):
         nl=False,
     )
 
-    context_msg = "Failed to delete the license policy!"
+    context_msg = "Failed to delete the licence policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            api.delete_license_policy(owner=owner, slug_perm=identifier)
+            api.delete_licence_policy(owner=owner, slug_perm=identifier)
 
     click.secho("OK", fg="green")

--- a/cloudsmith_cli/cli/commands/policy/licence.py
+++ b/cloudsmith_cli/cli/commands/policy/licence.py
@@ -252,7 +252,7 @@ def update(ctx, opts, owner, identifier, policy_config_file):
         err=use_stderr,
     )
 
-    spdx_identifiers = policy_config.get("spdx_identifiers", None)
+    spdx_identifiers = policy_config.get("spdx_identifiers", [])
     if len(spdx_identifiers) > len(set(spdx_identifiers)):
         raise click.BadParameter(
             "SPDX Identifiers must be unique.", param="spdx_identifiers"

--- a/cloudsmith_cli/cli/commands/policy/license.py
+++ b/cloudsmith_cli/cli/commands/policy/license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""CLI/Commands - create, retrieve, update or delete licence policies."""
+"""CLI/Commands - create, retrieve, update or delete license policies."""
 from __future__ import absolute_import, print_function, unicode_literals
 
 import json
@@ -14,13 +14,13 @@ from ...utils import fmt_bool, fmt_datetime, maybe_spinner
 from .command import policy
 
 
-def print_licence_policies(policies):
-    """Print licence policies as a table or output in another format."""
+def print_license_policies(policies):
+    """Print license policies as a table or output in another format."""
 
     headers = [
         "Name",
         "Description",
-        "Allow Unknown Licences",
+        "Allow Unknown Licenses",
         "Quarantine On Violation",
         "SPDX Identifiers",
         "Created",
@@ -47,11 +47,11 @@ def print_licence_policies(policies):
     click.echo()
 
     num_results = len(rows)
-    list_suffix = "licence polic%s" % ("y" if num_results == 1 else "ies")
+    list_suffix = "license polic%s" % ("y" if num_results == 1 else "ies")
     utils.pretty_print_list_info(num_results=num_results, suffix=list_suffix)
 
 
-@policy.group(cls=command.AliasGroup, name="licence", aliases=[])
+@policy.group(cls=command.AliasGroup, name="license", aliases=[])
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.common_api_auth_options
@@ -59,7 +59,7 @@ def print_licence_policies(policies):
 @click.pass_context
 def licence(*args, **kwargs):
     """
-    Manage licence policies for an organization.
+    Manage license policies for an organization.
 
     See the help for subcommands for more information on each.
     """
@@ -77,7 +77,7 @@ def licence(*args, **kwargs):
 @click.pass_context
 def ls(ctx, opts, owner, page, page_size):
     """
-    List licence policies.
+    List license policies.
 
     This requires appropriate permissions for the owner (a member of the
     organisation and a valid API key).
@@ -88,19 +88,19 @@ def ls(ctx, opts, owner, page, page_size):
 
     Full CLI example:
 
-      $ cloudsmith policy licence list your-org
+      $ cloudsmith policy license list your-org
     """
     owner = owner[0]
 
     # Use stderr for messages if the output is something else (e.g.  # JSON)
     use_stderr = opts.output != "pretty"
 
-    click.echo("Getting licence policies ... ", nl=False, err=use_stderr)
+    click.echo("Getting license policies ... ", nl=False, err=use_stderr)
 
-    context_msg = "Failed to get licence policies!"
+    context_msg = "Failed to get license policies!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies, page_info = api.list_licence_policies(
+            policies, page_info = api.list_license_policies(
                 owner=owner, page=page, page_size=page_size
             )
 
@@ -109,7 +109,7 @@ def ls(ctx, opts, owner, page, page_size):
     if utils.maybe_print_as_json(opts, policies, page_info):
         return
 
-    print_licence_policies(policies)
+    print_license_policies(policies)
 
 
 @licence.command(aliases=["new"])
@@ -122,29 +122,29 @@ def ls(ctx, opts, owner, page, page_size):
 @click.pass_context
 def create(ctx, opts, owner, policy_config_file):
     """
-    Create a new licence policy in a namespace.
+    Create a new license policy in a namespace.
 
     - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
-      to create a licence policy.
+      to create a license policy.
 
         Example: 'your-org'
 
     - POLICY_CONFIG_FILE: Config file specifying the settings for the
-      licence policy to be created.
+      license policy to be created.
 
         \b
         Example:
         {
-          "name": "your-licence-policy",
-          "description": "your licence policy description",
-          "spdx_identifiers" : ["your_licences"],
-          "allow_unknown_licences": false,
+          "name": "your-license-policy",
+          "description": "your license policy description",
+          "spdx_identifiers" : ["your_licenses"],
+          "allow_unknown_licenses": false,
           "quarantine_on_violation": true
         }
 
     Full CLI example:
 
-      $ cloudsmith policy licence create your-org policy-config-file.json
+      $ cloudsmith policy license create your-org policy-config-file.json
     """
     # Use stderr for messages if the output is something else (e.g. JSON)
     use_stderr = opts.output != "pretty"
@@ -153,13 +153,13 @@ def create(ctx, opts, owner, policy_config_file):
     policy_name = policy_config.get("name", None)
     if policy_name is None:
         raise click.BadParameter(
-            "Name is a required field for creating a licence policy.", param="name"
+            "Name is a required field for creating a license policy.", param="name"
         )
 
     spdx_identifiers = policy_config.get("spdx_identifiers", None)
     if spdx_identifiers is None:
         raise click.BadParameter(
-            "SPDX Identifiers is a required field for creating a licence policy.",
+            "SPDX Identifiers is a required field for creating a license policy.",
             param="spdx_identifiers",
         )
 
@@ -169,7 +169,7 @@ def create(ctx, opts, owner, policy_config_file):
         )
 
     click.secho(
-        "Creating %(name)s licence policy for the %(owner)s namespace ..."
+        "Creating %(name)s license policy for the %(owner)s namespace ..."
         % {
             "name": click.style(policy_name, bold=True),
             "owner": click.style(owner, bold=True),
@@ -178,23 +178,17 @@ def create(ctx, opts, owner, policy_config_file):
         err=use_stderr,
     )
 
-    # Convert `allow_unknown_licences` to `allow_unknown_licenses` (avoiding license keyword)
-    if "allow_unknown_licences" in policy_config:
-        policy_config["allow_unknown_licenses"] = policy_config.pop(
-            "allow_unknown_licences"
-        )
-
-    context_msg = "Failed to create the licence policy!"
+    context_msg = "Failed to create the license policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies = [api.create_licence_policy(owner, policy_config)]
+            policies = [api.create_license_policy(owner, policy_config)]
 
     click.secho("OK", fg="green", err=use_stderr)
 
     if utils.maybe_print_as_json(opts, policies):
         return
 
-    print_licence_policies(policies)
+    print_license_policies(policies)
 
 
 @licence.command()
@@ -208,34 +202,34 @@ def create(ctx, opts, owner, policy_config_file):
 @click.pass_context
 def update(ctx, opts, owner, identifier, policy_config_file):
     """
-    Update a licence policy.
+    Update a license policy.
 
     - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
-      to update a licence policy.
+      to update a license policy.
 
         Example: 'your-org'
 
-    - IDENTIFIER: Specify the licence policy IDENTIFIER (i.e. slug_perm)
-      for the licence policy which you wish to update.
+    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
+      for the license policy which you wish to update.
 
-        Example: 'your-licence-policy'
+        Example: 'your-license-policy'
 
     - POLICY_CONFIG_FILE: Config file specifying the settings for the
-      licence policy to be updated.
+      license policy to be updated.
 
         \b
         Example:
         {
-          "name": "your-licence-policy",
-          "description": "your licence policy description",
-          "spdx_identifiers" : ["your_licences"],
-          "allow_unknown_licences": false,
+          "name": "your-license-policy",
+          "description": "your license policy description",
+          "spdx_identifiers" : ["your_licenses"],
+          "allow_unknown_licenses": false,
           "quarantine_on_violation": true
         }
 
     Full CLI example:
 
-      $ cloudsmith policy licence update your-org your-licence-policy policy-config-file.json
+      $ cloudsmith policy license update your-org your-license-policy policy-config-file.json
     """
     # Use stderr for message if the output is something else (e.g. JSON)
     use_stderr = opts.output != "pretty"
@@ -243,7 +237,7 @@ def update(ctx, opts, owner, identifier, policy_config_file):
     policy_config = json.load(policy_config_file)
 
     click.secho(
-        "Updating %(slug_perm)s licence policy in the %(owner)s namespace ..."
+        "Updating %(slug_perm)s license policy in the %(owner)s namespace ..."
         % {
             "slug_perm": click.style(identifier, bold=True),
             "owner": click.style(owner, bold=True),
@@ -258,23 +252,17 @@ def update(ctx, opts, owner, identifier, policy_config_file):
             "SPDX Identifiers must be unique.", param="spdx_identifiers"
         )
 
-    # Convert `allow_unknown_licences` to `allow_unknown_licenses` (avoiding license keyword)
-    if "allow_unknown_licences" in policy_config:
-        policy_config["allow_unknown_licenses"] = policy_config.pop(
-            "allow_unknown_licences"
-        )
-
-    context_msg = "Failed to update the licence policy!"
+    context_msg = "Failed to update the license policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            policies = [api.update_licence_policy(owner, identifier, policy_config)]
+            policies = [api.update_license_policy(owner, identifier, policy_config)]
 
     click.secho("OK", fg="green", err=use_stderr)
 
     if utils.maybe_print_as_json(opts, policies):
         return
 
-    print_licence_policies(policies)
+    print_license_policies(policies)
 
 
 @licence.command(aliases=["rm"])
@@ -294,20 +282,20 @@ def update(ctx, opts, owner, identifier, policy_config_file):
 @click.pass_context
 def delete(ctx, opts, owner, identifier, yes):
     """
-    Delete a licence policy from a namespace.
+    Delete a license policy from a namespace.
 
     - OWNER: Specify the OWNER namespace (i.e. org).
 
         Example: 'your-org'
 
-    - IDENTIFIER: Specify the licence policy IDENTIFIER (i.e. slug_perm)
-      for the licence policy which you wish to delete.
+    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
+      for the license policy which you wish to delete.
 
-        Example: 'your-licence-policy'
+        Example: 'your-license-policy'
 
     Full CLI example:
 
-      $ cloudsmith policy licence delete your-org your-licence-policy
+      $ cloudsmith policy license delete your-org your-license-policy
     """
 
     delete_args = {
@@ -316,7 +304,7 @@ def delete(ctx, opts, owner, identifier, yes):
     }
 
     prompt = (
-        "delete the %(slug_perm)s licence policy from the %(namespace)s namespace"
+        "delete the %(slug_perm)s license policy from the %(namespace)s namespace"
         % delete_args
     )
 
@@ -328,9 +316,9 @@ def delete(ctx, opts, owner, identifier, yes):
         nl=False,
     )
 
-    context_msg = "Failed to delete the licence policy!"
+    context_msg = "Failed to delete the license policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            api.delete_licence_policy(owner=owner, slug_perm=identifier)
+            api.delete_license_policy(owner=owner, slug_perm=identifier)
 
     click.secho("OK", fg="green")

--- a/cloudsmith_cli/cli/commands/policy/license.py
+++ b/cloudsmith_cli/cli/commands/policy/license.py
@@ -163,11 +163,6 @@ def create(ctx, opts, owner, policy_config_file):
             param="spdx_identifiers",
         )
 
-    if len(spdx_identifiers) > len(set(spdx_identifiers)):
-        raise click.BadParameter(
-            "SPDX Identifiers must be unique.", param="spdx_identifiers"
-        )
-
     click.secho(
         "Creating %(name)s license policy for the %(owner)s namespace ..."
         % {
@@ -245,12 +240,6 @@ def update(ctx, opts, owner, identifier, policy_config_file):
         nl=False,
         err=use_stderr,
     )
-
-    spdx_identifiers = policy_config.get("spdx_identifiers", [])
-    if len(spdx_identifiers) > len(set(spdx_identifiers)):
-        raise click.BadParameter(
-            "SPDX Identifiers must be unique.", param="spdx_identifiers"
-        )
 
     context_msg = "Failed to update the license policy!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):

--- a/cloudsmith_cli/cli/commands/policy/license.py
+++ b/cloudsmith_cli/cli/commands/policy/license.py
@@ -1,0 +1,316 @@
+"""CLI/Commands - create, retrieve, update or delete license policies."""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+
+import click
+import six
+
+from ....core.api import orgs as api
+from ... import command, decorators, utils, validators
+from ...exceptions import handle_api_exceptions
+from ...utils import fmt_bool, fmt_datetime, maybe_spinner
+from .command import policy
+
+
+def print_license_policies(policies):
+    """Print license policies as a table or output in another format."""
+
+    headers = [
+        "Name",
+        "Description",
+        "Allow Unknown Licenses",
+        "Quarantine On Violation",
+        "SPDX Identifiers",
+        "Created At",
+        "Updated At",
+        "Identifier",
+    ]
+
+    rows = [
+        [
+            click.style(policy["name"], fg="cyan"),
+            click.style(policy["description"], fg="yellow"),
+            click.style(fmt_bool(policy["allow_unknown_licenses"]), fg="yellow"),
+            click.style(six.text_type(policy["on_violation_quarantine"]), fg="blue"),
+            click.style(six.text_type(policy["spdx_identifiers"]), fg="blue"),
+            click.style(fmt_datetime(policy["created_at"]), fg="blue"),
+            click.style(fmt_datetime(policy["updated_at"]), fg="blue"),
+            click.style(policy["slug_perm"], fg="green"),
+        ]
+        for policy in policies
+    ]
+
+    click.echo()
+    utils.pretty_print_table(headers, rows)
+    click.echo()
+
+    num_results = len(rows)
+    list_suffix = "vulnerability polic%s" % ("y" if num_results == 1 else "ies")
+    utils.pretty_print_list_info(num_results=num_results, suffix=list_suffix)
+
+
+@policy.group(cls=command.AliasGroup, name="license", aliases=[])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.pass_context
+def license(*args, **kwargs):
+    """
+    Manage license policies for an organization.
+
+    See the help for subcommands for more information on each.
+    """
+
+
+@license.command(name="list", aliases=["ls"])
+@decorators.common_cli_config_options
+@decorators.common_cli_list_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument(
+    "owner", metavar="OWNER", callback=validators.validate_owner, required=True
+)
+@click.pass_context
+def ls(ctx, opts, owner, page, page_size):
+    """
+    List vulnerability policies.
+
+    This requires appropriate permissions for the owner (a member of the
+    organisation and a valid API key).
+
+    - OWNER: Specify the OWNER namespace (i.e. org)
+
+      Example: 'your-org'
+
+    Full CLI example:
+
+      $ cloudsmith policy license list your-org
+    """
+    owner = owner[0]
+
+    # Use stderr for messages if the output is something else (e.g.  # JSON)
+    use_stderr = opts.output != "pretty"
+
+    click.echo("Getting license policies ... ", nl=False, err=use_stderr)
+
+    context_msg = "Failed to get license policies!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            policies, page_info = api.list_license_policies(
+                owner=owner, page=page, page_size=page_size
+            )
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, policies, page_info):
+        return
+
+    print_license_policies(policies)
+
+
+@license.command(aliases=["new"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument("owner", default=None, required=True)
+@click.argument("policy_config_file", type=click.File("rb"), required=True)
+@click.pass_context
+def create(ctx, opts, owner, policy_config_file):
+    """
+    Create a new license policy in a namespace.
+
+    - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
+      to create a license policy.
+
+        Example: 'your-org'
+
+    - POLICY_CONFIG_FILE: Config file specifying the settings for the
+      license policy to be created.
+
+        \b
+        Example:
+        {
+          "name": "your-license-policy",
+          "description": "your license policy description",
+          "spdx_identifiers" : ["your_licenses"],
+          "allow_unknown_licenses": false,
+          "quarantine_on_violation": true
+        }
+
+    Full CLI example:
+
+      $ cloudsmith policy license create your-org policy-config-file.json
+    """
+    # Use stderr for messages if the output is something else (e.g. JSON)
+    use_stderr = opts.output != "pretty"
+    policy_config = json.load(policy_config_file)
+
+    policy_name = policy_config.get("name", None)
+    if policy_name is None:
+        raise click.BadParameter(
+            "Name is a required field for creating a license policy.",
+            param="name",
+        )
+
+    spdx_identifiers = policy_config.get("spdx_identifiers", None)
+    if spdx_identifiers is None:
+        raise click.BadParameter(
+            "SPDX Identifiers is a required field for creating a license policy.",
+            param="spdx_identifiers",
+        )
+
+
+    click.secho(
+        "Creating %(name)s license policy for the %(owner)s namespace ..."
+        % {
+            "name": click.style(policy_name, bold=True),
+            "owner": click.style(owner, bold=True),
+        },
+        nl=False,
+        err=use_stderr,
+    )
+
+    context_msg = "Failed to create the license policy!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            policies = [api.create_license_policy(owner, policy_config)]
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, policies):
+        return
+
+    print_license_policies(policies)
+
+
+@license.command()
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument("owner", default=None, required=True)
+@click.argument("identifier", default=None, required=True)
+@click.argument("policy_config_file", type=click.File("rb"), required=True)
+@click.pass_context
+def update(ctx, opts, owner, identifier, policy_config_file):
+    """
+    Update a license policy.
+
+    - OWNER: Specify the OWNER namespace (i.e. user or org) where you want
+      to update a license policy.
+
+        Example: 'your-org'
+
+    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
+      for the license policy which you wish to update.
+
+        Example: 'your-license-policy'
+
+    - POLICY_CONFIG_FILE: Config file specifying the settings for the
+      license policy to be updated.
+
+        \b
+        Example:
+        {
+          "name": "your-license-policy",
+          "description": "your license policy description",
+          "spdx_identifiers" : ["your_licenses"],
+          "allow_unknown_licenses": false,
+          "quarantine_on_violation": true
+        }
+
+    Full CLI example:
+
+      $ cloudsmith policy license update your-org your-license-policy policy-config-file.json
+    """
+    # Use stderr for message if the output is something else (e.g. JSON)
+    use_stderr = opts.output != "pretty"
+
+    policy_config = json.load(policy_config_file)
+
+    click.secho(
+        "Updating %(slug_perm)s license policy in the %(owner)s namespace ..."
+        % {
+            "slug_perm": click.style(identifier, bold=True),
+            "owner": click.style(owner, bold=True),
+        },
+        nl=False,
+        err=use_stderr,
+    )
+
+    context_msg = "Failed to update the license policy!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            policies = [
+                api.update_license_policy(owner, identifier, policy_config)
+            ]
+
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if utils.maybe_print_as_json(opts, policies):
+        return
+
+    print_license_policies(policies)
+
+
+@license.command(aliases=["rm"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.argument("owner", metavar="OWNER")
+@click.argument("identifier", default=None, required=True)
+@click.option(
+    "-y",
+    "--yes",
+    default=False,
+    is_flag=True,
+    help="Assume yes as default answer to questions (this is dangerous!)",
+)
+@click.pass_context
+def delete(ctx, opts, owner, identifier, yes):
+    """
+    Delete a license policy from a namespace.
+
+    - OWNER: Specify the OWNER namespace (i.e. org).
+
+        Example: 'your-org'
+
+    - IDENTIFIER: Specify the license policy IDENTIFIER (i.e. slug_perm)
+      for the license policy which you wish to delete.
+
+        Example: 'your-license-policy'
+
+    Full CLI example:
+
+      $ cloudsmith policy license delete your-org your-license-policy
+    """
+
+    delete_args = {
+        "namespace": click.style(owner, bold=True),
+        "slug_perm": click.style(identifier, bold=True),
+    }
+
+    prompt = (
+        "delete the %(slug_perm)s license policy from the %(namespace)s namespace"
+        % delete_args
+    )
+
+    if not utils.confirm_operation(prompt, assume_yes=yes):
+        return
+
+    click.secho(
+        "Deleting %(slug_perm)s from the %(namespace)s namespace ... " % delete_args,
+        nl=False,
+    )
+
+    context_msg = "Failed to delete the license policy!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            api.delete_license_policy(owner=owner, slug_perm=identifier)
+
+    click.secho("OK", fg="green")

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -26,7 +26,7 @@ def create_license_policy_config_file(
         "on_violation_quarantine": on_violation_quarantine,
     }
 
-    file_path = directory / "License-POLICY-CONFIG.json"
+    file_path = directory / "LICENSE-POLICY-CONFIG.json"
     file_path.write_text(six.text_type(json.dumps(data)))
     return file_path
 
@@ -133,7 +133,7 @@ def test_license_policy_commands(runner, organization, tmp_path):
     # Change the values in the config file
     policy_config_file_path = create_license_policy_config_file(
         directory=tmp_path,
-        name=policy_name,
+        name=random_str(),
         description=random_str(),
         allow_unknown_licenses=random_bool(),
         on_violation_quarantine=random_bool(),

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+import six
+
+from ....commands.policy.licence import create, delete, ls, update
+from ...utils import random_bool, random_str
+
+
+def create_licence_policy_config_file(
+    directory,
+    name,
+    description,
+    allow_unknown_licences,
+    spdx_identifiers,
+    on_violation_quarantine,
+):
+    """Create a licence policy config file in `directory` and return its path."""
+
+    data = {
+        "name": name,
+        "description": description,
+        "spdx_identifiers": list(spdx_identifiers),
+        "allow_unknown_licences": allow_unknown_licences,
+        "quarantine_on_violation": on_violation_quarantine,
+    }
+
+    file_path = directory / "LICENCE-POLICY-CONFIG.json"
+    file_path.write_text(six.text_type(json.dumps(data)))
+    return file_path
+
+
+def parse_table_from_output(output):
+    """Return a dict of licence policy properties parsed from tabular cli output.
+
+    Note that this excludes any policies whose name doesn't start with the 'cli-test-'
+    prefix, in an effort to not interfere too much with the environment in which we are
+    testing.
+
+    This also helps us to verify that there is only one policy created by our test.
+    """
+
+    headers = []
+    row = []
+
+    separator = "|"
+
+    for line in output.split("\n"):
+        if not headers and line.startswith("Name"):
+            headers = [header.strip() for header in line.split(separator)]
+        elif line.startswith("cli-test-"):
+            if row:
+                raise Exception("Multiple licence policies detected - expected 1.")
+            row = [val.strip() for val in line.split(separator)]
+
+    if not headers:
+        raise Exception("Table not found in output!")
+
+    if not row:
+        raise Exception("No license policies found - expected 1.")
+
+    return dict(zip(headers, row))
+
+
+def assert_output_matches_policy_config(output, config_file_path):
+    """Assert that tabular output from a command invocation matches policy config."""
+
+    output_table = parse_table_from_output(output)
+    config = json.loads(config_file_path.read_text())
+
+    # Assert that configurable values are set correctly
+    assert output_table["Name"] == config["name"]
+    assert output_table["Description"] == config["description"]
+    assert output_table["SPDX Identifiers"] == config["spdx_identifiers"]
+    assert (
+        output_table["Allow Unknown Licences"]
+        == str(config["allow_unknown_licences"]).lower()
+    )
+    assert (
+        output_table["Quarantine On Violation"]
+        == str(config["quarantine_on_violation"]).lower()
+    )
+
+    # We just require non-configurable values to be truthy
+    assert output_table["Created"]
+    assert output_table["Updated"]
+    assert output_table["Identifier"]
+
+    # Return the slug_perm in case we need it for other cli calls
+    return output_table["Identifier"]
+
+
+@pytest.mark.usefixtures("set_api_key_env_var", "set_api_host_env_var")
+def test_licence_policy_commands(runner, organization, tmp_path):
+    """Test CRUD operations for licence policies."""
+
+    # Generate the vulnerability policy configuration file.
+    policy_name = random_str()
+
+    policy_config_file_path = create_licence_policy_config_file(
+        directory=tmp_path,
+        name=policy_name,
+        description=random_str(),
+        allow_unknown_licences=random_bool(),
+        on_violation_quarantine=random_bool(),
+        spdx_identifiers=["Apache-2.0"],
+    )
+
+    # Create the licence policy
+    result = runner.invoke(
+        create,
+        args=[organization, str(policy_config_file_path)],
+        catch_exceptions=False,
+    )
+    assert (
+        "Creating " + policy_name + " licence policy for the cloudsmith namespace ...OK"
+        in result.output
+    )
+    assert "Results: 1 licence policy" in result.output
+    slug_perm = assert_output_matches_policy_config(
+        result.output, policy_config_file_path
+    )
+
+    # Use the cli to get the policy
+    result = runner.invoke(ls, args=[organization], catch_exceptions=False)
+    assert "Getting licence policies ... OK" in result.output
+    # Ignoring the exact number of results and pluralization of the word "policy"
+    # here, because we may be in a system with pre-existing policies.
+    assert "Results:" in result.output
+    assert_output_matches_policy_config(result.output, policy_config_file_path)
+
+    # Change the values in the config file
+    policy_config_file_path = create_licence_policy_config_file(
+        directory=tmp_path,
+        name=policy_name,
+        description=random_str(),
+        allow_unknown_licences=random_bool(),
+        on_violation_quarantine=random_bool(),
+        spdx_identifiers=["Apache-1.0"],
+    )
+
+    # Use the cli to update the policy
+    result = runner.invoke(
+        update,
+        args=[organization, slug_perm, str(policy_config_file_path)],
+        catch_exceptions=False,
+    )
+    assert (
+        "Updating " + slug_perm + " licence policy in the cloudsmith namespace ...OK"
+        in result.output
+    )
+    assert "Results: 1 licence policy" in result.output
+    assert_output_matches_policy_config(result.output, policy_config_file_path)
+
+    # Check that delete prompts for confirmation
+    result = runner.invoke(
+        delete, args=[organization, slug_perm], input="N", catch_exceptions=False
+    )
+    assert (
+        "Are you absolutely certain you want to delete the "
+        + slug_perm
+        + " licence policy from the cloudsmith namespace? [y/N]: N"
+        in result.output
+    )
+    assert "OK, phew! Close call. :-)" in result.output
+
+    # Then actually delete it
+    result = runner.invoke(
+        delete, args=[organization, slug_perm], input="Y", catch_exceptions=False
+    )
+    assert (
+        "Are you absolutely certain you want to delete the "
+        + slug_perm
+        + " licence policy from the cloudsmith namespace? [y/N]: Y"
+        in result.output
+    )
+    assert (
+        "Deleting " + slug_perm + " from the cloudsmith namespace ... OK"
+        in result.output
+    )

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -72,7 +72,7 @@ def assert_output_matches_policy_config(output, config_file_path):
     # Assert that configurable values are set correctly
     assert output_table["Name"] == config["name"]
     assert output_table["Description"] == config["description"]
-    assert output_table["SPDX Identifiers"] == config["spdx_identifiers"]
+    assert output_table["SPDX Identifiers"] == str(config["spdx_identifiers"])
     assert (
         output_table["Allow Unknown Licences"]
         == str(config["allow_unknown_licences"]).lower()

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -95,7 +95,7 @@ def assert_output_matches_policy_config(output, config_file_path):
 def test_licence_policy_commands(runner, organization, tmp_path):
     """Test CRUD operations for licence policies."""
 
-    # Generate the vulnerability policy configuration file.
+    # Generate the licence policy configuration file.
     policy_name = random_str()
 
     policy_config_file_path = create_licence_policy_config_file(

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -23,7 +23,7 @@ def create_licence_policy_config_file(
         "description": description,
         "spdx_identifiers": list(spdx_identifiers),
         "allow_unknown_licences": allow_unknown_licences,
-        "quarantine_on_violation": on_violation_quarantine,
+        "on_violation_quarantine": on_violation_quarantine,
     }
 
     file_path = directory / "LICENCE-POLICY-CONFIG.json"
@@ -58,7 +58,7 @@ def parse_table_from_output(output):
         raise Exception("Table not found in output!")
 
     if not row:
-        raise Exception("No license policies found - expected 1.")
+        raise Exception("No licence policies found - expected 1.")
 
     return dict(zip(headers, row))
 
@@ -79,7 +79,7 @@ def assert_output_matches_policy_config(output, config_file_path):
     )
     assert (
         output_table["Quarantine On Violation"]
-        == str(config["quarantine_on_violation"]).lower()
+        == str(config["on_violation_quarantine"]).lower()
     )
 
     # We just require non-configurable values to be truthy

--- a/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_licence.py
@@ -4,35 +4,35 @@ import json
 import pytest
 import six
 
-from ....commands.policy.licence import create, delete, ls, update
+from ....commands.policy.license import create, delete, ls, update
 from ...utils import random_bool, random_str
 
 
-def create_licence_policy_config_file(
+def create_license_policy_config_file(
     directory,
     name,
     description,
-    allow_unknown_licences,
+    allow_unknown_licenses,
     spdx_identifiers,
     on_violation_quarantine,
 ):
-    """Create a licence policy config file in `directory` and return its path."""
+    """Create a license policy config file in `directory` and return its path."""
 
     data = {
         "name": name,
         "description": description,
         "spdx_identifiers": list(spdx_identifiers),
-        "allow_unknown_licences": allow_unknown_licences,
+        "allow_unknown_licenses": allow_unknown_licenses,
         "on_violation_quarantine": on_violation_quarantine,
     }
 
-    file_path = directory / "LICENCE-POLICY-CONFIG.json"
+    file_path = directory / "License-POLICY-CONFIG.json"
     file_path.write_text(six.text_type(json.dumps(data)))
     return file_path
 
 
 def parse_table_from_output(output):
-    """Return a dict of licence policy properties parsed from tabular cli output.
+    """Return a dict of license policy properties parsed from tabular cli output.
 
     Note that this excludes any policies whose name doesn't start with the 'cli-test-'
     prefix, in an effort to not interfere too much with the environment in which we are
@@ -51,14 +51,14 @@ def parse_table_from_output(output):
             headers = [header.strip() for header in line.split(separator)]
         elif line.startswith("cli-test-"):
             if row:
-                raise Exception("Multiple licence policies detected - expected 1.")
+                raise Exception("Multiple license policies detected - expected 1.")
             row = [val.strip() for val in line.split(separator)]
 
     if not headers:
         raise Exception("Table not found in output!")
 
     if not row:
-        raise Exception("No licence policies found - expected 1.")
+        raise Exception("No license policies found - expected 1.")
 
     return dict(zip(headers, row))
 
@@ -74,8 +74,8 @@ def assert_output_matches_policy_config(output, config_file_path):
     assert output_table["Description"] == config["description"]
     assert output_table["SPDX Identifiers"] == str(config["spdx_identifiers"])
     assert (
-        output_table["Allow Unknown Licences"]
-        == str(config["allow_unknown_licences"]).lower()
+        output_table["Allow Unknown Licenses"]
+        == str(config["allow_unknown_licenses"]).lower()
     )
     assert (
         output_table["Quarantine On Violation"]
@@ -92,50 +92,50 @@ def assert_output_matches_policy_config(output, config_file_path):
 
 
 @pytest.mark.usefixtures("set_api_key_env_var", "set_api_host_env_var")
-def test_licence_policy_commands(runner, organization, tmp_path):
-    """Test CRUD operations for licence policies."""
+def test_license_policy_commands(runner, organization, tmp_path):
+    """Test CRUD operations for license policies."""
 
-    # Generate the licence policy configuration file.
+    # Generate the license policy configuration file.
     policy_name = random_str()
 
-    policy_config_file_path = create_licence_policy_config_file(
+    policy_config_file_path = create_license_policy_config_file(
         directory=tmp_path,
         name=policy_name,
         description=random_str(),
-        allow_unknown_licences=random_bool(),
+        allow_unknown_licenses=random_bool(),
         on_violation_quarantine=random_bool(),
         spdx_identifiers=["Apache-2.0"],
     )
 
-    # Create the licence policy
+    # Create the license policy
     result = runner.invoke(
         create,
         args=[organization, str(policy_config_file_path)],
         catch_exceptions=False,
     )
     assert (
-        "Creating " + policy_name + " licence policy for the cloudsmith namespace ...OK"
+        "Creating " + policy_name + " license policy for the cloudsmith namespace ...OK"
         in result.output
     )
-    assert "Results: 1 licence policy" in result.output
+    assert "Results: 1 license policy" in result.output
     slug_perm = assert_output_matches_policy_config(
         result.output, policy_config_file_path
     )
 
     # Use the cli to get the policy
     result = runner.invoke(ls, args=[organization], catch_exceptions=False)
-    assert "Getting licence policies ... OK" in result.output
+    assert "Getting license policies ... OK" in result.output
     # Ignoring the exact number of results and pluralization of the word "policy"
     # here, because we may be in a system with pre-existing policies.
     assert "Results:" in result.output
     assert_output_matches_policy_config(result.output, policy_config_file_path)
 
     # Change the values in the config file
-    policy_config_file_path = create_licence_policy_config_file(
+    policy_config_file_path = create_license_policy_config_file(
         directory=tmp_path,
         name=policy_name,
         description=random_str(),
-        allow_unknown_licences=random_bool(),
+        allow_unknown_licenses=random_bool(),
         on_violation_quarantine=random_bool(),
         spdx_identifiers=["Apache-1.0"],
     )
@@ -147,10 +147,10 @@ def test_licence_policy_commands(runner, organization, tmp_path):
         catch_exceptions=False,
     )
     assert (
-        "Updating " + slug_perm + " licence policy in the cloudsmith namespace ...OK"
+        "Updating " + slug_perm + " license policy in the cloudsmith namespace ...OK"
         in result.output
     )
-    assert "Results: 1 licence policy" in result.output
+    assert "Results: 1 license policy" in result.output
     assert_output_matches_policy_config(result.output, policy_config_file_path)
 
     # Check that delete prompts for confirmation
@@ -160,7 +160,7 @@ def test_licence_policy_commands(runner, organization, tmp_path):
     assert (
         "Are you absolutely certain you want to delete the "
         + slug_perm
-        + " licence policy from the cloudsmith namespace? [y/N]: N"
+        + " license policy from the cloudsmith namespace? [y/N]: N"
         in result.output
     )
     assert "OK, phew! Close call. :-)" in result.output
@@ -172,7 +172,7 @@ def test_licence_policy_commands(runner, organization, tmp_path):
     assert (
         "Are you absolutely certain you want to delete the "
         + slug_perm
-        + " licence policy from the cloudsmith namespace? [y/N]: Y"
+        + " license policy from the cloudsmith namespace? [y/N]: Y"
         in result.output
     )
     assert (

--- a/cloudsmith_cli/core/api/orgs.py
+++ b/cloudsmith_cli/core/api/orgs.py
@@ -65,3 +65,55 @@ def delete_vulnerability_policy(owner, slug_perm):
         )
 
     ratelimits.maybe_rate_limit(client, headers)
+
+
+def list_license_policies(owner, page, page_size):
+    """List license policies in a namespace."""
+    client = get_orgs_api()
+
+    with catch_raise_api_exception():
+        policies, _, headers = client.orgs_license_policy_list_with_http_info(
+            org=owner, page=page, page_size=page_size
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    page_info = PageInfo.from_headers(headers)
+    return [policy.to_dict() for policy in policies], page_info
+
+
+def create_license_policy(owner, policy_config):
+    """Create a license policy in a namespace."""
+    client = get_orgs_api()
+
+    with catch_raise_api_exception():
+        policy, _, headers = client.orgs_license_policy_create_with_http_info(
+            org=owner, data=policy_config
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return policy.to_dict()
+
+
+def update_license_policy(owner, slug_perm, policy_config):
+    """Update a license policy in a namespace."""
+    client = get_orgs_api()
+
+    with catch_raise_api_exception():
+        policy, _, headers = client.orgs_license_policy_partial_update_with_http_info(
+            org=owner, slug_perm=slug_perm, data=policy_config
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return policy.to_dict()
+
+
+def delete_license_policy(owner, slug_perm):
+    """Delete a license policy from a namespace."""
+    client = get_orgs_api()
+
+    with catch_raise_api_exception():
+        _, _, headers = client.orgs_license_policy_delete_with_http_info(
+            owner, slug_perm
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)

--- a/cloudsmith_cli/core/api/orgs.py
+++ b/cloudsmith_cli/core/api/orgs.py
@@ -67,8 +67,8 @@ def delete_vulnerability_policy(owner, slug_perm):
     ratelimits.maybe_rate_limit(client, headers)
 
 
-def list_license_policies(owner, page, page_size):
-    """List license policies in a namespace."""
+def list_licence_policies(owner, page, page_size):
+    """List licence policies in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -81,8 +81,8 @@ def list_license_policies(owner, page, page_size):
     return [policy.to_dict() for policy in policies], page_info
 
 
-def create_license_policy(owner, policy_config):
-    """Create a license policy in a namespace."""
+def create_licence_policy(owner, policy_config):
+    """Create a licence policy in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -94,8 +94,8 @@ def create_license_policy(owner, policy_config):
     return policy.to_dict()
 
 
-def update_license_policy(owner, slug_perm, policy_config):
-    """Update a license policy in a namespace."""
+def update_licence_policy(owner, slug_perm, policy_config):
+    """Update a licence policy in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -107,8 +107,8 @@ def update_license_policy(owner, slug_perm, policy_config):
     return policy.to_dict()
 
 
-def delete_license_policy(owner, slug_perm):
-    """Delete a license policy from a namespace."""
+def delete_licence_policy(owner, slug_perm):
+    """Delete a licence policy from a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():

--- a/cloudsmith_cli/core/api/orgs.py
+++ b/cloudsmith_cli/core/api/orgs.py
@@ -67,8 +67,8 @@ def delete_vulnerability_policy(owner, slug_perm):
     ratelimits.maybe_rate_limit(client, headers)
 
 
-def list_licence_policies(owner, page, page_size):
-    """List licence policies in a namespace."""
+def list_license_policies(owner, page, page_size):
+    """List license policies in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -81,8 +81,8 @@ def list_licence_policies(owner, page, page_size):
     return [policy.to_dict() for policy in policies], page_info
 
 
-def create_licence_policy(owner, policy_config):
-    """Create a licence policy in a namespace."""
+def create_license_policy(owner, policy_config):
+    """Create a license policy in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -94,8 +94,8 @@ def create_licence_policy(owner, policy_config):
     return policy.to_dict()
 
 
-def update_licence_policy(owner, slug_perm, policy_config):
-    """Update a licence policy in a namespace."""
+def update_license_policy(owner, slug_perm, policy_config):
+    """Update a license policy in a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():
@@ -107,8 +107,8 @@ def update_licence_policy(owner, slug_perm, policy_config):
     return policy.to_dict()
 
 
-def delete_licence_policy(owner, slug_perm):
-    """Delete a licence policy from a namespace."""
+def delete_license_policy(owner, slug_perm):
+    """Delete a license policy from a namespace."""
     client = get_orgs_api()
 
     with catch_raise_api_exception():


### PR DESCRIPTION
Adds functionality to manage license policies via CLI

<img width="1399" alt="image" src="https://github.com/cloudsmith-io/cloudsmith-cli/assets/29574195/ab22619f-ebd9-4a21-b927-6f79a8812fc2">
