### PR TITLE
Update readme.md to include extra commands and more upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please see the [changelog](https://github.com/cloudsmith-io/cloudsmith-cli/blob/
 
 The CLI currently supports the following commands (and sub-commands):
 
-- `auth`:                 Authenticate the CLI against an organization's SAML configuration.
+- `authenticate`|`auth`:  Authenticate the CLI against an organization's SAML configuration.
 - `check`:                Check rate limits and service status.
 - `copy`|`cp`:            Copy a package to another repository.
 - `delete`|`rm`:          Delete a package from a repository.
@@ -52,7 +52,10 @@ The CLI currently supports the following commands (and sub-commands):
 - `metrics`:              Metrics and statistics for a repository.
   - `tokens`:               Retrieve bandwidth usage for entitlement tokens.
   - `packages`:             Retrieve package usage for repository.
-- `move`|`mv`:            Move (promote) a package to another repo.
+- `move`|`mv`|`promote`:  Move (promote) a package to another repo.
+- `policy`:               Manage policies for an organization.
+  - `license`:              Manage license policies for an organization.
+  - `vulnerability`:        Manage vulnerability policies for an organization.
 - `push`|`upload`:        Push (upload) a new package to a repository.
   - `alpine`:               Push (upload) a new Alpine package upstream.
   - `cargo`:                Push (upload) a new Cargo package upstream.
@@ -87,16 +90,30 @@ The CLI currently supports the following commands (and sub-commands):
   - `delete`|`rm`:          Delete a repository from a namespace.
 - `resync`:               Resynchronise a package in a repository.
 - `status`:               Get the synchronisation status for a package.
-- `tags`:                 Manage the tags for a package in a repository.
+- `tags`|`tag`:           Manage the tags for a package in a repository.
   - `add`:                  Add tags to a package in a repository.
   - `clear`:                Clear all existing (non-immutable) tags from a package in a repository.
   - `list`|`ls`:            List tags for a package in a repository.
   - `remove`|`rm`:          Remove tags from a package in a repository.
   - `replace`:              Replace all existing (non-immutable) tags on a package in a repository.
-- `whoami`:               Retrieve your current authentication status.
 - `tokens`:               Manage API tokens.
   - `list`|`ls`:            List API tokens.
   - `refresh`:              Refresh an API token.
+- `upstream`:             Manage upstreams for a repository.
+  - `cran`:                 Manage cran upstreams for a repository.
+  - `dart`:                 Manage dart upstreams for a repository.
+  - `deb`:                  Manage deb upstreams for a repository.
+  - `docker`:               Manage docker upstreams for a repository.
+  - `helm`:                 Manage helm upstreams for a repository.
+  - `hex`:                  Manage hex upstreams for a repository.
+  - `maven`:                Manage maven upstreams for a repository.
+  - `npm`:                  Manage npm upstreams for a repository.
+  - `nuget`:                Manage nuget upstreams for a repository.
+  - `python`:               Manage python upstreams for a repository.
+  - `rpm`:                  Manage rpm upstreams for a repository.
+  - `ruby`:                 Manage ruby upstreams for a repository.
+  - `swift`:                Manage swift upstreams for a repository.
+- `whoami`:               Retrieve your current authentication status.
 
 ## Installation
 

--- a/cloudsmith_cli/cli/commands/upstream.py
+++ b/cloudsmith_cli/cli/commands/upstream.py
@@ -28,6 +28,8 @@ UPSTREAM_FORMATS = [
     "rpm",
     "ruby",
     "cran",
+    "swift",
+    "hex",
 ]
 
 


### PR DESCRIPTION
Update the readme to include commands that are present but are not in the readme. 

Plus swift and hex are now available as upstreams. 

For reference (cli v1.8.2 i.e. the current version outputs):

```
cloudsmith --help
Usage: cloudsmith [OPTIONS] COMMAND [ARGS]...

     ________                __               _ __  __       ________    ____
    / ____/ /___  __  ______/ /________ ___  (_) /_/ /_     / ____/ /   /  _/
   / /   / / __ \/ / / / __  / ___/ __ `__ \/ / __/ __ \   / /   / /    / /
  / /___/ / /_/ / /_/ / /_/ (__  ) / / / / / / /_/ / / /  / /___/ /____/ /
  \____/_/\____/\__,_/\__,_/____/_/ /_/ /_/_/\__/_/ /_/   \____/_____/___/

  The Cloudsmith Command-Line Interface - Be Awesome. Automate Everything.

Options:
  -V, --version            Show the version numbers for the API and CLI.
  -C, --config-file PATH   The path to your config.ini file.
  --credentials-file PATH  The path to your credentials.ini file.
  -P, --profile TEXT       The name of the profile to use for configuration.
  -h, --help               Show this message and exit.

Commands:
  authenticate|auth   Authenticate to Cloudsmith using the org's SAML setup.
  check               Check rate limits and service status.
  copy|cp             Copy a package to another repository.
  delete|rm           Delete a package from a repository.
  dependencies|deps   List direct (non-transitive) dependencies for a...
  docs                Launch the help website in your browser.
  entitlements|ents   Manage the entitlements for a repository.
  help                Show this delightful help message and exit.
  list|ls             List distros, packages, repos and entitlements.
  login|token         Retrieve your API authentication token/key via login.
  metrics             Retrieve Metrics.
  move|mv|promote     Move (promote) a package to another repo.
  policy              Manage policies for an organization.
  push|upload|deploy  Push (upload) a new package to a repository.
  quarantine|block    Manage quarantined packages in a repository.
  quota               Display Quota limits and history for an organisation.
  repositories|repos  Manage Repositories.
  resync              Resynchronise a package in a repository.
  status              Get the synchronisation status for a package.
  tags|tag            Manage the tags for a package in a repository.
  tokens              Manage your user API tokens.
  upstream            Manage upstreams for a repository.
  whoami              Retrieve your current authentication status.
  ```