### PR TITLE
ci: update github action permissions for release to allow write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
  id-token: write
- contents: read
+ contents: write
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
### What's Changed

The `contents` permission has been updated from `read` to `write` to allow the workflow to enable a release to be created via the action.

### Why It's Required
When creating a GitHub release, the workflow needs to:

* Create the release object with release notes
* Attach release assets

This should resolve the following error:

<img width="479" height="232" alt="image" src="https://github.com/user-attachments/assets/784e865e-fe85-4b5a-bb61-0156cf1abbb9" />

relates to:
- https://github.com/cloudsmith-io/cloudsmith-cli/pull/209