### PR TITLE
chore: Fix suppressed error detail

### DIFF
--- a/cloudsmith_cli/cli/commands/login.py
+++ b/cloudsmith_cli/cli/commands/login.py
@@ -6,7 +6,7 @@ import stat
 import click
 import cloudsmith_api
 
-from ...core.api.exceptions import TwoFactorRequiredException, AuthenticationError
+from ...core.api.exceptions import TwoFactorRequiredException
 from ...core.api.user import get_user_token
 from ...core.utils import get_help_website
 from .. import decorators

--- a/cloudsmith_cli/cli/commands/login.py
+++ b/cloudsmith_cli/cli/commands/login.py
@@ -6,7 +6,7 @@ import stat
 import click
 import cloudsmith_api
 
-from ...core.api.exceptions import TwoFactorRequiredException
+from ...core.api.exceptions import TwoFactorRequiredException, AuthenticationError
 from ...core.api.user import get_user_token
 from ...core.utils import get_help_website
 from .. import decorators
@@ -157,9 +157,9 @@ def login(ctx, opts, login, password):  # pylint: disable=redefined-outer-name
             )
             ctx.exit(1)
 
-    except cloudsmith_api.rest.ApiException:
+    except cloudsmith_api.rest.ApiException as e:
         click.echo("\r\033[K", nl=False)
-        click.secho("Authentication failed: Invalid username/password.", fg="red")
+        click.secho(f"Authentication failed: {str(e)}", fg="red")
         ctx.exit(1)
 
     click.secho("OK", fg="green")

--- a/cloudsmith_cli/core/api/user.py
+++ b/cloudsmith_cli/core/api/user.py
@@ -49,7 +49,7 @@ def get_user_token(login, password, totp_token=None, two_factor_token=None):
                     raise TwoFactorRequiredException(two_factor_token)
             except (ValueError, KeyError):
                 pass
-        
+
         # If not 2FA, use the context manager to handle other API exceptions
         with catch_raise_api_exception():
             raise


### PR DESCRIPTION
* Ensure we are not suppressing relevant error details when logging in hits an error (e.g. a bunch of errors were being suppressed by the raised error message "Invalid username/password").