### PR TITLE
chore: tests for api init and rest client retry

### DIFF
--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -23,7 +23,7 @@ def initialise_api(
     error_retry_codes=None,
     error_retry_cb=None,
 ):
-    """Initialise the API."""
+    """Initialise the cloudsmith_api.Configuration."""
     # FIXME: pylint: disable=too-many-arguments
     config = cloudsmith_api.Configuration()
     config.debug = debug
@@ -50,8 +50,12 @@ def initialise_api(
     if key:
         config.api_key["X-Api-Key"] = key
 
-    if hasattr(cloudsmith_api.Configuration, "set_default"):
-        cloudsmith_api.Configuration.set_default(config)
+    # Important! Some of the attributes set above (e.g. error_retry_max) are not
+    # present in the cloudsmith_api.Configuration class declaration.
+    # By calling the set_default() method, we ensure that future instances of that
+    # class will include those attributes, and their (default) values.
+    cloudsmith_api.Configuration.set_default(config)
+
     return config
 
 

--- a/cloudsmith_cli/core/rest.py
+++ b/cloudsmith_cli/core/rest.py
@@ -12,7 +12,7 @@ import requests.exceptions
 from cloudsmith_api.configuration import Configuration
 from cloudsmith_api.rest import ApiException, RESTClientObject
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry  # pylint: disable=import-error
+from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
 

--- a/cloudsmith_cli/core/rest.py
+++ b/cloudsmith_cli/core/rest.py
@@ -12,7 +12,7 @@ import requests.exceptions
 from cloudsmith_api.configuration import Configuration
 from cloudsmith_api.rest import ApiException, RESTClientObject
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry  # pylint: disable=import-error
+from urllib3.util.retry import Retry  # pylint: disable=import-error
 
 logger = logging.getLogger(__name__)
 

--- a/cloudsmith_cli/core/tests/test_init.py
+++ b/cloudsmith_cli/core/tests/test_init.py
@@ -1,0 +1,63 @@
+from cloudsmith_api import Configuration
+
+from ..api.init import initialise_api
+
+
+def test_initialise_api_sets_cloudsmith_api_config_default():
+    """Assert that the extra attributes we add to the cloudsmith_cli.Configuration class
+    are present on newly-created instances of that class.
+    """
+
+    # Read and understand the Configuration class's initialiser.
+    # Notice how the _default class attribute is used if not None.
+    # https://github.com/cloudsmith-io/cloudsmith-api/blob/57963fff5b7818783b3d87246495275545d505df/bindings/python/src/cloudsmith_api/configuration.py#L32-L40
+
+    # There are a number of attributes which we automagically add to instances of
+    # cloudsmith_api.Configuration().
+    extra_config_attrs = [
+        "rate_limit",
+        "error_retry_max",
+        "error_retry_backoff",
+        "error_retry_codes",
+        "error_retry_cb",
+    ]
+
+    # We do that in our initialise_api() function by
+    # (i) creating a new instance of Configuration and adding attributes/values to it.
+    # (ii) calling the cloudsmith_api.Configuration.set_default(config) classmethod.
+
+    # For the purposes of this test, we need to explcitly call set_default(None) at the
+    # outset because other tests in the suite may have called initialise_api() already.
+    # Resetting Configuration._default to None here effectively reverts the
+    # Configuration class to its vanilla, unmodified behaviour/state.
+    Configuration.set_default(None)
+
+    # Because Configuration._default is None, a newly-created instance of
+    # cloudsmith_api.Configuration() should not have any other attributes than those
+    # in the auto-generated swagger-codegen class declaration.
+    new_config_before_initialise = Configuration()
+    assert all(
+        not hasattr(new_config_before_initialise, attr) for attr in extra_config_attrs
+    )
+
+    # Our initialise_api() function should create an instance of
+    # cloudsmith_api.Configuration, add some extra attributes to it, set default values
+    # and pass that instance to cloudsmith_api.Configuration.set_default().
+    config_from_initialise = initialise_api()
+    assert all(hasattr(config_from_initialise, attr) for attr in extra_config_attrs)
+    assert (
+        Configuration._default  # pylint: disable=protected-access
+        is config_from_initialise
+    )
+
+    # After which point, any newly-created instances of cloudsmith_api.Configuration
+    # should automagically include copies of those "extra" attributes we assigned to
+    # the "default" config instance in our initialise_api() function.
+    new_config_after_initialise = Configuration()
+    assert all(
+        hasattr(new_config_after_initialise, attr) for attr in extra_config_attrs
+    )
+    assert (
+        Configuration._default  # pylint: disable=protected-access
+        is not new_config_after_initialise
+    )

--- a/cloudsmith_cli/core/tests/test_rest.py
+++ b/cloudsmith_cli/core/tests/test_rest.py
@@ -1,0 +1,39 @@
+import httpretty
+
+from ..api.init import initialise_api
+from ..rest import RestClient
+
+
+class TestRestClient:
+    @httpretty.activate(allow_net_connect=False, verbose=True)
+    def test_implicit_retry_for_status_codes(self):
+        """Assert that the rest client retries certain status codes automatically."""
+        # initialise_api() needs to be called before RestClient can be instantiated,
+        # because it adds default attributes to cloudsmith_api.Configuration which
+        # RestClient expects to be there.
+        # In the context of a full test suite run, this will probably have already
+        # happened elsewhere. But just in case this test is ever run in isolation...
+        initialise_api()
+
+        client = RestClient()
+
+        method = "GET"
+        url = "https://test.site"
+
+        httpretty.register_uri(
+            method,
+            url,
+            responses=[
+                httpretty.Response("", status=500),
+                httpretty.Response("", status=502),
+                httpretty.Response("", status=503),
+                httpretty.Response("", status=504),
+                httpretty.Response("", status=500),
+                httpretty.Response("", status=200),
+            ],
+        )
+
+        r = client.request(method, url)
+
+        assert len(httpretty.latest_requests()) == 6
+        assert r.status == 200

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 # Use this file to declare development-only dependencies.
 # All production dependencies should be declared in setup.py `install_requires`.
 bumpversion
+httpretty
 pip-tools
 pre-commit
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,8 @@ filelock==3.12.2
     # via virtualenv
 future==0.18.3
     # via cloudsmith-cli (setup.py)
+httpretty==1.1.4
+    # via -r requirements.in
 identify==2.5.26
     # via pre-commit
 idna==3.4


### PR DESCRIPTION
Added tests for `initialise_api()` and retry functionality in `RestClient.request()`.

I really just wanted to test the retry stuff, but you can't instantiate a rest client without doing the api initialisation first.

Side note:
I found that the more popular requests mocking libraries( e.g. [responses](https://github.com/getsentry/responses/issues/135) and [requests-mock](https://github.com/jamielennox/requests-mock/issues/83)) conflict with retry functionality in our requests adapter, because they too operate (i.e. mock) at the requests adapter level. httpretty operates at the socket level, which makes it possible to test our gear.