### PR TITLE
fix: remove unused py2 packages

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -659,4 +659,3 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed more unused dependencies relating to python 2.7 compatibility ([#142](https://github.com/cloudsmith-io/cloudsmith-cli/pull/142))
+
 ## [1.0.0] - 2023-08-10
 
 ### Breaking change

--- a/cloudsmith_cli/core/api/exceptions.py
+++ b/cloudsmith_cli/core/api/exceptions.py
@@ -1,14 +1,10 @@
 """API - Exceptions."""
 
 import contextlib
+import http.client
+import json
 
 from cloudsmith_api.rest import ApiException as _ApiException
-from six.moves import http_client
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 
 class ApiException(Exception):
@@ -21,7 +17,7 @@ class ApiException(Exception):
         if status == 422:
             self.status_description = "Unprocessable Entity"
         else:
-            self.status_description = http_client.responses.get(
+            self.status_description = http.client.responses.get(
                 status, "Unknown Status"
             )
         self.detail = detail

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,6 @@ click-spinner==0.1.10
     # via cloudsmith-cli (setup.py)
 cloudsmith-api==2.0.7
     # via cloudsmith-cli (setup.py)
-colorama==0.4.6
-    # via cloudsmith-cli (setup.py)
 configparser==6.0.0
     # via click-configfile
 coverage[toml]==7.2.7
@@ -48,8 +46,6 @@ exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via virtualenv
-future==0.18.3
-    # via cloudsmith-cli (setup.py)
 httpretty==1.1.4
     # via -r requirements.in
 identify==2.5.26
@@ -99,8 +95,6 @@ requests==2.31.0
 requests-toolbelt==1.0.0
     # via cloudsmith-cli (setup.py)
 semver==3.0.1
-    # via cloudsmith-cli (setup.py)
-simplejson==3.19.1
     # via cloudsmith-cli (setup.py)
 six==1.16.0
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,3 @@ show_missing = true
 [tool:pytest]
 addopts = --cov=cloudsmith_cli
 norecursedirs = bin .git .venv
-filterwarnings =
-    ignore::DeprecationWarning:cloudsmith_api.*:
-    error

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,4 +42,5 @@ show_missing = true
 addopts = --cov=cloudsmith_cli
 norecursedirs = bin .git .venv
 filterwarnings =
+    ignore::DeprecationWarning:cloudsmith_api.*:
     error

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,9 @@ setup(
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
         "cloudsmith-api>=2.0.7,<3.0",  # Compatible upto (but excluding) 3.0+
-        "colorama>=0.3.9",
-        "future>=0.16.0",
         "requests>=2.18.4",
         "requests_toolbelt>=0.8.0",
         "semver>=2.7.9",
-        "simplejson>=3.12.0",
         "urllib3<2.0",
     ],
     entry_points={


### PR DESCRIPTION
Cleaned up some more old py2 cruft.

Removed the following packages from setup.py requirements:

- colorama
- future
- simplejson