### PR TITLE
Remove keyring from requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,6 @@
 bumpversion
 freezegun
 httpretty
-keyring
 pip-tools
 pre-commit
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,8 +72,8 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.0.2
     # via keyring
-keyring==25.3.0
-    # via -r requirements.in
+keyring==25.4.1
+    # via cloudsmith-cli (setup.py)
 lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0


### PR DESCRIPTION
# What changed?

Now that `keyring` is correctly specified in `setup.py` as of #177, remove it from `requirements.in` meant for dev dependencies