### PR TITLE
chore: test against all supported runtimes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           twine upload --repository-url <<parameters.registry_url>> --username <<parameters.username>> --password <<parameters.password>> --verbose dist/*
 
 orbs:
+  python: circleci/python@2.1.1
   cloudsmith_ci:
     jobs:
       execute:
@@ -136,6 +137,21 @@ workflows:
           service_name: pytest
           command: pytest --cov-report xml:./reports/coverage.xml --junitxml ./reports/pytest.xml
           is_test_suite: true
+      - python/test:
+          name: pytest-python3.9
+          version: "3.9"
+          pkg-manager: pip
+          pip-dependency-file: requirements.txt
+      - python/test:
+          name: pytest-python3.10
+          version: "3.10"
+          pkg-manager: pip
+          pip-dependency-file: requirements.txt
+      - python/test:
+          name: pytest-python3.11
+          version: "3.11"
+          pkg-manager: pip
+          pip-dependency-file: requirements.txt
       - publish:
           filters:
             branches:

--- a/bin/circle-exec
+++ b/bin/circle-exec
@@ -13,4 +13,4 @@ trap cleanup EXIT
 circleci config process .circleci/config.yml > $WORK_DIR/config.yml
 cat $WORK_DIR/config.yml
 circleci local execute --config $WORK_DIR/config.yml \
-  --env "CIRCLE_LOCAL=true"
+  --env "CIRCLE_LOCAL=true" "$@"

--- a/cloudsmith_cli/cli/tests/commands/policy/test_vulnerability.py
+++ b/cloudsmith_cli/cli/tests/commands/policy/test_vulnerability.py
@@ -32,15 +32,8 @@ def create_vulnerability_policy_config_file(
     return file_path
 
 
-def parse_table_from_output(output):
-    """Return a dict of vulnerability policy properties parsed from tabular cli output.
-
-    Note that this excludes any policies whose name doesn't start with the 'cli-test-'
-    prefix, in an effort to not interfere too much with the environment in which we are
-    testing.
-
-    This also helps us to verify that there is only one policy created by our test.
-    """
+def parse_table_from_output(output, policy_name):
+    """Return a dict of vulnerability policy properties parsed from tabular cli output."""
 
     headers = []
     row = []
@@ -50,7 +43,7 @@ def parse_table_from_output(output):
     for line in output.split("\n"):
         if not headers and line.startswith("Name"):
             headers = [header.strip() for header in line.split(separator)]
-        elif line.startswith("cli-test-"):
+        elif line.startswith(policy_name):
             if row:
                 raise Exception(
                     "Multiple vulnerability policies detected - expected 1."
@@ -69,8 +62,8 @@ def parse_table_from_output(output):
 def assert_output_matches_policy_config(output, config_file_path):
     """Assert that tabular output from a command invocation matches policy config."""
 
-    output_table = parse_table_from_output(output)
     config = json.loads(config_file_path.read_text())
+    output_table = parse_table_from_output(output, policy_name=config["name"])
 
     # Assert that configurable values are set correctly
     assert output_table["Name"] == config["name"]
@@ -124,7 +117,6 @@ def test_vulnerability_policy_commands(runner, organization, tmp_path):
         + " vulnerability policy for the cloudsmith namespace ...OK"
         in result.output
     )
-    assert "Results: 1 vulnerability policy" in result.output
     slug_perm = assert_output_matches_policy_config(
         result.output, policy_config_file_path
     )
@@ -132,9 +124,6 @@ def test_vulnerability_policy_commands(runner, organization, tmp_path):
     # Use the cli to get the policy
     result = runner.invoke(ls, args=[organization], catch_exceptions=False)
     assert "Getting vulnerability policies ... OK" in result.output
-    # Ignoring the exact number of results and pluralization of the word "policy"
-    # here, because we may be in a system with pre-existing policies.
-    assert "Results:" in result.output
     assert_output_matches_policy_config(result.output, policy_config_file_path)
 
     # Change the values in the config file
@@ -160,7 +149,6 @@ def test_vulnerability_policy_commands(runner, organization, tmp_path):
         + " vulnerability policy in the cloudsmith namespace ...OK"
         in result.output
     )
-    assert "Results: 1 vulnerability policy" in result.output
     assert_output_matches_policy_config(result.output, policy_config_file_path)
 
     # Check that delete prompts for confirmation


### PR DESCRIPTION
For python > 3.8, use circleci's python orb to pytest.

Existing 3.8-based stuff stays as-is, because the python orb doesn't integrate with code climate. (We can change that at a later stage if we want to use something other than code climate which the orb _does_ integrate with.)

Plus a couple of tweaks to tests to not be overly-strict about how many policies exist in an org, now that we're running multiple pytests in parallel. (This could be improved in future if we ever support creating an org from the cli...)