### PR TITLE
CENG-355: Add `--show-all` flag to display all results from repo/package list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   pip install shiv
+                  pip install cloudsmith-cli
             - name: Get version
               id: get_version
               run: echo "VERSION=$(cat cloudsmith_cli/data/VERSION)" >> $GITHUB_ENV
@@ -43,3 +44,10 @@ jobs:
                   asset_path: ./cloudsmith-${{ env.VERSION }}.pyz
                   asset_name: cloudsmith-${{ env.VERSION }}.pyz
                   asset_content_type: application/zip
+            - name: Rename asses to cloudsmith.pyz
+              run: mv ./cloudsmith-${{ env.VERSION }}.pyz cloudsmith.pyz
+            - name: Upload to Cloudsmith
+              run: cloudsmith push raw ${{ vars.CLOUDSMITH_NAMESPACE }}/${{ vars.CLOUDSMITH_REPO }} cloudsmith.pyz --name "cloudsmith-cli" --version ${{ env.VERSION }}
+              env:
+                  CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+                  VERSION: ${{ env.VERSION }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ For most purposes, you probably just want `pip install -r requirements.txt`.
 
 Our [direnv config](./.envrc) file codifies the development environment setup which we use internally.
 
+Run `pre-commit run -a black` to format the code.
 
 ## Coding Conventions
 

--- a/cloudsmith_cli/cli/commands/list_.py
+++ b/cloudsmith_cli/cli/commands/list_.py
@@ -128,7 +128,7 @@ def entitlements_(*args, **kwargs):  # pylint: disable=missing-docstring
     help=("A boolean-like search term for querying package attributes."),
 )
 @click.pass_context
-def packages(ctx, opts, owner_repo, page, page_size, query):
+def packages(ctx, opts, owner_repo, page, page_size, show_all, query):
     """
     List packages for a repository.
 
@@ -165,20 +165,48 @@ def packages(ctx, opts, owner_repo, page, page_size, query):
 
     --query 'name:^foo$ filename:.zip$ architecture:~x86'
 
+    Options:
+      -p, --page INTEGER     The page of results to show.
+      -l, --page-size INTEGER  The number of results to return per page.
+      --show-all             Show all results by automatically paginating through all pages.
+      -q, --query TEXT       A boolean-like search term for querying package attributes.
     """
     owner, repo = owner_repo
+
+    if show_all:
+        if page is not None or page_size is not None:
+            raise click.UsageError(
+                "--show-all cannot be used with --page or --page-size"
+            )
+    else:
+        if page is None and page_size is None:
+            show_all = True
 
     # Use stderr for messages if the output is something else (e.g.  # JSON)
     use_stderr = opts.output != "pretty"
 
-    click.echo("Getting list of packages ... ", nl=False, err=use_stderr)
+    if show_all:
+        click.echo(
+            f"Retrieving all packages for repository {owner}/{repo}. This may take a while...",
+            err=use_stderr,
+        )
+    else:
+        click.echo("Getting list of packages ... ", nl=False, err=use_stderr)
 
     context_msg = "Failed to get list of packages!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
         with maybe_spinner(opts):
-            packages_, page_info = list_packages(
-                owner=owner, repo=repo, page=page, page_size=page_size, query=query
-            )
+            if show_all:
+                packages_, page_info = utils.get_all_pages(
+                    list_packages,
+                    owner=owner,
+                    repo=repo,
+                    query=query,
+                )
+            else:
+                packages_, page_info = list_packages(
+                    owner=owner, repo=repo, page=page, page_size=page_size, query=query
+                )
 
     click.secho("OK", fg="green", err=use_stderr)
 
@@ -211,7 +239,10 @@ def packages(ctx, opts, owner_repo, page, page_size, query):
     num_results = len(packages_)
     list_suffix = "package%s visible" % ("s" if num_results != 1 else "")
     utils.pretty_print_list_info(
-        num_results=num_results, page_info=page_info, suffix=list_suffix
+        num_results=num_results,
+        page_info=page_info,
+        suffix=list_suffix,
+        show_all=show_all,
     )
 
 
@@ -229,7 +260,7 @@ def packages(ctx, opts, owner_repo, page, page_size, query):
     required=False,
 )
 @click.pass_context
-def repos(ctx, opts, owner_repo, page, page_size):
+def repos(ctx, opts, owner_repo, page, page_size, show_all):
     """
     List repositories for a namespace (owner).
 

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -142,31 +142,33 @@ def common_cli_output_options(f):
 
 
 def common_cli_list_options(f):
-    """Add common list options to commands."""
+    """Add common options for list commands."""
 
     @click.option(
         "-p",
         "--page",
         default=1,
-        type=int,
-        help="The page to view for lists, where 1 is the first page",
+        help="The page of results to show.",
+        type=click.INT,
         callback=validators.validate_page,
     )
     @click.option(
         "-l",
         "--page-size",
-        default=30,
-        type=int,
-        help="The amount of items to view per page for lists.",
+        default=None,
+        help="The number of results to return per page.",
+        type=click.INT,
         callback=validators.validate_page_size,
     )
-    @click.pass_context
+    @click.option(
+        "--show-all",
+        is_flag=True,
+        default=False,
+        help="Show all results by automatically paginating through all pages.",
+    )
     @functools.wraps(f)
-    def wrapper(ctx, *args, **kwargs):
-        # pylint: disable=missing-docstring
-        opts = config.get_or_create_options(ctx)
-        kwargs["opts"] = opts
-        return ctx.invoke(f, *args, **kwargs)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
Add all pages from https://github.com/cloudsmith-io/cloudsmith-cli/pull/171 and address issue https://github.com/cloudsmith-io/cloudsmith-cli/issues/170. 

Example for all packages:

```
> python3 -m cloudsmith_cli ls packages bart-demo-org/dockerland --show-all
Retrieving all packages for repository bart-demo-org/dockerland. This may take a while...

....

Results: 90 of 90 packages visible (all pages)
```

Example for all repos:

```
> python3 -m cloudsmith_cli ls repos bart-demo-org --show-all
Retrieving all repositories for bart-demo-org. This may take a while...

...
Results: 80 of 80 repositories visible (all pages)
```

* Include code from https://github.com/cloudsmith-io/cloudsmith-cli/pull/168 to upload zipapp to Cloudsmith repo
* Added black formatting step to Contribution docs