### PR TITLE
Fix version requirement on urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "requests>=2.18.4",
         "requests_toolbelt>=0.8.0",
         "semver>=2.7.9",
-        "urllib3<2.0",
+        "urllib3>=1.26.0,<2.0",
     ],
     entry_points={
         "console_scripts": ["cloudsmith=cloudsmith_cli.cli.commands.main:main"]


### PR DESCRIPTION
Hello,

The changes in [`101fdea` (#141)](https://github.com/cloudsmith-io/cloudsmith-cli/pull/141/commits/101fdeab4ad5fb82215127891ca36610221457cb) broke compatibility with urllib3 prior to version 1.26.0 where `allowed_methods` was introduced in the `Retry` constructor.

I encountered this issue trying to run cloudsmith-cli on Ubuntu 20.04 where `python3-urllib3` is `1.25.8` and thus incompatible with the latest cloudsmith-cli release.

The change in this PR should hopefully improve the diagnosis in such environments.