### PR TITLE
Add Dockerfile for containerized CLI + update workflow to push Zipapp and container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,21 @@ jobs:
                   asset_path: ./cloudsmith-${{ env.VERSION }}.pyz
                   asset_name: cloudsmith-${{ env.VERSION }}.pyz
                   asset_content_type: application/zip
+            - name: Install and authenticate Cloudmsith CLI
+              uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
+              with:
+                  oidc-namespace: 'cloudsmith'
+                  oidc-service-slug: 'cli-publisher'
+                  oidc-auth-only: 'true'
+            - name: Push Zipapp to Cloudsmith
+              id: push_zipapp
+              run: cloudsmith push raw cloudsmith/cli-zipapp ./cloudsmith-${{ env.VERSION }}.pyz
+            - name: Build Docker image
+              id: build_cli_image
+              run: |
+                  docker build -t cloudsmith-cli:${{ env.VERSION }} .
+                  docker save -o cloudsmith-cli:${{ env.VERSION }}.docker cloudsmith-cli:${{ env.VERSION }}
+            - name: Push Dockerised CLI
+              id: push_dockerised_cli
+              run: |
+                  cloudsmith push docker cloudsmith-cli:${{ env.VERSION }}.docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-alpine
+
+LABEL maintainer="support@cloudsmith.io"
+LABEL description="Official Cloudsmith CLI, now served in a handy container"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PATH="/opt/cloudsmith:${PATH}"
+
+RUN apk add --no-cache curl bash
+
+RUN mkdir -p /opt/cloudsmith \
+ && curl -1sLf -o /opt/cloudsmith/cloudsmith 'https://dl.cloudsmith.io/public/cloudsmith/cli-zipapp/raw/names/cloudsmith-cli/versions/latest/cloudsmith-latest.pyz' \
+ && chmod +x /opt/cloudsmith/cloudsmith
+
+# Default command
+CMD ["/bin/sh"]


### PR DESCRIPTION
**Added**:
- Introduced a new Dockerfile that builds a containerized version of the Cloudsmith CLI, using the official Zipapp from the cli-zipapp repo.
- Updated Release workflow to push the zipapp and containerised CLI to Cloudsmith OSS repos.
