### PR TITLE
ceng-163: Fix repository pagination

### DIFF
--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -127,7 +127,9 @@ def get(ctx, opts, owner_repo, page, page_size):
     if utils.maybe_print_as_json(opts, repos_, page_info):
         return
 
-    print_repositories(opts=opts, data=repos_, show_list_info=False, page_info=page_info)
+    print_repositories(
+        opts=opts, data=repos_, show_list_info=False, page_info=page_info
+    )
 
 
 @repositories.command(aliases=["new"])

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -127,7 +127,7 @@ def get(ctx, opts, owner_repo, page, page_size):
     if utils.maybe_print_as_json(opts, repos_, page_info):
         return
 
-    print_repositories(opts=opts, data=repos_, show_list_info=False)
+    print_repositories(opts=opts, data=repos_, show_list_info=False, page_info=page_info)
 
 
 @repositories.command(aliases=["new"])


### PR DESCRIPTION
Before the change, the repository list command didn't return pagination: 
![image](https://github.com/cloudsmith-io/cloudsmith-cli/assets/55028730/720a8f3f-cf44-4f0f-81c5-2b663b216987)

After the change, the pagination is back:
![image](https://github.com/cloudsmith-io/cloudsmith-cli/assets/55028730/c4d1d157-e196-47e8-8eed-37717ff01bec)
 