### PR TITLE
fix: use method_whitelist kwarg for urllib3 < 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.1.0] - 2023-09-08
 
+### Fixed
+
+- Revert change to urllib3 Retry constructor `method_whitelist`/`allowed_methods` kwarg ([#148](https://github.com/cloudsmith-io/cloudsmith-cli/pull/148))
+
 ### Added
 
 - Added support for large file uploads ([#143](https://github.com/cloudsmith-io/cloudsmith-cli/pull/143))

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ We'd also like to say thank you to the following people (in alphabetical order),
 - Rob Madole ([@robmadole](https://github.com/robmadole))
 - Sean Allen ([@SeanTAllen](https://github.com/SeanTAllen))
 - Jesse Rhoads ([@JesseRhoads-PD](https://github.com/JesseRhoads-PD))
+- Pierre Gergondet ([@gergondet](https://github.com/gergondet))

--- a/cloudsmith_cli/core/rest.py
+++ b/cloudsmith_cli/core/rest.py
@@ -106,7 +106,7 @@ def create_requests_session(
     retry = RetryWithCallback(
         backoff_factor=backoff_factor,
         connect=retries,
-        allowed_methods=False,
+        method_whitelist=False,
         read=retries,
         status_forcelist=tuple(status_forcelist),
         status=retries,


### PR DESCRIPTION
Essentially a revert of 101fdeab4ad5fb82215127891ca36610221457cb in which I changed the name of a kwarg supplied to urllib3's `Retry`, as it was issuing a DeprecationWarning.

In hindsight, this was not strictly necessary given that the deprecation is due to take effect in urllib3 2.0, and we currently constrain to < 2.0.

This also caused issues with the 1.1.0 release of cloudsmith-cli in environments where a sufficiently recent version of urllib3 (which accepts the new kwarg name) is not available.

closes #146 #147 