### PR TITLE
fix: uses -allow-existing to avoid prompt timeouts to allow venv to be reused

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ orbs:
               name: Install dependencies
               command: |
                 python3 -m pip install uv
-                uv venv .venv
+                uv venv .venv --allow-existing
                 uv pip install -r requirements.txt
                 . .venv/bin/activate
           - save_cache:


### PR DESCRIPTION
### What's Changed

This pull request makes a minor update to the dependency installation step in the CircleCI configuration. The change ensures that the virtual environment setup command does not fail if the `.venv` directory already exists, improving reliability in repeated or cached runs.

Currently on CI, the prompt to recreate `.venv` times out after 10 minutes waiting for the prompt to be answered:

```bash
Installing collected packages: uv
Successfully installed uv-0.8.20
WARNING: You are using pip version 21.2.4; however, version 25.2 is available.
You should consider upgrading via the '/usr/local/bin/python3 -m pip install --upgrade pip' command.
Using CPython 3.9.9 interpreter at: /usr/local/bin/python
Creating virtual environment at: .venv
? A virtual environment already exists at `.venv`. Do you want to replace it? [y/n] › yes

hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to skip this prompt
Too long with no output (exceeded 10m0s): context deadline exceeded
```

However, using the `-allow-existing` flag avoids having to recreate the .venv, which means we don't receive the prompt and experience the timeout.

```bash
> uv help venv

      --allow-existing
          Preserve any existing files or directories at the target path.

          By default, `uv venv` will exit with an error if the given path is non-empty. The `--allow-existing` option will instead write to the given path, regardless of its contents, and without clearing it
          beforehand.

          WARNING: This option can lead to unexpected behavior if the existing virtual environment and the newly-created virtual environment are linked to different Python interpreters.
```

As the steps to install that use uv runs per version of python in isolation, we shouldn't encounter the case where we change python versions on an existing `.venv`. 