### PR TITLE
Get all pages

### DIFF
--- a/cloudsmith_cli/cli/commands/list_.py
+++ b/cloudsmith_cli/cli/commands/list_.py
@@ -174,11 +174,26 @@ def packages(ctx, opts, owner_repo, page, page_size, query):
     click.echo("Getting list of packages ... ", nl=False, err=use_stderr)
 
     context_msg = "Failed to get list of packages!"
-    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
-        with maybe_spinner(opts):
-            packages_, page_info = list_packages(
-                owner=owner, repo=repo, page=page, page_size=page_size, query=query
-            )
+    if page != -1:
+        with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+            with maybe_spinner(opts):
+                packages_, page_info = list_packages(
+                    owner=owner, repo=repo, page=page, page_size=page_size, query=query
+                )
+    else:
+        with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+            with maybe_spinner(opts):
+                packages_ = []
+                page_number = 1
+                page_max = 999999999999  # Infinity... until we get the first page and know the real size
+                while page_number <= page_max:
+                    partial_packages, page_info = list_packages(
+                        owner=owner, repo=repo, page=page_number, page_size=page_size, query=query
+                    )
+                    packages_.extend(partial_packages)
+                    page_number += 1
+                    page_max = page_info.page_total
+                page_info = None
 
     click.secho("OK", fg="green", err=use_stderr)
 

--- a/cloudsmith_cli/cli/commands/repos.py
+++ b/cloudsmith_cli/cli/commands/repos.py
@@ -117,10 +117,24 @@ def get(ctx, opts, owner_repo, page, page_size):
 
     context_msg = "Failed to get list of repositories!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
-        with maybe_spinner(opts):
-            repos_, page_info = api.list_repos(
-                owner=owner, repo=repo, page=page, page_size=page_size
-            )
+        if page != -1:
+            with maybe_spinner(opts):
+                repos_, page_info = api.list_repos(
+                    owner=owner, repo=repo, page=page, page_size=page_size
+                )
+        else:
+            with maybe_spinner(opts):
+                repos_ = []
+                page_number = 1
+                page_max = 999999999999  # Infinity... until we get the first page and know the real size
+                while page_number <= page_max:
+                    partial_repos, page_info = api.list_repos(
+                        owner=owner, repo=repo, page=page_number, page_size=page_size
+                    )
+                    repos_.extend(partial_repos)
+                    page_number += 1
+                    page_max = page_info.page_total
+                page_info = None
 
     click.secho("OK", fg="green", err=use_stderr)
 

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -140,6 +140,8 @@ def validate_owner_repo_distro(ctx, param, value):
 def validate_page(ctx, param, value):
     """Ensure that a valid value for page is chosen."""
     # pylint: disable=unused-argument
+    if value == -1:
+        return value
     if value == 0:
         raise click.BadParameter(
             "Page is not zero-based, please set a value to 1 or higher.", param=param


### PR DESCRIPTION
Fixes https://github.com/cloudsmith-io/cloudsmith-cli/issues/170

This is a work in progress.

This codes enables `ls repos` and `ls pkgs` to get all pages.

I wanted to add a flag `--all-pages` but I couldn't figure out how. I made a couple attempts to add the appropriate click statements but I couldn't get the value to propagate to where it was needed.  I could use some help!

In the meanwhile I added a (brutal but temporarily) way to activate this code.  The (undocumented) `--page -1` enables this feature.

```
$ python3 -m cloudsmith_cli ls pkgs --page-size 3 --page -1  stackoverflow/raw
Getting list of packages ... OK
...
...
[REDACTED]                  | 2023.1.17          | Completed | [REDACTED]/raw/[REDACTED]               

Results: 62 packages visible
```

Could you help me add a proper flag?  Ideally this should be the default, with the `--page x` enabling the old behavior for backwards compatibility.