### PR TITLE
Chore {CENG-758 - fixed the incorrect URLs in the CONTRIBUTING.md file}

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
-Please refer to Cloudsmith's standard guide on [Open-Source Contributing](https://docs.cloudsmith.com/contributing).
+Please refer to Cloudsmith's standard guide on [Open-Source Contributing](https://docs.cloudsmith.com/resources/contributing).
 
 
 ## Contributor License Agreement
 
-By making any contributions to Cloudsmith Ltd projects you agree to be bound by the terms of the Cloudsmith Ltd [Contributor License Agreement](https://docs.cloudsmith.com/contributor-license-agreement).
+By making any contributions to Cloudsmith Ltd projects you agree to be bound by the terms of the Cloudsmith Ltd [Contributor License Agreement](https://docs.cloudsmith.com/resources/contributor-license-agreement).
 
 
 ## Development Environment
@@ -42,4 +42,4 @@ Please ensure that [CHANGELOG.md](./CHANGELOG.md) is updated appropriately with 
 
 ## Need Help?
 
-See the section for raising a question in the [Contributing Guide](https://docs.cloudsmith.com/contributing).
+See the section for raising a question in the [Contributing Guide](https://docs.cloudsmith.com/resources/contributing).


### PR DESCRIPTION
Improving the `CONTRIBUTING.md` file for cloudsmith-io/cloudsmith-cli repository

As checked, currently, the redirect URLs in the CONTRIBUTING.md file point to Open Source Contributing, Contributor License Agreement, and Contributing Guide, which are incorrect per the current documents. 

Current URLs in the file:
- https://docs.cloudsmith.com/contributing
- https://docs.cloudsmith.com/contributor-license-agreement

Checked and found that the Correct URLs should be:
- https://docs.cloudsmith.com/resources/contributing
- https://docs.cloudsmith.com/resources/contributor-license-agreement
 