### PR TITLE
Issue 115: Set null for name and email so whoami works on service acct

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ We'd also like to say thank you to the following people (in alphabetical order),
 - Michal Nowak ([@Mno-hime](https://github.com/Mno-hime))
 - Rob Madole ([@robmadole](https://github.com/robmadole))
 - Sean Allen ([@SeanTAllen](https://github.com/SeanTAllen))
+- Jesse Rhoads ([@JesseRhoads-PD](https://github.com/JesseRhoads-PD))

--- a/cloudsmith_cli/cli/commands/whoami.py
+++ b/cloudsmith_cli/cli/commands/whoami.py
@@ -25,17 +25,24 @@ def whoami(ctx, opts):
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
             is_auth, username, email, name = get_user_brief()
-
     click.secho("OK", fg="green")
     click.echo("You are authenticated as:")
     if not is_auth:
         click.secho("Nobody (i.e. anonymous user)", fg="yellow")
     else:
         click.secho(
-            "%(name)s (slug: %(username)s, email: %(email)s)"
+            "%(name)s (slug: %(username)s"
             % {
                 "name": click.style(name, fg="cyan"),
                 "username": click.style(username, fg="magenta"),
-                "email": click.style(email, fg="green"),
-            }
+            },
+            nl=False,
         )
+
+        if email:
+            click.secho(
+                ", email: %(email)s" % {"email": click.style(email, fg="green")},
+                nl=False,
+            )
+
+        click.echo(")")


### PR DESCRIPTION
This should fix an issue we encountered where cloudsmith-cli can't do a whoami on a service account.