### PR TITLE
feat: implements alpine upstreams

### DIFF
--- a/cloudsmith_cli/cli/commands/upstream.py
+++ b/cloudsmith_cli/cli/commands/upstream.py
@@ -18,6 +18,7 @@ from ..utils import (
 from .main import main
 
 UPSTREAM_FORMATS = [
+    "alpine",
     "cargo",
     "conda",
     "cran",

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ click-didyoumean==0.3.1
     # via cloudsmith-cli (setup.py)
 click-spinner==0.1.10
     # via cloudsmith-cli (setup.py)
-cloudsmith-api==2.0.24
+cloudsmith-api==2.0.25
     # via cloudsmith-cli (setup.py)
 configparser==7.2.0
     # via click-configfile

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "click-didyoumean>=0.0.3",
         "click-spinner>=0.1.7",
         "json5>=0.9.0",  # For parsing JSONC (JSON with comments) in VS Code settings
-        "cloudsmith-api>=2.0.24,<3.0",  # Compatible upto (but excluding) 3.0+
+        "cloudsmith-api>=2.0.25,<3.0",  # Compatible upto (but excluding) 3.0+
         "keyring>=25.4.1",
         "mcp==1.9.1",
         "python-toon==0.1.2",


### PR DESCRIPTION
### What's Changed

This pull request introduces an update to the supported package formats to manage Alpine upstreams. 

Dependency update:

* Bumped the `cloudsmith-api` dependency version from `>=2.0.24,<3.0` to `>=2.0.25,<3.0` in `setup.py` to ensure compatibility with the latest API features.

depends on:
- https://github.com/cloudsmith-io/cloudsmith-api/pull/88

Supported formats:

* Added `"alpine"` to the list of supported package upstreams in `cloudsmith_cli/cli/commands/upstream.py`.