### PR TITLE
Drop mix_stderr=False from CliRunner()

### DIFF
--- a/cloudsmith_cli/cli/tests/conftest.py
+++ b/cloudsmith_cli/cli/tests/conftest.py
@@ -19,7 +19,7 @@ def _get_env_var_or_skip(key):
 @pytest.fixture()
 def runner():
     """Return a CliRunner with which to run Commands."""
-    return click.testing.CliRunner(mix_stderr=False)
+    return click.testing.CliRunner()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Upstream deprecated the option to mangle original stdout and stderr, and instead provides result.output that copies the original streams into a new mixed stream, in proper terminal order.

Passing mix_stderr is invalid since version 8.2.

```
>       return click.testing.CliRunner(mix_stderr=False)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
```

See: https://github.com/pallets/click/pull/2523

This should also fix the build failure in nixpkgs: https://hydra.nixos.org/build/310534057/nixlog/2