### PR TITLE
Add support for SAML authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please see the [changelog](https://github.com/cloudsmith-io/cloudsmith-cli/blob/
 
 The CLI currently supports the following commands (and sub-commands):
 
+- `auth`:                 Authenticate the CLI against an organization's SAML configuration.
 - `check`:                Check rate limits and service status.
 - `copy`|`cp`:            Copy a package to another repository.
 - `delete`|`rm`:          Delete a package from a repository.
@@ -169,11 +170,26 @@ You can specify the following configuration options:
 - `api_key`: The API key for authenticating with the API.
 
 
-### Getting Your API Key
+### Authenticating
 
 You'll need to provide authentication to Cloudsmith for any CLI actions that result in accessing private data or making changes to resources (such as pushing a new package to a repository)..
 
-With the CLI this is simple to do. You can retrieve your API key using the `cloudsmith login` command:
+#### SAML authentication
+
+You can authenticate using your organization's SAML provider, if configured, with the `cloudsmith auth` command:
+```
+cloudsmith auth --owner example
+Beginning authentication for the example org ...
+Opening your organization's SAML IDP URL in your browser: https://example.com/some-saml-idp
+
+Starting webserver to begin authentication ...
+
+Authentication complete
+```
+
+#### Getting Your API Key
+
+You can retrieve your API key using the `cloudsmith login` command:
 
 ```
 cloudsmith login

--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -1,6 +1,7 @@
 """CLI/Commands - Import all commands."""
 
 from . import (
+    auth,
     check,
     copy,
     delete,

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -37,7 +37,7 @@ def authenticate(ctx, opts, owner):
     )
     org_saml_url += urlencode({"redirect_url": "http://localhost:12400"})
 
-    org_saml_response = requests.get(org_saml_url, timeout=5)
+    org_saml_response = requests.get(org_saml_url, timeout=30)
     idp_url = org_saml_response.json().get("redirect_url")
 
     click.echo(
@@ -55,5 +55,7 @@ def authenticate(ctx, opts, owner):
     )
     auth_server.handle_request()
 
+    click.echo()
     click.echo(f"Access token: {get_access_token()}")
+    click.echo()
     click.echo(f"Refresh token: {get_refresh_token()}")

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -26,7 +26,6 @@ from .main import main
 @click.pass_context
 def authenticate(ctx, opts, owner):
     """Authenticate to Cloudsmith using the org's SAML setup."""
-    # TODO: Why is a single arg a list?
     owner = owner[0]
 
     click.echo(

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -47,7 +47,7 @@ def authenticate(ctx, opts, owner):
         click.echo("Starting webserver to begin authentication ... ")
 
         auth_server = AuthenticationWebServer(
-            ("0.0.0.0", 12400),
+            ("127.0.0.1", 12400),
             AuthenticationWebRequestHandler,
             api_host=api_host,
             owner=owner,

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -27,6 +27,7 @@ from .main import main
 def authenticate(ctx, opts, owner):
     """Authenticate to Cloudsmith using the org's SAML setup."""
     owner = owner[0]
+    api_host = opts.api_config.host
 
     click.echo(
         "Beginning authentication for the {owner} org ... ".format(
@@ -36,7 +37,7 @@ def authenticate(ctx, opts, owner):
 
     context_message = "Failed to authenticate via SSO!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_message):
-        idp_url = get_idp_url(opts.api_host, owner)
+        idp_url = get_idp_url(api_host, owner)
         click.echo(
             "Opening your organization's SAML IDP URL in your browser: %(idp_url)s"
             % {"idp_url": click.style(idp_url, bold=True)}
@@ -48,7 +49,7 @@ def authenticate(ctx, opts, owner):
         auth_server = AuthenticationWebServer(
             ("0.0.0.0", 12400),
             AuthenticationWebRequestHandler,
-            api_host=opts.api_host,
+            api_host=api_host,
             owner=owner,
         )
         auth_server.handle_request()

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -1,0 +1,59 @@
+"""CLI/Commands - Authenticate the user."""
+import webbrowser
+from urllib.parse import urlencode
+
+import click
+import requests
+
+from ...core.keyring import get_access_token, get_refresh_token
+from .. import decorators, validators
+from ..webserver import AuthenticationWebRequestHandler, AuthenticationWebServer
+from .main import main
+
+
+@main.command(aliases=["auth"])
+@click.option(
+    "-o",
+    "--owner",
+    metavar="OWNER",
+    required=True,
+    callback=validators.validate_owner,
+    prompt=True,
+    help="The name of the Cloudsmith organization to authenticate with.",
+)
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.initialise_api
+@click.pass_context
+def authenticate(ctx, opts, owner):
+    """Authenticate to Cloudsmith using the org's SAML setup."""
+    # TODO: Why is a single arg a list?
+    owner = owner[0]
+
+    # TODO: best way to consistently get API host?
+    org_saml_url = "{api_host}/orgs/{owner}/saml/?".format(
+        api_host=opts.api_config.host,
+        owner=owner,
+    )
+    org_saml_url += urlencode({"redirect_url": "http://localhost:12400"})
+
+    org_saml_response = requests.get(org_saml_url, timeout=5)
+    idp_url = org_saml_response.json().get("redirect_url")
+
+    click.echo(
+        "Opening your organization's SAML IDP URL in your browser: %(idp_url)s"
+        % {"idp_url": idp_url}
+    )
+    webbrowser.open(idp_url)
+    click.echo("Starting webserver to begin authentication ... ")
+
+    auth_server = AuthenticationWebServer(
+        ("0.0.0.0", 12400),
+        AuthenticationWebRequestHandler,
+        api_host=opts.api_config.host,
+        owner=owner,
+    )
+    auth_server.handle_request()
+
+    click.echo(f"Access token: {get_access_token()}")
+    click.echo(f"Refresh token: {get_refresh_token()}")

--- a/cloudsmith_cli/cli/commands/login.py
+++ b/cloudsmith_cli/cli/commands/login.py
@@ -1,11 +1,9 @@
 """CLI/Commands - Get an API token."""
 
 import collections
-import getpass
 import stat
 
 import click
-import keyring
 
 from ...core.api.user import get_user_token
 from ...core.utils import get_help_website
@@ -101,30 +99,6 @@ def create_config_files(ctx, opts, api_key):
         click.secho("EXISTS" if config.present else "NOT CREATED", fg="yellow")
 
     return create, has_errors
-
-
-def get_username():
-    return getpass.getuser()
-
-
-def store_access_token(access_token):
-    username = get_username()
-    keyring.set_password("cloudsmith_cli-access_token", username, access_token)
-
-
-def get_access_token():
-    username = get_username()
-    return keyring.get_password("cloudsmith_cli-access_token", username)
-
-
-def store_refresh_token(refresh_token):
-    username = get_username()
-    keyring.set_password("cloudsmith_cli-refresh_token", username, refresh_token)
-
-
-def get_refresh_token():
-    username = get_username()
-    return keyring.get_password("cloudsmith_cli-refresh_token", username)
 
 
 @main.command(aliases=["token"])

--- a/cloudsmith_cli/cli/exceptions.py
+++ b/cloudsmith_cli/cli/exceptions.py
@@ -146,9 +146,9 @@ def get_401_error_hint(ctx, opts, exc):
         )
 
     return (
-        "You don't have an API key set, but it seems this action "
+        "You don't have an API key or access token set, but it seems this action "
         "requires authentication - Try getting your API key via "
-        "'cloudsmith token' first then try again."
+        "'cloudsmith token', or access token via 'cloudsmith auth', then try again."
     )
 
 

--- a/cloudsmith_cli/cli/exceptions.py
+++ b/cloudsmith_cli/cli/exceptions.py
@@ -7,6 +7,7 @@ import sys
 import click
 
 from ..core.api.exceptions import ApiException
+from ..core.keyring import get_access_token
 
 
 @contextlib.contextmanager
@@ -131,6 +132,10 @@ def get_401_error_hint(ctx, opts, exc):
             "Since you have an API key set, this probably means "
             "you don't have the permission to perform this action."
         )
+
+    access_token = get_access_token(opts.api_host)
+    if access_token:
+        return "Since you have an SSO access token set, this probably means that it has expired. Try getting a new token with 'cloudsmith auth', then try again."
 
     if ctx.info_name == "token":
         # This is already the token command

--- a/cloudsmith_cli/cli/saml.py
+++ b/cloudsmith_cli/cli/saml.py
@@ -1,0 +1,86 @@
+from urllib.parse import urlencode
+
+import requests
+
+from ..core.api.exceptions import ApiException
+
+
+def get_idp_url(api_host, owner):
+    org_saml_url = "{api_host}/orgs/{owner}/saml/?{params}".format(
+        api_host=api_host,
+        owner=owner,
+        params=urlencode({"redirect_url": "http://localhost:12400"}),
+    )
+
+    org_saml_response = requests.get(org_saml_url, timeout=30)
+
+    try:
+        org_saml_response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ApiException(
+            org_saml_response.status_code,
+            headers=exc.response.headers,
+            body=exc.response.content,
+        )
+
+    return org_saml_response.json().get("redirect_url")
+
+
+def exchange_2fa_token(api_host, two_factor_token, totp_token):
+    exchange_data = {"two_factor_token": two_factor_token, "totp_token": totp_token}
+    exchange_url = "{api_host}/user/two-factor/".format(api_host=api_host)
+
+    exchange_response = requests.post(
+        exchange_url,
+        data=exchange_data,
+        headers={
+            "Authorization": "Bearer {two_factor_token}".format(
+                two_factor_token=two_factor_token
+            )
+        },
+        timeout=30,
+    )
+
+    try:
+        exchange_response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ApiException(
+            exchange_response.status_code,
+            headers=exc.response.headers,
+            body=exc.response.content,
+        )
+
+    exchange_data = exchange_response.json()
+    access_token = exchange_data.get("access_token")
+    refresh_token = exchange_data.get("refresh_token")
+
+    return (access_token, refresh_token)
+
+
+def refresh_access_token(api_host, access_token, refresh_token):
+    data = {"refresh_token": refresh_token}
+    url = "{api_host}/user/refresh-token/".format(api_host=api_host)
+
+    response = requests.post(
+        url,
+        data=data,
+        headers={
+            "Authorization": "Bearer {access_token}".format(access_token=access_token)
+        },
+        timeout=30,
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ApiException(
+            response.status_code,
+            headers=exc.response.headers,
+            body=exc.response.content,
+        )
+
+    response_data = response.json()
+    access_token = response_data.get("access_token")
+    refresh_token = response_data.get("refresh_token")
+
+    return (access_token, refresh_token)

--- a/cloudsmith_cli/cli/tests/test_saml.py
+++ b/cloudsmith_cli/cli/tests/test_saml.py
@@ -1,0 +1,151 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from ...core.api.exceptions import ApiException
+from ..saml import exchange_2fa_token, get_idp_url, refresh_access_token
+
+
+@pytest.fixture
+def mock_get_request():
+    with patch.object(requests, "get") as mock_get:
+        yield mock_get
+
+
+@pytest.fixture
+def mock_post_request():
+    with patch.object(requests, "post") as mock_post:
+        yield mock_post
+
+
+@pytest.fixture
+def mock_response():
+    with patch("requests.Response", autospec=True) as MockResponse:
+        yield MockResponse.return_value
+
+
+class TestSaml:
+    api_host = "https://example.com"
+
+    # urlencoded params {"redirect_url": "http://localhost:12400"}
+    query_params = "redirect_url=http%3A%2F%2Flocalhost%3A12400"
+
+    def test_get_idp_url(self, mock_get_request, mock_response):
+        mock_get_request.return_value = mock_response
+        mock_response.json.return_value = {"redirect_url": "response_redirect_url"}
+
+        assert get_idp_url(self.api_host, "test_org") == "response_redirect_url"
+        mock_get_request.assert_called_once_with(
+            f"{self.api_host}/orgs/test_org/saml/?{self.query_params}", timeout=30
+        )
+
+    def test_get_idp_url_with_request_error(self, mock_get_request, mock_response):
+        mock_get_request.return_value = mock_response
+        mock_response.status_code = 500
+        mock_response.headers = {"foo": "bar"}
+        mock_response.content = "Error body"
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "An error occurred", response=mock_response
+        )
+
+        with pytest.raises(ApiException) as exc:
+            get_idp_url(self.api_host, "test_org")
+
+            assert exc == ApiException(
+                status=500, headers={"foo": "bar"}, body="Error body"
+            )
+            mock_get_request.assert_called_once_with(
+                f"{self.api_host}/orgs/test_org/saml/?{self.query_params}", timeout=30
+            )
+
+    def test_exchange_2fa_token(self, mock_post_request, mock_response):
+        mock_post_request.return_value = mock_response
+        mock_response.json.return_value = {
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+
+        assert exchange_2fa_token(self.api_host, "two_factor_token", "totp_token") == (
+            "access_token",
+            "refresh_token",
+        )
+        mock_post_request.assert_called_once_with(
+            f"{self.api_host}/user/two-factor/",
+            data={"two_factor_token": "two_factor_token", "totp_token": "totp_token"},
+            headers={"Authorization": "Bearer two_factor_token"},
+            timeout=30,
+        )
+
+    def test_exchange_2fa_token_with_request_error(
+        self, mock_post_request, mock_response
+    ):
+        mock_post_request.return_value = mock_response
+        mock_response.status_code = 500
+        mock_response.headers = {"foo": "bar"}
+        mock_response.content = "Error body"
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "An error occurred", response=mock_response
+        )
+
+        with pytest.raises(ApiException) as exc:
+            exchange_2fa_token(self.api_host, "two_factor_token", "totp_token")
+
+            assert exc == ApiException(
+                status=500, headers={"foo": "bar"}, body="Error body"
+            )
+            mock_post_request.assert_called_once_with(
+                f"{self.api_host}/user/two-factor/",
+                data={
+                    "two_factor_token": "two_factor_token",
+                    "totp_token": "totp_token",
+                },
+                headers={"Authorization": "Bearer two_factor_token"},
+                timeout=30,
+            )
+
+    def test_refresh_access_token(self, mock_post_request, mock_response):
+        mock_post_request.return_value = mock_response
+        mock_response.json.return_value = {
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+
+        assert refresh_access_token(self.api_host, "access_token", "refresh_token") == (
+            "access_token",
+            "refresh_token",
+        )
+        mock_post_request.assert_called_once_with(
+            f"{self.api_host}/user/refresh-token/",
+            data={"refresh_token": "refresh_token"},
+            headers={"Authorization": "Bearer access_token"},
+            timeout=30,
+        )
+
+    def test_refresh_access_token_with_request_error(
+        self, mock_post_request, mock_response
+    ):
+        mock_post_request.return_value = mock_response
+        mock_response.status_code = 500
+        mock_response.headers = {"foo": "bar"}
+        mock_response.content = "Error body"
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "An error occurred", response=mock_response
+        )
+        mock_response.json.return_value = {
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+
+        with pytest.raises(ApiException) as exc:
+            exchange_2fa_token(self.api_host, "two_factor_token", "totp_token")
+
+            assert exc == ApiException(
+                status=500, headers={"foo": "bar"}, body="Error body"
+            )
+            mock_post_request.assert_called_once_with(
+                f"{self.api_host}/user/refresh-token/",
+                data={"refresh_token": "refresh_token"},
+                headers={"Authorization": "Bearer access_token"},
+                timeout=30,
+            )

--- a/cloudsmith_cli/cli/utils.py
+++ b/cloudsmith_cli/cli/utils.py
@@ -1,5 +1,4 @@
 """CLI - Utilities."""
-
 import json
 import platform
 from contextlib import contextmanager

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -56,7 +56,12 @@ class AuthenticationWebRequestHandler(BaseHTTPRequestHandler):
         exchange_data = {"two_factor_token": two_factor_token, "totp_token": totp_token}
         exchange_url = "{api_host}/user/two-factor/".format(api_host=self.api_host)
 
-        exchange_response = requests.post(exchange_url, data=exchange_data, timeout=5)
+        exchange_response = requests.post(
+            exchange_url,
+            data=exchange_data,
+            headers={"Authorization": f"Bearer {two_factor_token}"},
+            timeout=30,
+        )
 
         exchange_data = exchange_response.json()
         access_token = exchange_data.get("access_token")

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -41,11 +41,10 @@ class AuthenticationWebServer(HTTPServer):
         if self.verify_request(request, client_address):
             try:
                 self.process_request(request, client_address)
-            except ApiException as exc:
-                self.handle_error(request, client_address)
-                self.exception = exc
-                self.shutdown_request(request)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
+            except (  # pylint: disable=broad-exception-caught
+                Exception,
+                ApiException,
+            ) as exc:
                 self.handle_error(request, client_address)
                 self.exception = exc
                 self.shutdown_request(request)

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -49,12 +49,13 @@ class AuthenticationWebRequestHandler(BaseHTTPRequestHandler):
         )
 
     def _exchange_2fa_token(self, two_factor_token):
-        totp_token = click.prompt("Please enter your 2FA token", type=str)
+        totp_token = click.prompt(
+            "Please enter your 2FA token", hide_input=True, type=str
+        )
 
         exchange_data = {"two_factor_token": two_factor_token, "totp_token": totp_token}
         exchange_url = "{api_host}/user/two-factor/".format(api_host=self.api_host)
 
-        click.echo(f"Exchanging 2FA token with request to {exchange_url}")
         exchange_response = requests.post(exchange_url, data=exchange_data, timeout=5)
 
         exchange_data = exchange_response.json()

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -1,0 +1,101 @@
+import json
+from functools import cached_property
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qsl, urlparse
+
+import click
+import requests
+
+from ..core.keyring import store_sso_tokens
+
+
+class AuthenticationWebServer(HTTPServer):
+    def __init__(
+        self, server_address, RequestHandlerClass, bind_and_activate=True, **kwargs
+    ):
+        self.api_host = kwargs.get("api_host")
+        self.owner = kwargs.get("owner")
+
+        super().__init__(
+            server_address, RequestHandlerClass, bind_and_activate=bind_and_activate
+        )
+
+    def finish_request(self, request, client_address):
+        self.RequestHandlerClass(
+            request, client_address, self, api_host=self.api_host, owner=self.owner
+        )
+
+
+class AuthenticationWebRequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, request, client_address, server, **kwargs):
+        self.api_host = kwargs.get("api_host")
+        self.owner = kwargs.get("owner")
+
+        super().__init__(request, client_address, server)
+
+    @cached_property
+    def url(self):
+        return urlparse(self.path)
+
+    @cached_property
+    def query_data(self):
+        return dict(parse_qsl(self.url.query))
+
+    def get_response(self):
+        return json.dumps(
+            {
+                "query_data": self.query_data,
+            }
+        )
+
+    def _exchange_2fa_token(self, two_factor_token):
+        totp_token = click.prompt("Please enter your 2FA token", type=str)
+
+        exchange_data = {"two_factor_token": two_factor_token, "totp_token": totp_token}
+        exchange_url = "{api_host}/user/two-factor/".format(api_host=self.api_host)
+
+        click.echo(f"Exchanging 2FA token with request to {exchange_url}")
+        exchange_response = requests.post(exchange_url, data=exchange_data, timeout=5)
+
+        exchange_data = exchange_response.json()
+        access_token = exchange_data.get("access_token")
+        refresh_token = exchange_data.get("refresh_token")
+
+        return (access_token, refresh_token)
+
+    def _return_response(self, message=None):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+
+        if not message:
+            message = self.get_response()
+
+        self.wfile.write(message.encode("utf-8"))
+
+    def _return_success_response(self):
+        self._return_response()
+
+    def _return_error_response(self):
+        self._return_response()
+
+    def do_GET(self):
+        access_token = self.query_data.get("access_token")
+        refresh_token = self.query_data.get("refresh_token")
+        two_factor_token = self.query_data.get("two_factor_token")
+
+        if access_token:
+            store_sso_tokens(access_token, refresh_token)
+
+            self._return_success_response()
+            return
+
+        if two_factor_token:
+            access_token, refresh_token = self._exchange_2fa_token(two_factor_token)
+            store_sso_tokens(access_token, refresh_token)
+
+            self._return_success_response()
+            return
+
+        self._return_error_response()
+        return

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -49,7 +49,7 @@ def initialise_api(
             config.username, config.password = values.split(":")
 
     access_token = get_access_token()
-    if access_token:
+    if headers and access_token:
         config.headers["Authorization"] = "Bearer {access_token}".format(
             access_token=access_token
         )

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -3,10 +3,13 @@
 import base64
 from typing import Type, TypeVar
 
+import click
 import cloudsmith_api
 
-from ..keyring import get_access_token
+from ...cli import saml
+from .. import keyring
 from ..rest import RestClient
+from .exceptions import ApiException
 
 
 def initialise_api(
@@ -31,7 +34,7 @@ def initialise_api(
     config.host = host if host else config.host
     config.proxy = proxy if proxy else config.proxy
     config.user_agent = user_agent
-    config.headers = headers
+    config.headers = headers if headers else {}
     config.rate_limit = rate_limit
     config.rate_limit_callback = rate_limit_callback
     config.error_retry_max = error_retry_max
@@ -41,20 +44,51 @@ def initialise_api(
     config.verify_ssl = ssl_verify
     config.client_side_validation = False
 
-    if headers:
-        if "Authorization" in config.headers:
-            encoded = config.headers["Authorization"].split(" ")[1]
-            decoded = base64.b64decode(encoded)
-            values = decoded.decode("utf-8")
-            config.username, config.password = values.split(":")
-
-    access_token = get_access_token(config.host)
+    access_token = keyring.get_access_token(config.host)
     if access_token:
-        config.api_key["Authorization"] = "Bearer {access_token}".format(
-            access_token=access_token
-        )
+        auth_header = config.headers.get("Authorization")
+
+        # overwrite auth header if empty or is basic auth without username or password
+        if not auth_header or auth_header == config.get_basic_auth_token():
+            refresh_token = keyring.get_refresh_token(config.host)
+
+            try:
+                if keyring.should_refresh_access_token(config.host):
+                    new_access_token, new_refresh_token = saml.refresh_access_token(
+                        config.host, access_token, refresh_token
+                    )
+                    keyring.store_sso_tokens(
+                        config.host, new_access_token, new_refresh_token
+                    )
+            except ApiException:
+                keyring.update_refresh_attempted_at(config.host)
+
+                # try falling back to API key auth if refresh fails
+                if key:
+                    config.api_key["X-Api-Key"] = key
+
+            config.headers["Authorization"] = "Bearer {access_token}".format(
+                access_token=access_token
+            )
+
+            if config.debug:
+                click.echo("SSO access token config value set")
     elif key:
         config.api_key["X-Api-Key"] = key
+
+        if config.debug:
+            click.echo("User API key config value set")
+
+    if headers:
+        if "Authorization" in config.headers:
+            auth_type, encoded = config.headers["Authorization"].split(" ")
+            if auth_type == "Basic":
+                decoded = base64.b64decode(encoded)
+                values = decoded.decode("utf-8")
+                config.username, config.password = values.split(":")
+
+                if config.debug:
+                    click.echo("Username and password config values set")
 
     # Important! Some of the attributes set above (e.g. error_retry_max) are not
     # present in the cloudsmith_api.Configuration class declaration.

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -48,13 +48,12 @@ def initialise_api(
             values = decoded.decode("utf-8")
             config.username, config.password = values.split(":")
 
-    access_token = get_access_token()
-    if headers and access_token:
-        config.headers["Authorization"] = "Bearer {access_token}".format(
+    access_token = get_access_token(config.host)
+    if access_token:
+        config.api_key["Authorization"] = "Bearer {access_token}".format(
             access_token=access_token
         )
-
-    if key:
+    elif key:
         config.api_key["X-Api-Key"] = key
 
     # Important! Some of the attributes set above (e.g. error_retry_max) are not

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -5,6 +5,7 @@ from typing import Type, TypeVar
 
 import cloudsmith_api
 
+from ..keyring import get_access_token
 from ..rest import RestClient
 
 
@@ -46,6 +47,12 @@ def initialise_api(
             decoded = base64.b64decode(encoded)
             values = decoded.decode("utf-8")
             config.username, config.password = values.split(":")
+
+    access_token = get_access_token()
+    if access_token:
+        config.headers["Authorization"] = "Bearer {access_token}".format(
+            access_token=access_token
+        )
 
     if key:
         config.api_key["X-Api-Key"] = key

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -63,6 +63,11 @@ def initialise_api(
             except ApiException:
                 keyring.update_refresh_attempted_at(config.host)
 
+                click.secho(
+                    "An error occurred when attempting to refresh your SSO access token. To refresh this session, run 'cloudsmith auth'",
+                    fg="yellow",
+                )
+
                 # try falling back to API key auth if refresh fails
                 if key:
                     config.api_key["X-Api-Key"] = key

--- a/cloudsmith_cli/core/keyring.py
+++ b/cloudsmith_cli/core/keyring.py
@@ -1,10 +1,12 @@
 import getpass
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import keyring
 
 ACCESS_TOKEN_KEY = "cloudsmith_cli-access_token-{api_host}"
-ACCESS_TOKEN_REFRESHED_AT_KEY = "cloudsmith_cli-access_token_refreshed_at-{api_host}"
+ACCESS_TOKEN_REFRESH_ATTEMPTED_AT_KEY = (
+    "cloudsmith_cli-access_token_refresh_attempted_at-{api_host}"
+)
 REFRESH_TOKEN_KEY = "cloudsmith_cli-refresh_token-{api_host}"
 
 
@@ -24,21 +26,35 @@ def get_access_token(api_host):
     return keyring.get_password(key, username)
 
 
-def store_access_token_refreshed_at(api_host, refresh_time=None):
+def update_refresh_attempted_at(api_host, refresh_time=None):
     if refresh_time is None:
         refresh_time = datetime.utcnow()
 
-    refreshed_at_value = refresh_time.isoformat()
+    refresh_attempted_at_value = refresh_time.isoformat()
 
     username = _get_username()
-    key = ACCESS_TOKEN_REFRESHED_AT_KEY.format(api_host=api_host)
-    keyring.set_password(key, username, refreshed_at_value)
+    key = ACCESS_TOKEN_REFRESH_ATTEMPTED_AT_KEY.format(api_host=api_host)
+    keyring.set_password(key, username, refresh_attempted_at_value)
 
 
-def get_access_token_refreshed_at(api_host):
+def get_refresh_attempted_at(api_host):
     username = _get_username()
-    key = ACCESS_TOKEN_REFRESHED_AT_KEY.format(api_host=api_host)
-    return keyring.get_password(key, username)
+    key = ACCESS_TOKEN_REFRESH_ATTEMPTED_AT_KEY.format(api_host=api_host)
+    value = keyring.get_password(key, username)
+
+    if value:
+        return datetime.fromisoformat(value)
+
+    return None
+
+
+def should_refresh_access_token(api_host):
+    token_refreshed_at = get_refresh_attempted_at(api_host)
+
+    if token_refreshed_at:
+        return token_refreshed_at < (datetime.utcnow() - timedelta(minutes=30))
+
+    return True
 
 
 def store_refresh_token(api_host, refresh_token):
@@ -56,7 +72,7 @@ def get_refresh_token(api_host):
 def store_sso_tokens(api_host, access_token, refresh_token):
     if access_token:
         store_access_token(api_host=api_host, access_token=access_token)
-        store_access_token_refreshed_at(api_host=api_host)
+        update_refresh_attempted_at(api_host=api_host)
 
     if refresh_token:
         store_refresh_token(api_host=api_host, refresh_token=refresh_token)

--- a/cloudsmith_cli/core/keyring.py
+++ b/cloudsmith_cli/core/keyring.py
@@ -1,0 +1,35 @@
+import getpass
+
+import keyring
+
+
+def get_username():
+    return getpass.getuser()
+
+
+def store_access_token(access_token):
+    username = get_username()
+    keyring.set_password("cloudsmith_cli-access_token", username, access_token)
+
+
+def get_access_token():
+    username = get_username()
+    return keyring.get_password("cloudsmith_cli-access_token", username)
+
+
+def store_refresh_token(refresh_token):
+    username = get_username()
+    keyring.set_password("cloudsmith_cli-refresh_token", username, refresh_token)
+
+
+def get_refresh_token():
+    username = get_username()
+    return keyring.get_password("cloudsmith_cli-refresh_token", username)
+
+
+def store_sso_tokens(access_token, refresh_token):
+    if access_token:
+        store_access_token(access_token)
+
+    if refresh_token:
+        store_refresh_token(refresh_token)

--- a/cloudsmith_cli/core/keyring.py
+++ b/cloudsmith_cli/core/keyring.py
@@ -1,35 +1,62 @@
 import getpass
+from datetime import datetime
 
 import keyring
 
+ACCESS_TOKEN_KEY = "cloudsmith_cli-access_token-{api_host}"
+ACCESS_TOKEN_REFRESHED_AT_KEY = "cloudsmith_cli-access_token_refreshed_at-{api_host}"
+REFRESH_TOKEN_KEY = "cloudsmith_cli-refresh_token-{api_host}"
 
-def get_username():
+
+def _get_username():
     return getpass.getuser()
 
 
-def store_access_token(access_token):
-    username = get_username()
-    keyring.set_password("cloudsmith_cli-access_token", username, access_token)
+def store_access_token(api_host, access_token):
+    username = _get_username()
+    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
+    keyring.set_password(key, username, access_token)
 
 
-def get_access_token():
-    username = get_username()
-    return keyring.get_password("cloudsmith_cli-access_token", username)
+def get_access_token(api_host):
+    username = _get_username()
+    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
+    return keyring.get_password(key, username)
 
 
-def store_refresh_token(refresh_token):
-    username = get_username()
-    keyring.set_password("cloudsmith_cli-refresh_token", username, refresh_token)
+def store_access_token_refreshed_at(api_host, refresh_time=None):
+    if refresh_time is None:
+        refresh_time = datetime.utcnow()
+
+    refreshed_at_value = refresh_time.isoformat()
+
+    username = _get_username()
+    key = ACCESS_TOKEN_REFRESHED_AT_KEY.format(api_host=api_host)
+    keyring.set_password(key, username, refreshed_at_value)
 
 
-def get_refresh_token():
-    username = get_username()
-    return keyring.get_password("cloudsmith_cli-refresh_token", username)
+def get_access_token_refreshed_at(api_host):
+    username = _get_username()
+    key = ACCESS_TOKEN_REFRESHED_AT_KEY.format(api_host=api_host)
+    return keyring.get_password(key, username)
 
 
-def store_sso_tokens(access_token, refresh_token):
+def store_refresh_token(api_host, refresh_token):
+    username = _get_username()
+    key = REFRESH_TOKEN_KEY.format(api_host=api_host)
+    keyring.set_password(key, username, refresh_token)
+
+
+def get_refresh_token(api_host):
+    username = _get_username()
+    key = REFRESH_TOKEN_KEY.format(api_host=api_host)
+    return keyring.get_password(key, username)
+
+
+def store_sso_tokens(api_host, access_token, refresh_token):
     if access_token:
-        store_access_token(access_token)
+        store_access_token(api_host=api_host, access_token=access_token)
+        store_access_token_refreshed_at(api_host=api_host)
 
     if refresh_token:
-        store_refresh_token(refresh_token)
+        store_refresh_token(api_host=api_host, refresh_token=refresh_token)

--- a/cloudsmith_cli/core/keyring.py
+++ b/cloudsmith_cli/core/keyring.py
@@ -15,20 +15,27 @@ def _get_username():
     return getpass.getuser()
 
 
-def store_access_token(api_host, access_token):
+def _get_value(key):
     username = _get_username()
-    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
-    keyring.set_password(key, username, access_token)
-
-
-def get_access_token(api_host):
-    username = _get_username()
-    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
-
     try:
         return keyring.get_password(key, username)
     except KeyringError:
         return None
+
+
+def _set_value(key, value):
+    username = _get_username()
+    keyring.set_password(key, username, value)
+
+
+def store_access_token(api_host, access_token):
+    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
+    _set_value(key, access_token)
+
+
+def get_access_token(api_host):
+    key = ACCESS_TOKEN_KEY.format(api_host=api_host)
+    return _get_value(key)
 
 
 def update_refresh_attempted_at(api_host, refresh_time=None):
@@ -37,18 +44,15 @@ def update_refresh_attempted_at(api_host, refresh_time=None):
 
     refresh_attempted_at_value = refresh_time.isoformat()
 
-    username = _get_username()
     key = ACCESS_TOKEN_REFRESH_ATTEMPTED_AT_KEY.format(api_host=api_host)
-    keyring.set_password(key, username, refresh_attempted_at_value)
+    _set_value(key, refresh_attempted_at_value)
 
 
 def get_refresh_attempted_at(api_host):
-    username = _get_username()
     key = ACCESS_TOKEN_REFRESH_ATTEMPTED_AT_KEY.format(api_host=api_host)
+    value = _get_value(key)
 
-    try:
-        value = keyring.get_password(key, username)
-    except KeyringError:
+    if not value:
         return None
 
     try:
@@ -67,15 +71,13 @@ def should_refresh_access_token(api_host):
 
 
 def store_refresh_token(api_host, refresh_token):
-    username = _get_username()
     key = REFRESH_TOKEN_KEY.format(api_host=api_host)
-    keyring.set_password(key, username, refresh_token)
+    _set_value(key, refresh_token)
 
 
 def get_refresh_token(api_host):
-    username = _get_username()
     key = REFRESH_TOKEN_KEY.format(api_host=api_host)
-    return keyring.get_password(key, username)
+    return _get_value(key)
 
 
 def store_sso_tokens(api_host, access_token, refresh_token):

--- a/cloudsmith_cli/core/tests/test_init.py
+++ b/cloudsmith_cli/core/tests/test_init.py
@@ -1,63 +1,186 @@
+from unittest.mock import patch
+
+import pytest
 from cloudsmith_api import Configuration
 
+from ...cli import saml
+from .. import keyring
 from ..api.init import initialise_api
 
 
-def test_initialise_api_sets_cloudsmith_api_config_default():
-    """Assert that the extra attributes we add to the cloudsmith_cli.Configuration class
-    are present on newly-created instances of that class.
-    """
+@pytest.fixture
+def mocked_get_access_token():
+    with patch.object(
+        keyring, "get_access_token", return_value="dummy_access_token"
+    ) as get_access_token_mock:
+        yield get_access_token_mock
 
-    # Read and understand the Configuration class's initialiser.
-    # Notice how the _default class attribute is used if not None.
-    # https://github.com/cloudsmith-io/cloudsmith-api/blob/57963fff5b7818783b3d87246495275545d505df/bindings/python/src/cloudsmith_api/configuration.py#L32-L40
 
-    # There are a number of attributes which we automagically add to instances of
-    # cloudsmith_api.Configuration().
-    extra_config_attrs = [
-        "rate_limit",
-        "error_retry_max",
-        "error_retry_backoff",
-        "error_retry_codes",
-        "error_retry_cb",
-    ]
+@pytest.fixture
+def mocked_get_refresh_token():
+    with patch.object(
+        keyring, "get_refresh_token", return_value="dummy_refresh_token"
+    ) as get_refresh_token_mock:
+        yield get_refresh_token_mock
 
-    # We do that in our initialise_api() function by
-    # (i) creating a new instance of Configuration and adding attributes/values to it.
-    # (ii) calling the cloudsmith_api.Configuration.set_default(config) classmethod.
 
-    # For the purposes of this test, we need to explcitly call set_default(None) at the
-    # outset because other tests in the suite may have called initialise_api() already.
-    # Resetting Configuration._default to None here effectively reverts the
-    # Configuration class to its vanilla, unmodified behaviour/state.
-    Configuration.set_default(None)
+@pytest.fixture
+def mocked_should_refresh_access_token():
+    with patch.object(
+        keyring, "should_refresh_access_token", return_value=False
+    ) as should_refresh_access_token_mock:
+        yield should_refresh_access_token_mock
 
-    # Because Configuration._default is None, a newly-created instance of
-    # cloudsmith_api.Configuration() should not have any other attributes than those
-    # in the auto-generated swagger-codegen class declaration.
-    new_config_before_initialise = Configuration()
-    assert all(
-        not hasattr(new_config_before_initialise, attr) for attr in extra_config_attrs
-    )
 
-    # Our initialise_api() function should create an instance of
-    # cloudsmith_api.Configuration, add some extra attributes to it, set default values
-    # and pass that instance to cloudsmith_api.Configuration.set_default().
-    config_from_initialise = initialise_api()
-    assert all(hasattr(config_from_initialise, attr) for attr in extra_config_attrs)
-    assert (
-        Configuration._default  # pylint: disable=protected-access
-        is config_from_initialise
-    )
+@pytest.fixture
+def mocked_refresh_access_token():
+    with patch.object(
+        saml,
+        "refresh_access_token",
+        return_value=("new_access_token", "new_refresh_token"),
+    ) as refresh_access_token_mock:
+        yield refresh_access_token_mock
 
-    # After which point, any newly-created instances of cloudsmith_api.Configuration
-    # should automagically include copies of those "extra" attributes we assigned to
-    # the "default" config instance in our initialise_api() function.
-    new_config_after_initialise = Configuration()
-    assert all(
-        hasattr(new_config_after_initialise, attr) for attr in extra_config_attrs
-    )
-    assert (
-        Configuration._default  # pylint: disable=protected-access
-        is not new_config_after_initialise
-    )
+
+@pytest.fixture
+def mocked_store_sso_tokens():
+    with patch.object(keyring, "store_sso_tokens") as store_sso_tokens_mock:
+        yield store_sso_tokens_mock
+
+
+@pytest.fixture
+def mocked_update_refresh_attempted_at():
+    with patch.object(
+        keyring, "update_refresh_attempted_at"
+    ) as update_refresh_attempted_at_mock:
+        yield update_refresh_attempted_at_mock
+
+
+class TestInitialiseApi:
+    def setup_class(cls):  # pylint: disable=no-self-argument
+        # For the purposes of these tests, we need to explcitly call set_default(None) at the
+        # outset because other tests in the suite may have called initialise_api() already.
+        # Resetting Configuration._default to None here effectively reverts the
+        # Configuration class to its vanilla, unmodified behaviour/state.
+        Configuration.set_default(None)
+
+    def test_initialise_api_sets_cloudsmith_api_config_default(
+        self, mocked_get_access_token
+    ):
+        """Assert that the extra attributes we add to the cloudsmith_cli.Configuration class
+        are present on newly-created instances of that class.
+        """
+
+        # Read and understand the Configuration class's initialiser.
+        # Notice how the _default class attribute is used if not None.
+        # https://github.com/cloudsmith-io/cloudsmith-api/blob/57963fff5b7818783b3d87246495275545d505df/bindings/python/src/cloudsmith_api/configuration.py#L32-L40
+
+        # There are a number of attributes which we automagically add to instances of
+        # cloudsmith_api.Configuration().
+        extra_config_attrs = [
+            "rate_limit",
+            "error_retry_max",
+            "error_retry_backoff",
+            "error_retry_codes",
+            "error_retry_cb",
+        ]
+
+        # We do that in our initialise_api() function by
+        # (i) creating a new instance of Configuration and adding attributes/values to it.
+        # (ii) calling the cloudsmith_api.Configuration.set_default(config) classmethod.
+
+        # Because Configuration._default is None, a newly-created instance of
+        # cloudsmith_api.Configuration() should not have any other attributes than those
+        # in the auto-generated swagger-codegen class declaration.
+        new_config_before_initialise = Configuration()
+        assert all(
+            not hasattr(new_config_before_initialise, attr)
+            for attr in extra_config_attrs
+        )
+
+        # Our initialise_api() function should create an instance of
+        # cloudsmith_api.Configuration, add some extra attributes to it, set default values
+        # and pass that instance to cloudsmith_api.Configuration.set_default().
+        config_from_initialise = initialise_api()
+        assert all(hasattr(config_from_initialise, attr) for attr in extra_config_attrs)
+        assert (
+            Configuration._default  # pylint: disable=protected-access
+            is config_from_initialise
+        )
+
+        # After which point, any newly-created instances of cloudsmith_api.Configuration
+        # should automagically include copies of those "extra" attributes we assigned to
+        # the "default" config instance in our initialise_api() function.
+        new_config_after_initialise = Configuration()
+        assert all(
+            hasattr(new_config_after_initialise, attr) for attr in extra_config_attrs
+        )
+        assert (
+            Configuration._default  # pylint: disable=protected-access
+            is not new_config_after_initialise
+        )
+
+    def test_initialise_api_with_refreshable_access_token_set(
+        self,
+        mocked_get_access_token,
+        mocked_get_refresh_token,
+        mocked_should_refresh_access_token,
+        mocked_refresh_access_token,
+        mocked_store_sso_tokens,
+        mocked_update_refresh_attempted_at,
+    ):
+        mocked_should_refresh_access_token.return_value = True
+
+        config = initialise_api(host="https://example.com")
+
+        assert config.headers == {"Authorization": "Bearer dummy_access_token"}
+        mocked_refresh_access_token.assert_called_once()
+        mocked_store_sso_tokens.assert_called_once_with(
+            "https://example.com", "new_access_token", "new_refresh_token"
+        )
+        mocked_update_refresh_attempted_at.called_once()
+
+    def test_initialise_api_with_recently_refreshed_access_token_and_empty_basic_auth_set(
+        self,
+        mocked_get_access_token,
+        mocked_get_refresh_token,
+        mocked_should_refresh_access_token,
+        mocked_refresh_access_token,
+        mocked_store_sso_tokens,
+        mocked_update_refresh_attempted_at,
+    ):
+        auth_header = Configuration().get_basic_auth_token()
+        config = initialise_api(
+            host="https://example.com", headers={"Authorization": auth_header}
+        )
+
+        assert config.headers == {"Authorization": "Bearer dummy_access_token"}
+        assert config.username == ""
+        assert config.password == ""
+        mocked_refresh_access_token.assert_not_called()
+        mocked_store_sso_tokens.assert_not_called()
+        mocked_update_refresh_attempted_at.not_called()
+
+    def test_initialise_api_with_recently_refreshed_access_token_and_present_basic_auth(
+        self,
+        mocked_get_access_token,
+        mocked_get_refresh_token,
+        mocked_should_refresh_access_token,
+        mocked_refresh_access_token,
+        mocked_store_sso_tokens,
+        mocked_update_refresh_attempted_at,
+    ):
+        temp_config = Configuration()
+        temp_config.username = "username"
+        temp_config.password = "password"
+        auth_header = temp_config.get_basic_auth_token()
+        config = initialise_api(
+            host="https://example.com", headers={"Authorization": auth_header}
+        )
+
+        assert config.headers == {"Authorization": auth_header}
+        assert config.username == "username"
+        assert config.password == "password"
+        mocked_refresh_access_token.assert_not_called()
+        mocked_store_sso_tokens.assert_not_called()
+        mocked_update_refresh_attempted_at.not_called()

--- a/cloudsmith_cli/core/tests/test_init.py
+++ b/cloudsmith_cli/core/tests/test_init.py
@@ -70,6 +70,7 @@ class TestInitialiseApi:
         """Assert that the extra attributes we add to the cloudsmith_cli.Configuration class
         are present on newly-created instances of that class.
         """
+        mocked_get_access_token.return_value = None
 
         # Read and understand the Configuration class's initialiser.
         # Notice how the _default class attribute is used if not None.

--- a/cloudsmith_cli/core/tests/test_keyring.py
+++ b/cloudsmith_cli/core/tests/test_keyring.py
@@ -1,0 +1,192 @@
+import getpass
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import keyring
+import pytest
+from freezegun import freeze_time
+from keyring.errors import KeyringError
+
+from ..keyring import (
+    get_access_token,
+    get_refresh_attempted_at,
+    get_refresh_token,
+    should_refresh_access_token,
+    store_access_token,
+    store_refresh_token,
+    store_sso_tokens,
+    update_refresh_attempted_at,
+)
+
+
+@pytest.fixture
+def mock_get_user():
+    with patch.object(getpass, "getuser", return_value="test_user") as get_user_mock:
+        yield get_user_mock
+
+
+@pytest.fixture
+def mock_get_password():
+    with patch.object(keyring, "get_password") as get_password_mock:
+        yield get_password_mock
+
+
+@pytest.fixture
+def mock_set_password():
+    with patch.object(keyring, "set_password") as set_password_mock:
+        yield set_password_mock
+
+
+class TestKeyring:
+    api_host = "https://example.com"
+
+    def test_store_access_token(self, mock_get_user, mock_set_password):
+        store_access_token(self.api_host, "access_token")
+
+        mock_set_password.assert_called_once_with(
+            "cloudsmith_cli-access_token-https://example.com",
+            "test_user",
+            "access_token",
+        )
+
+    def test_get_access_token(self, mock_get_user, mock_get_password):
+        mock_get_password.return_value = "access_token"
+
+        assert get_access_token(self.api_host) == "access_token"
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token-https://example.com", "test_user"
+        )
+
+    def test_get_access_token_when_error_raised(self, mock_get_user, mock_get_password):
+        mock_get_password.side_effect = KeyringError("A keyring error occurred")
+
+        assert get_access_token(self.api_host) is None
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token-https://example.com", "test_user"
+        )
+
+    @freeze_time("2024-06-01 10:00:00")
+    def test_update_refresh_attempted_at(self, mock_get_user, mock_set_password):
+        attempted_at = datetime.utcnow().isoformat()
+
+        update_refresh_attempted_at(self.api_host)
+
+        mock_set_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+            attempted_at,
+        )
+
+    def test_get_refresh_attempted_at(self, mock_get_user, mock_get_password):
+        mock_get_password.return_value = datetime(
+            2024, 6, 1, 10, 0, tzinfo=timezone.utc
+        ).isoformat()
+
+        assert get_refresh_attempted_at(self.api_host) == datetime(
+            2024, 6, 1, hour=10, minute=0, tzinfo=timezone.utc
+        )
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    def test_get_refresh_attempted_at_when_keyring_error_raised(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.side_effect = KeyringError("A keyring error occurred")
+
+        assert get_refresh_attempted_at(self.api_host) is None
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    def test_get_refresh_attempted_at_when_invalid_datetime_returned(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.return_value = "invalid_datetime"
+
+        assert get_refresh_attempted_at(self.api_host) is None
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    @freeze_time("2024-06-01 10:00:00")
+    def test_should_refresh_access_token_with_new_token(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.return_value = datetime.utcnow().isoformat()
+
+        assert not should_refresh_access_token(self.api_host)
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    @freeze_time("2024-06-01 10:00:00")
+    def test_should_refresh_access_token_with_token_about_to_expire(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.return_value = (
+            datetime.utcnow() - timedelta(minutes=30)
+        ).isoformat()
+
+        assert not should_refresh_access_token(self.api_host)
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    @freeze_time("2024-06-01 10:00:00")
+    def test_should_refresh_access_token_with_expired_token(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.return_value = (
+            datetime.utcnow() - timedelta(minutes=31)
+        ).isoformat()
+
+        assert should_refresh_access_token(self.api_host)
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+        )
+
+    def test_store_refresh_token(self, mock_get_user, mock_set_password):
+        store_refresh_token(self.api_host, "refresh_token")
+
+        mock_set_password.assert_called_once_with(
+            "cloudsmith_cli-refresh_token-https://example.com",
+            "test_user",
+            "refresh_token",
+        )
+
+    def test_get_refresh_token(self, mock_get_user, mock_get_password):
+        mock_get_password.return_value = "refresh_token"
+
+        assert get_refresh_token(self.api_host) == "refresh_token"
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-refresh_token-https://example.com", "test_user"
+        )
+
+    @freeze_time("2024-06-01 10:00:00")
+    def test_store_sso_tokens(self, mock_get_user, mock_set_password):
+        refresh_attempted_at = datetime.utcnow().isoformat()
+        store_sso_tokens(self.api_host, "access_token", "refresh_token")
+
+        assert mock_set_password.call_count == 3
+        mock_set_password.assert_any_call(
+            "cloudsmith_cli-access_token-https://example.com",
+            "test_user",
+            "access_token",
+        )
+        mock_set_password.assert_any_call(
+            "cloudsmith_cli-access_token_refresh_attempted_at-https://example.com",
+            "test_user",
+            refresh_attempted_at,
+        )
+        mock_set_password.assert_any_call(
+            "cloudsmith_cli-refresh_token-https://example.com",
+            "test_user",
+            "refresh_token",
+        )

--- a/cloudsmith_cli/core/tests/test_keyring.py
+++ b/cloudsmith_cli/core/tests/test_keyring.py
@@ -169,6 +169,16 @@ class TestKeyring:
             "cloudsmith_cli-refresh_token-https://example.com", "test_user"
         )
 
+    def test_get_refresh_token_when_error_raised(
+        self, mock_get_user, mock_get_password
+    ):
+        mock_get_password.side_effect = KeyringError("A keyring error occurred")
+
+        assert get_refresh_token(self.api_host) is None
+        mock_get_password.assert_called_once_with(
+            "cloudsmith_cli-refresh_token-https://example.com", "test_user"
+        )
+
     @freeze_time("2024-06-01 10:00:00")
     def test_store_sso_tokens(self, mock_get_user, mock_set_password):
         refresh_attempted_at = datetime.utcnow().isoformat()

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 # Use this file to declare development-only dependencies.
 # All production dependencies should be declared in setup.py `install_requires`.
 bumpversion
+freezegun
 httpretty
 keyring
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,8 @@ exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via virtualenv
+freezegun==1.5.1
+    # via -r requirements.in
 httpretty==1.1.4
     # via -r requirements.in
 identify==2.5.26
@@ -105,7 +107,9 @@ pytest==7.4.0
 pytest-cov==4.1.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via cloudsmith-api
+    # via
+    #   cloudsmith-api
+    #   freezegun
 pyyaml==6.0.1
     # via pre-commit
 requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ click-didyoumean==0.3.1
     # via cloudsmith-cli (setup.py)
 click-spinner==0.1.10
     # via cloudsmith-cli (setup.py)
-cloudsmith-api==2.0.14
+cloudsmith-api==2.0.13
     # via cloudsmith-cli (setup.py)
 configparser==7.1.0
     # via click-configfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ click-didyoumean==0.3.1
     # via cloudsmith-cli (setup.py)
 click-spinner==0.1.10
     # via cloudsmith-cli (setup.py)
-cloudsmith-api==2.0.13
+cloudsmith-api==2.0.14
     # via cloudsmith-cli (setup.py)
 configparser==7.1.0
     # via click-configfile


### PR DESCRIPTION
# What changed?

Adds the `cloudsmith auth` command to authenticate using an organization's configured SAML provider rather than an API key

Access and refresh tokens are stored in the operating system keyring with the timestamp they were generated at. On each command, if the access token is set, the CLI will check if the token should be refreshed prior to executing the command specified

As part of the refresh, the timestamp denoting when the last refresh was attempted will be updated, ensuring we don't repeatedly try to refresh the token on multiple invocations if the refresh failed