### PR TITLE
fix(docker): run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,9 @@ RUN mkdir -p /opt/cloudsmith \
  && curl -1sLf -o /opt/cloudsmith/cloudsmith "https://dl.cloudsmith.io/public/${CLOUDSMITH_NAMESPACE}/${CLOUDSMITH_REPO}/raw/names/cloudsmith-cli/versions/${CLOUDSMITH_CLI_VERSION}/cloudsmith.pyz" \
  && chmod +x /opt/cloudsmith/cloudsmith
 
+# Run as a non-root user
+RUN adduser -D -u 1000 cloudsmith
+USER cloudsmith
+
 # Default command
 ENTRYPOINT [ "cloudsmith" ]


### PR DESCRIPTION
# Description

Resolves the "Missing User Instruction" code scanning alert. The image now creates a dedicated `cloudsmith` user (uid 1000) and drops root before the entrypoint runs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

Verified locally: image builds and `cloudsmith --version` runs as uid 1000.

Two remaining Dockerfile alerts are deliberately not addressed — recommend dismissal with justification: HEALTHCHECK is meaningless for a CLI entrypoint container (no long-running process), and apk version pins break rebuilds once versions rotate out of the Alpine index.
