### PR TITLE
Pin cloudsmith-api to less than 2.0.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "click-configfile>=0.2.3",
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
-        "cloudsmith-api>=2.0.7,<3.0",  # Compatible upto (but excluding) 3.0+
+        "cloudsmith-api<=2.0.7,<3.0",  # Compatible upto (but excluding) 3.0+
         "requests>=2.18.4",
         "requests_toolbelt>=0.8.0",
         "semver>=2.7.9",


### PR DESCRIPTION
- While we investigate an issue with `cloudsmith-api` v2.0.8.