### PR TITLE
Update CLI to store access and refresh tokens

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,8 @@ set -e
 # development dependencies. Based on:
 # https://hynek.me/til/python-project-local-venvs/
 export VIRTUAL_ENV=.venv
+
+pyenv install --skip-existing 3.8.16
 layout pyenv 3.8.16
 . .venv/bin/activate
 python -m pip install -q -r requirements.txt

--- a/.envrc
+++ b/.envrc
@@ -10,6 +10,9 @@ layout pyenv 3.8.16
 python -m pip install -q -r requirements.txt
 
 # Load environment variables from the .env file (for pytest, mainly)
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
 dotenv
 
 # Install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Both configuration files use the simple INI format, such as:
 api_key=1234567890abcdef1234567890abcdef
 ```
 
+Additionally, the CLI will store SSO access and refresh tokens in the system keyring
+using the [`keyring`](https://github.com/jaraco/keyring) library.
+
+
 ### Non-Credentials (config.ini)
 
 See the [default config](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/master/cloudsmith_cli/data/config.ini) in GitHub:

--- a/cloudsmith_cli/cli/commands/login.py
+++ b/cloudsmith_cli/cli/commands/login.py
@@ -1,9 +1,11 @@
 """CLI/Commands - Get an API token."""
 
 import collections
+import getpass
 import stat
 
 import click
+import keyring
 
 from ...core.api.user import get_user_token
 from ...core.utils import get_help_website
@@ -99,6 +101,30 @@ def create_config_files(ctx, opts, api_key):
         click.secho("EXISTS" if config.present else "NOT CREATED", fg="yellow")
 
     return create, has_errors
+
+
+def get_username():
+    return getpass.getuser()
+
+
+def store_access_token(access_token):
+    username = get_username()
+    keyring.set_password("cloudsmith_cli-access_token", username, access_token)
+
+
+def get_access_token():
+    username = get_username()
+    return keyring.get_password("cloudsmith_cli-access_token", username)
+
+
+def store_refresh_token(refresh_token):
+    username = get_username()
+    keyring.set_password("cloudsmith_cli-refresh_token", username, refresh_token)
+
+
+def get_refresh_token():
+    username = get_username()
+    return keyring.get_password("cloudsmith_cli-refresh_token", username)
 
 
 @main.command(aliases=["token"])

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 # All production dependencies should be declared in setup.py `install_requires`.
 bumpversion
 httpretty
+keyring
 pip-tools
 pre-commit
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,19 +6,21 @@
 #
 astroid==2.15.6
     # via pylint
+backports-tarfile==1.2.0
+    # via jaraco-context
 build==0.10.0
     # via pip-tools
 bump2version==1.0.1
     # via bumpversion
 bumpversion==0.6.0
     # via -r requirements.in
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   cloudsmith-api
     #   requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.6
     # via
@@ -28,13 +30,13 @@ click==8.1.6
     #   pip-tools
 click-configfile==0.2.3
     # via cloudsmith-cli (setup.py)
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via cloudsmith-cli (setup.py)
 click-spinner==0.1.10
     # via cloudsmith-cli (setup.py)
-cloudsmith-api==2.0.12
+cloudsmith-api==2.0.13
     # via cloudsmith-cli (setup.py)
-configparser==6.0.0
+configparser==7.1.0
     # via click-configfile
 coverage[toml]==7.2.7
     # via
@@ -52,16 +54,32 @@ httpretty==1.1.4
     # via -r requirements.in
 identify==2.5.26
     # via pre-commit
-idna==3.4
+idna==3.8
     # via requests
+importlib-metadata==8.5.0
+    # via keyring
+importlib-resources==6.4.5
+    # via keyring
 iniconfig==2.0.0
     # via pytest
 isort==5.12.0
     # via pylint
+jaraco-classes==3.4.0
+    # via keyring
+jaraco-context==6.0.1
+    # via keyring
+jaraco-functools==4.0.2
+    # via keyring
+keyring==25.3.0
+    # via -r requirements.in
 lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0
     # via pylint
+more-itertools==10.5.0
+    # via
+    #   jaraco-classes
+    #   jaraco-functools
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.1
@@ -86,17 +104,17 @@ pytest==7.4.0
     # via pytest-cov
 pytest-cov==4.1.0
     # via -r requirements.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via cloudsmith-api
 pyyaml==6.0.1
     # via pre-commit
-requests==2.31.0
+requests==2.32.3
     # via
     #   cloudsmith-cli (setup.py)
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via cloudsmith-cli (setup.py)
-semver==3.0.1
+semver==3.0.2
     # via cloudsmith-cli (setup.py)
 six==1.16.0
     # via
@@ -117,7 +135,7 @@ typing-extensions==4.7.1
     # via
     #   astroid
     #   pylint
-urllib3==1.26.16
+urllib3==1.26.20
     # via
     #   cloudsmith-api
     #   cloudsmith-cli (setup.py)
@@ -128,6 +146,10 @@ wheel==0.41.1
     # via pip-tools
 wrapt==1.15.0
     # via astroid
+zipp==3.20.2
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
# What changed?

1. Adds the [`keyring`](https://github.com/jaraco/keyring) dependency
2. Adds utility methods to store SSO access & refresh tokens in the system keyring
3. Updates `.envrc` to:
  3.1. install the required python version if missing
  3.2. copy `.env.example` to `.env` if `.env` is missing