### PR TITLE
feat(no-ticket): add Maven shell-plugin credential helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `cloudsmith credential-helper generic` resolves a credential through the full provider chain (API key, `credentials.ini`, system keyring, OIDC) and emits it as a versioned JSON document — `{"version": 1, "username": "token", "password": "<token>"}` — for tools that shell out to the CLI rather than importing it. It takes no arguments: a Cloudsmith token is organisation-wide, so the host it will be used against does not change which credential resolves. Errors exit non-zero with a message on stderr and never emit a partial document.
+
+- `cloudsmith credential-helper domains` emits a versioned JSON document — `{"version": 1, "domains": [{"host": ..., "format": ..., "backend_kind": ..., "enabled": ..., "validated": ..., "type": ...}]}` — listing the hosts Cloudsmith can authenticate: the built-in service domains plus any custom domains configured for an organisation, along with the package format each one serves. Disabled and unvalidated custom domains are included too, with their state intact, so a misconfigured domain is visible rather than silently missing. The command takes no arguments: the organisation is resolved from `CLOUDSMITH_ORG` or `oidc_org` in `config.ini`, and with no organisation configured just the built-in hosts are listed, which needs no authentication. Like `credential-helper generic`, this command is for programmatic consumers only and has no human-readable output mode.
+- The built-in domain list can be replaced via a `[domains]` section in `config.ini`, mapping hostname to package format, for dedicated and on-premise deployments. For safety this is honoured only from trusted configuration — your user-level config directory, `~/.cloudsmith`, or an explicit `--config-file`. A `[domains]` section in a directory-relative `config.ini` is ignored with a warning, because that file can be committed to a repository and this list decides which hosts may receive a credential.
+
 ### Fixed
 
 - Files larger than 100MB now upload correctly when authenticated via SSO or OIDC. The multi-part upload read its credentials from `opts.api_key`, which is only populated by `--api-key`, `CLOUDSMITH_API_KEY` or `credentials.ini` — so with an SSO session or OIDC auto-discovery it was empty, the auth header was dropped, and the part upload failed with a misleading `404 - Not Found` ("this usually means the user/org is wrong or not visible") even though every preceding API call had succeeded. Credentials are now taken from the resolved credential chain, with SSO access tokens sent as a bearer `Authorization` header and API keys/OIDC tokens as `X-Api-Key`.

--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -10,6 +10,7 @@ from . import (
     docs,
     download,
     entitlements,
+    exec_,
     help_,
     list_,
     login,

--- a/cloudsmith_cli/cli/commands/credential_helper/__init__.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/__init__.py
@@ -11,6 +11,7 @@ import click
 from ..main import main
 from .docker import docker as docker_cmd
 from .manage import install_cmd, list_cmd, uninstall_cmd
+from .shell import shell_init
 
 
 @click.group()
@@ -32,6 +33,7 @@ def credential_helper():
 
 
 credential_helper.add_command(docker_cmd, name="docker")
+credential_helper.add_command(shell_init, name="shell-init")
 credential_helper.add_command(install_cmd, name="install")
 credential_helper.add_command(uninstall_cmd, name="uninstall")
 credential_helper.add_command(list_cmd, name="list")

--- a/cloudsmith_cli/cli/commands/credential_helper/__init__.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/__init__.py
@@ -10,6 +10,8 @@ import click
 
 from ..main import main
 from .docker import docker as docker_cmd
+from .domains import domains_cmd
+from .generic import generic as generic_cmd
 from .manage import install_cmd, list_cmd, uninstall_cmd
 from .shell import shell_init
 
@@ -33,6 +35,8 @@ def credential_helper():
 
 
 credential_helper.add_command(docker_cmd, name="docker")
+credential_helper.add_command(domains_cmd, name="domains")
+credential_helper.add_command(generic_cmd, name="generic")
 credential_helper.add_command(shell_init, name="shell-init")
 credential_helper.add_command(install_cmd, name="install")
 credential_helper.add_command(uninstall_cmd, name="uninstall")

--- a/cloudsmith_cli/cli/commands/credential_helper/domains.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/domains.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Cloudsmith Ltd
+"""List the hosts Cloudsmith can authenticate: built-in and custom domains.
+
+The built-in ``*.cloudsmith.io`` service hosts ship with the CLI so that every
+consumer shares one authoritative table; custom domains cannot be inferred, so
+discovering them requires an API lookup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import click
+
+from ....credential_helpers.backends import BackendKind
+from ....credential_helpers.custom_domains import get_custom_domains
+from ....credential_helpers.default_domains import (
+    load_default_domains,
+    untrusted_config_declares_domains,
+)
+from ...config import get_default_config_path
+from ...decorators import (
+    common_api_auth_options,
+    common_cli_config_options,
+    resolve_credentials,
+)
+
+PROTOCOL_VERSION = 1
+
+
+def format_name(backend_kind: int | None) -> str:
+    """Return a human-readable package format for a backend kind value.
+
+    A download-CDN domain has no backend kind and renders as ``-``.  A value
+    outside :class:`BackendKind` renders as itself: the enum is a
+    hand-maintained mirror of the server-side one, so a newly added server
+    format must not break this command.
+    """
+    if backend_kind is None:
+        return "-"
+
+    try:
+        return BackendKind(backend_kind).name.lower()
+    except ValueError:
+        return str(backend_kind)
+
+
+@click.command("domains")
+@common_cli_config_options
+@common_api_auth_options
+@resolve_credentials
+@click.pass_context
+def domains_cmd(ctx, opts) -> None:
+    """Emit the Cloudsmith hosts and their package formats as JSON.
+
+    Emits machine-readable JSON for programmatic consumers listing the
+    built-in Cloudsmith service hosts (``*.cloudsmith.io``) alongside the
+    organisation's custom domains. Each entry's ``type`` field distinguishes
+    ``default`` from ``custom``. Every domain is included, even custom ones
+    that are disabled or not yet validated, so a domain that is present but
+    not working is visible rather than silently absent. Consumers that need a
+    usable host should filter on both ``enabled`` and ``validated``.
+
+    The built-in hosts are always listed and need no organisation or
+    authentication. Custom domains are looked up for the configured
+    organisation - CLOUDSMITH_ORG, or ``oidc_org`` in ``config.ini`` - and
+    omitted when none is configured.
+
+    Output (stdout):
+        JSON: {"version": 1, "domains": [{"host": ..., "format": ...,
+        "backend_kind": ..., "enabled": ..., "validated": ..., "type": ...}]}
+
+    Examples:
+
+    \b
+        # List the built-in hosts
+        $ cloudsmith credential-helper domains
+
+    \b
+        # List built-in hosts plus an organisation's custom domains
+        $ CLOUDSMITH_ORG=my-org cloudsmith credential-helper domains
+    """
+    if untrusted_config_declares_domains():
+        click.secho(
+            "Warning: ignoring [domains] section in ./config.ini -- config.ini "
+            "in the current directory is untrusted. Put it in "
+            f"{get_default_config_path()} or ~/.cloudsmith instead.",
+            fg="yellow",
+            err=True,
+        )
+
+    explicit_config = ctx.meta.get("config_file")
+    if explicit_config and os.path.isdir(explicit_config):
+        explicit_config = os.path.join(explicit_config, "config.ini")
+
+    data = [
+        {
+            "host": domain.host,
+            "format": domain.format_label,
+            "backend_kind": domain.backend_kind,
+            "enabled": True,
+            "validated": True,
+            "type": "default",
+        }
+        for domain in load_default_domains(config_path=explicit_config)
+    ]
+
+    org = opts.oidc_org
+    if org:
+        api_key = opts.credential.api_key if opts.credential else None
+        auth_type = (
+            getattr(opts.credential, "auth_type", "api_key")
+            if opts.credential
+            else "api_key"
+        )
+
+        try:
+            records = get_custom_domains(
+                org,
+                api_key=api_key,
+                auth_type=auth_type,
+                api_host=opts.api_host,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            raise click.ClickException(
+                f"Failed to fetch custom domains for {org!r}: {exc}"
+            ) from exc
+
+        data.extend(
+            {
+                "host": record.host,
+                "format": format_name(record.backend_kind),
+                "backend_kind": record.backend_kind,
+                "enabled": record.enabled,
+                "validated": record.validated,
+                "type": "custom",
+            }
+            for record in sorted(records, key=lambda record: record.host)
+        )
+
+    click.echo(json.dumps({"version": PROTOCOL_VERSION, "domains": data}))

--- a/cloudsmith_cli/cli/commands/credential_helper/generic.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/generic.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Cloudsmith Ltd
+"""
+Generic credential helper command.
+
+Emits a versioned JSON credential document.
+"""
+
+import sys
+
+import click
+
+from ....credential_helpers.generic import execute
+from ...decorators import common_api_auth_options, resolve_credentials
+
+
+@click.command()
+@common_api_auth_options
+@resolve_credentials
+def generic(opts):
+    """
+    Emit a Cloudsmith credential as JSON.
+
+    Resolves a credential through the full provider chain and writes a
+    versioned JSON document to stdout.  Takes no arguments: a Cloudsmith token
+    is organisation-wide, so the host it will be used against does not change
+    which credential resolves.  Use ``cloudsmith credential-helper domains`` to
+    discover which hosts Cloudsmith can authenticate.
+
+    Output (stdout):
+        JSON: {"version": 1, "username": "token", "password": "<token>"}
+
+    Exit codes:
+        0: Success
+        1: No credential could be resolved
+
+    Examples:
+        # Resolve a credential
+        $ cloudsmith credential-helper generic
+
+        # Extract just the token
+        $ cloudsmith credential-helper generic | jq -r .password
+
+    Environment variables:
+        CLOUDSMITH_API_KEY: API key for authentication (optional)
+    """
+    exit_code, stdout, stderr = execute(credential=opts.credential)
+
+    if stdout is not None:
+        click.echo(stdout)
+    if stderr is not None:
+        click.echo(stderr, err=True)
+    sys.exit(exit_code)

--- a/cloudsmith_cli/cli/commands/credential_helper/manage.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/manage.py
@@ -8,12 +8,13 @@ Provides ``credential-helper install``, ``credential-helper uninstall``, and
 
 from __future__ import annotations
 
-import os
 import sys
 
 import click
 
 from ....credential_helpers.docker.installer import DockerInstaller
+from ....credential_helpers.maven.installer import MavenInstaller
+from ....credential_helpers.shellplugin.config import DEFAULT_REGISTRY_ID
 from ... import utils
 from ...decorators import (
     common_api_auth_options,
@@ -28,6 +29,7 @@ from ...decorators import (
 
 _INSTALLERS: dict[str, type] = {
     "docker": DockerInstaller,
+    "maven": MavenInstaller,
 }
 
 
@@ -86,7 +88,7 @@ def _get_installer(name: str):
     "--no-discover",
     is_flag=True,
     default=False,
-    help="Disable automatic discovery of custom Docker domains.",
+    help="Disable automatic discovery of custom domains.",
 )
 @click.option(
     "--refresh",
@@ -97,7 +99,21 @@ def _get_installer(name: str):
 @click.option(
     "--org",
     default=None,
-    help="Cloudsmith organisation slug for custom-domain discovery.",
+    envvar="CLOUDSMITH_ORG",
+    help="Cloudsmith organisation slug.",
+)
+@click.option(
+    "--repo",
+    default=None,
+    envvar="CLOUDSMITH_REPO",
+    help="Cloudsmith repository slug.",
+)
+@click.option(
+    "--registry-id",
+    default=DEFAULT_REGISTRY_ID,
+    show_default=True,
+    help="Id the credentials are registered under in your project config "
+    "(e.g. the Maven settings.xml/pom.xml <server> id).",
 )
 @common_cli_config_options
 @common_cli_output_options
@@ -114,6 +130,8 @@ def install_cmd(
     no_discover: bool,
     refresh: bool,
     org: str | None,
+    repo: str | None,
+    registry_id: str,
 ) -> None:
     """Install a credential helper launcher and configure the package manager.
 
@@ -138,16 +156,29 @@ def install_cmd(
         $ cloudsmith credential-helper install docker --no-discover
     """
     installer = _get_installer(helper)
-    org = org or os.environ.get("CLOUDSMITH_ORG", "").strip() or None
     api_key = opts.credential.api_key if opts.credential else None
     auth_type = (
         getattr(opts.credential, "auth_type", "api_key")
         if opts.credential
         else "api_key"
     )
+
+    per_repo = getattr(installer, "requires_repo", False)
+    if per_repo and not repo:
+        click.echo(
+            f"Error: helper {helper!r} requires --repo (and --org).",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Shell plugins (per-repo) keep their shims in a fixed dir; --bin-dir only
+    # applies to launcher-based helpers like Docker.
+    if per_repo:
+        extra: dict = {"repo": repo, "registry_id": registry_id}
+    else:
+        extra = {"bin_dir": bin_dir}
     try:
         actions = installer.install(
-            bin_dir=bin_dir,
             domains=domains,
             dry_run=dry_run,
             discover=not no_discover,
@@ -156,6 +187,7 @@ def install_cmd(
             api_key=api_key,
             auth_type=auth_type,
             api_host=opts.api_host,
+            **extra,
         )
     except OSError as exc:
         raise click.ClickException(
@@ -217,8 +249,9 @@ def uninstall_cmd(ctx, opts, helper: str, bin_dir: str | None, dry_run: bool) ->
         $ cloudsmith credential-helper uninstall docker --dry-run
     """
     installer = _get_installer(helper)
+    extra = {} if getattr(installer, "requires_repo", False) else {"bin_dir": bin_dir}
     try:
-        actions = installer.uninstall(bin_dir=bin_dir, dry_run=dry_run)
+        actions = installer.uninstall(dry_run=dry_run, **extra)
     except OSError as exc:
         raise click.ClickException(
             f"Failed to uninstall {helper!r} credential helper: {exc}"

--- a/cloudsmith_cli/cli/commands/credential_helper/manage.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/manage.py
@@ -164,9 +164,9 @@ def install_cmd(
     )
 
     per_repo = getattr(installer, "requires_repo", False)
-    if per_repo and not repo:
+    if per_repo and not (org and repo):
         click.echo(
-            f"Error: helper {helper!r} requires --repo (and --org).",
+            f"Error: helper {helper!r} requires --org and --repo.",
             err=True,
         )
         sys.exit(1)

--- a/cloudsmith_cli/cli/commands/credential_helper/shell.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/shell.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Cloudsmith Ltd
+"""``cloudsmith credential-helper shell-init`` — print shell init for shims.
+
+Add ``eval "$(cloudsmith credential-helper shell-init)"`` to your shell rc file
+to put the Cloudsmith shims directory ahead of the real package-manager
+binaries on ``$PATH``.
+"""
+
+import click
+
+from ....credential_helpers.shellplugin.shellinit import detect_shell, generate_init
+
+
+@click.command(name="shell-init")
+@click.option(
+    "--shell",
+    "shell_name",
+    type=click.Choice(["bash", "zsh", "fish"]),
+    default=None,
+    help="Target shell. Auto-detected from $SHELL when omitted.",
+)
+def shell_init(shell_name):
+    """Print shell init that puts the Cloudsmith shims dir first on PATH.
+
+    Examples:
+
+    \b
+        # bash / zsh
+        $ eval "$(cloudsmith credential-helper shell-init)"
+
+    \b
+        # fish
+        $ cloudsmith credential-helper shell-init --shell fish | source
+    """
+    shell = shell_name or detect_shell()
+    click.echo(generate_init(shell), nl=False)

--- a/cloudsmith_cli/cli/commands/exec_.py
+++ b/cloudsmith_cli/cli/commands/exec_.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Cloudsmith Ltd
+"""CLI/Commands - Run a command with Cloudsmith credentials provisioned."""
+
+import sys
+
+import click
+
+from ...credential_helpers.shellplugin import runner
+from ..decorators import common_api_auth_options, resolve_credentials
+from .main import main
+
+
+@main.command(name="exec", context_settings={"ignore_unknown_options": True})
+@click.option(
+    "--org", default=None, envvar="CLOUDSMITH_ORG", help="Cloudsmith organisation slug."
+)
+@click.option(
+    "--repo", default=None, envvar="CLOUDSMITH_REPO", help="Cloudsmith repository slug."
+)
+@click.argument("command", nargs=-1, type=click.UNPROCESSED, required=True)
+@common_api_auth_options
+@resolve_credentials
+def exec_(opts, org, repo, command):
+    """Run a package-manager command authenticated against Cloudsmith.
+
+    Wraps the command so it resolves dependencies from (and publishes to) your
+    Cloudsmith repository, with credentials injected for that single run and
+    cleaned up afterwards. The package manager is detected automatically from
+    the command, so just put it after ``--``:
+
+    \b
+        $ cloudsmith exec -- mvn clean deploy
+    """
+    exit_code = runner.run(
+        list(command),
+        credential=opts.credential,
+        owner=org,
+        repo=repo,
+        api_host=opts.api_host,
+    )
+    sys.exit(exit_code)

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_domains.py
@@ -1,0 +1,270 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the `cloudsmith credential-helper domains` command."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ....cli import config as cli_config
+from ....cli.commands.credential_helper.domains import domains_cmd, format_name
+from ....credential_helpers import default_domains
+from ....credential_helpers.custom_domains import CustomDomain
+
+_PATCH_TARGET = (
+    "cloudsmith_cli.cli.commands.credential_helper.domains.get_custom_domains"
+)
+
+HERMETIC_ARGS = ["--api-key", "fake-api-key"]
+
+
+@pytest.fixture(autouse=True)
+def hermetic_environment(monkeypatch):
+    """Keep the developer's real environment out of these tests.
+
+    An inherited CLOUDSMITH_ORG would trigger a live custom-domain lookup, an
+    inherited CLOUDSMITH_CONFIG_FILE would supply a foreign domain table, and a
+    [domains] section in the developer's real trusted config.ini would replace
+    the built-in hosts these tests assert on. The CLI's Options object is a
+    process-wide thread-local and ConfigReader.load_config permanently
+    prepends any explicit --config-file to class-level state, so both are
+    pinned per test to stop one test's organisation leaking into the next.
+    """
+    monkeypatch.delenv("CLOUDSMITH_ORG", raising=False)
+    monkeypatch.delenv("CLOUDSMITH_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(default_domains, "_trusted_config_path", lambda: None)
+    monkeypatch.delattr(cli_config.OPTIONS, "value", raising=False)
+    monkeypatch.setattr(cli_config.ConfigReader, "config_files", ["config.ini"])
+    monkeypatch.setattr(cli_config.ConfigReader, "config_searchpath", ["."])
+
+
+def _domain(host, backend_kind, enabled=True, validated=True):
+    """Build a CustomDomain record for a test."""
+    return CustomDomain(
+        host=host,
+        backend_kind=backend_kind,
+        enabled=enabled,
+        validated=validated,
+    )
+
+
+@pytest.mark.parametrize(
+    "backend_kind,expected",
+    [
+        (3, "python"),
+        (4, "maven"),
+        (6, "docker"),
+        (9, "npm"),
+        # Download-CDN domains carry no backend kind.
+        (None, "-"),
+        # BackendKind is a hand-maintained mirror of the server enum; a value
+        # the CLI does not know must render, not crash.
+        (9999, "9999"),
+    ],
+)
+def test_format_name(backend_kind, expected):
+    """backend_kind maps to a lowercased format name, with safe fallbacks."""
+    assert format_name(backend_kind) == expected
+
+
+def test_document_has_exactly_version_and_domains_keys(runner):
+    """The top-level document has exactly the keys `version` and `domains`."""
+    with patch(_PATCH_TARGET, return_value=[]):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    assert set(document.keys()) == {"version", "domains"}
+    assert document["version"] == 1
+
+
+def test_lists_domains_with_format_names(runner, monkeypatch):
+    """Each domain appears with its host and resolved package format."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("pypi.acme.example.com", 3),
+        _domain("dl.acme.example.com", None),
+    ]
+
+    with patch(_PATCH_TARGET, return_value=records):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    by_host = {entry["host"]: entry for entry in document["domains"]}
+    assert by_host["pypi.acme.example.com"]["format"] == "python"
+    assert by_host["dl.acme.example.com"]["format"] == "-"
+
+
+def test_disabled_and_unvalidated_domains_are_listed(runner, monkeypatch):
+    """A domain that is not usable is still present, with its state intact."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("stale.acme.example.com", 3, enabled=False, validated=False),
+        _domain("healthy.acme.example.com", 3, enabled=True, validated=True),
+    ]
+
+    with patch(_PATCH_TARGET, return_value=records):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    by_host = {entry["host"]: entry for entry in document["domains"]}
+    assert by_host["stale.acme.example.com"]["enabled"] is False
+    assert by_host["stale.acme.example.com"]["validated"] is False
+    assert by_host["healthy.acme.example.com"]["enabled"] is True
+    assert by_host["healthy.acme.example.com"]["validated"] is True
+
+
+def test_org_with_zero_custom_domains_yields_only_defaults(runner, monkeypatch):
+    """An org with zero custom domains yields just the defaults."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    with patch(_PATCH_TARGET, return_value=[]):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    assert document["version"] == 1
+    hosts = {entry["host"] for entry in document["domains"]}
+    assert "python.cloudsmith.io" in hosts
+    assert all(entry["type"] == "default" for entry in document["domains"])
+
+
+def test_custom_entry_has_exact_key_set(runner, monkeypatch):
+    """A custom entry's full key set is exactly the six expected fields."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    with patch(_PATCH_TARGET, return_value=[_domain("pypi.acme.example.com", 3)]):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    custom_entries = [
+        entry for entry in document["domains"] if entry["type"] == "custom"
+    ]
+    assert custom_entries == [
+        {
+            "host": "pypi.acme.example.com",
+            "format": "python",
+            "backend_kind": 3,
+            "enabled": True,
+            "validated": True,
+            "type": "custom",
+        }
+    ]
+
+
+def test_org_resolves_from_environment(runner, monkeypatch):
+    """CLOUDSMITH_ORG selects the organisation whose custom domains are listed."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme-from-env")
+
+    with patch(_PATCH_TARGET, return_value=[]) as mock_get:
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert mock_get.call_args.args[0] == "acme-from-env"
+
+
+def test_org_resolves_from_config_file(runner, tmp_path):
+    """oidc_org in a trusted config.ini selects the organisation."""
+    config = tmp_path / "config.ini"
+    config.write_text("[default]\noidc_org = acme-from-config\n", encoding="utf-8")
+
+    with patch(_PATCH_TARGET, return_value=[]) as mock_get:
+        result = runner.invoke(
+            domains_cmd,
+            ["--config-file", str(config), *HERMETIC_ARGS],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert mock_get.call_args.args[0] == "acme-from-config"
+
+
+def test_without_org_no_custom_domain_lookup(runner):
+    """With no organisation configured, no custom-domain lookup is attempted."""
+    with patch(_PATCH_TARGET, return_value=[]) as mock_get:
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    mock_get.assert_not_called()
+
+
+def test_network_error_handling(runner, monkeypatch):
+    """Network errors from get_custom_domains propagate as clear ClickException."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    network_error = ConnectionError("DNS resolution failed")
+
+    with patch(_PATCH_TARGET, side_effect=network_error):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "Failed to fetch custom domains for 'acme'" in result.stderr
+    assert "DNS resolution failed" in result.stderr
+    # Ensure no raw traceback in output
+    assert "Traceback" not in result.output
+
+
+def test_defaults_are_listed_alongside_custom_domains(runner, monkeypatch):
+    """Built-in hosts and custom domains appear in one document, typed."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    with patch(_PATCH_TARGET, return_value=[_domain("pypi.acme.example.com", 3)]):
+        result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    by_host = {entry["host"]: entry for entry in document["domains"]}
+    assert by_host["python.cloudsmith.io"]["type"] == "default"
+    assert by_host["pypi.acme.example.com"]["type"] == "custom"
+
+
+def test_defaults_listed_without_org(runner):
+    """Defaults need no org, so the command works unauthenticated."""
+    result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    hosts = {entry["host"] for entry in document["domains"]}
+    assert "python.cloudsmith.io" in hosts
+
+
+def test_explicit_config_file_supplies_default_domains(runner, tmp_path):
+    """An explicit --config-file is a trusted source for [domains]."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[domains]\nindex.internal.example.com = python\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        domains_cmd,
+        ["--config-file", str(config), *HERMETIC_ARGS],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    document = json.loads(result.stdout)
+    hosts = {entry["host"] for entry in document["domains"]}
+    # The built-in table was replaced wholesale, not merged.
+    assert hosts == {"index.internal.example.com"}
+
+
+def test_untrusted_config_warning_does_not_contaminate_stdout(
+    runner, monkeypatch, tmp_path
+):
+    """A cwd config.ini's [domains] section triggers a stderr-only warning."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.ini").write_text(
+        "[domains]\nindex.internal.example.com = python\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(domains_cmd, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Warning" in result.stderr
+    document = json.loads(result.stdout)
+    assert document["version"] == 1
+    # The untrusted [domains] section was ignored, so built-in hosts remain.
+    hosts = {entry["host"] for entry in document["domains"]}
+    assert "python.cloudsmith.io" in hosts

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_generic.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_generic.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the `cloudsmith credential-helper generic` command."""
+
+import json
+from unittest.mock import patch
+
+from ....cli.commands.credential_helper.generic import generic
+from ....core.credentials.models import CredentialResult
+from ....credential_helpers.generic import _REFUSAL_MESSAGE, PROTOCOL_VERSION, execute
+
+TOKEN = "k_secret_token_value"
+
+HERMETIC_ARGS = ["--api-key", "fake-api-key"]
+
+
+def test_execute_success_returns_versioned_document():
+    """A resolved credential produces the exact version-1 contract."""
+    credential = CredentialResult(api_key=TOKEN, source_name="env")
+
+    code, stdout, stderr = execute(credential=credential)
+
+    assert code == 0
+    assert stderr is None
+    assert json.loads(stdout) == {
+        "version": PROTOCOL_VERSION,
+        "username": "token",
+        "password": TOKEN,
+    }
+
+
+def test_execute_document_has_no_extra_keys():
+    """Consumers pin on the contract - no undeclared keys may leak in."""
+    credential = CredentialResult(api_key=TOKEN, source_name="env")
+
+    _, stdout, _ = execute(credential=credential)
+
+    assert set(json.loads(stdout)) == {"version", "username", "password"}
+
+
+def test_execute_no_credential_refuses():
+    """No credential -> exit 1, message on stderr, nothing on stdout."""
+    code, stdout, stderr = execute(credential=None)
+
+    assert code == 1
+    assert stdout is None
+    assert "Unable to retrieve credentials" in stderr
+
+
+def test_execute_empty_api_key_refuses():
+    """An empty api_key is not a usable credential."""
+    credential = CredentialResult(api_key="", source_name="env")
+
+    code, stdout, stderr = execute(credential=credential)
+
+    assert code == 1
+    assert stdout is None
+    assert stderr == _REFUSAL_MESSAGE
+
+
+def test_execute_degrades_on_unexpected_exception():
+    """A raising credential degrades to a clean refusal, never a traceback."""
+
+    class ExplodingCredential:
+        """Stands in for any object whose attribute access misbehaves."""
+
+        @property
+        def api_key(self):
+            raise RuntimeError("boom")
+
+    code, stdout, stderr = execute(credential=ExplodingCredential())
+
+    assert code == 1
+    assert stdout is None
+    assert stderr == _REFUSAL_MESSAGE
+
+
+def test_token_only_ever_appears_on_stdout():
+    """The secret must never be written to stderr."""
+    credential = CredentialResult(api_key=TOKEN, source_name="env")
+
+    _, stdout, stderr = execute(credential=credential)
+
+    assert TOKEN in stdout
+    assert stderr is None
+
+
+def test_cli_emits_bare_contract_on_stdout(runner):
+    """The command echoes execute()'s stdout verbatim, with nothing on stderr."""
+    document = json.dumps(
+        {"version": PROTOCOL_VERSION, "username": "token", "password": TOKEN}
+    )
+
+    with patch(
+        "cloudsmith_cli.cli.commands.credential_helper.generic.execute",
+        return_value=(0, document, None),
+    ):
+        result = runner.invoke(generic, args=HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "version": PROTOCOL_VERSION,
+        "username": "token",
+        "password": TOKEN,
+    }
+    assert result.stderr == ""
+
+
+def test_cli_refusal_exits_1_with_empty_stdout(runner):
+    """A refusal must not emit a partial document on stdout."""
+    with patch(
+        "cloudsmith_cli.cli.commands.credential_helper.generic.execute",
+        return_value=(1, None, _REFUSAL_MESSAGE),
+    ):
+        result = runner.invoke(generic, args=HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Unable to retrieve credentials" in result.stderr

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_maven.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_maven.py
@@ -1,0 +1,841 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the Maven shell-plugin credential helper (config, settings.xml,
+shims, shell-init, runner, installer, and CLI wiring)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ....credential_helpers.shellplugin import config as plugin_config
+
+# ---------------------------------------------------------------------------
+# 1. config — PluginEntry + plugins.json
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _home(tmp_path, monkeypatch):
+    """Point the CLI config dir at a tmp dir so plugins.json/shims land under it."""
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.shellplugin.config.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+    return tmp_path
+
+
+def test_config_path_and_shims_dir_in_config_dir(_home):
+    """config_path() and shims_dir() live in the CLI config directory."""
+    assert plugin_config.config_path() == _home / "package-managers.ini"
+    assert plugin_config.shims_dir() == _home / "shims"
+
+
+def test_load_plugins_missing_file_returns_empty(_home):
+    """load_plugins() returns {} when plugins.json does not exist."""
+    assert plugin_config.load_plugins() == {}
+
+
+def test_set_then_get_plugin_roundtrip(_home):
+    """set_plugin persists every field; get_plugin reads it back."""
+    entry = plugin_config.PluginEntry(
+        owner="acme",
+        repo="prod",
+        api_host="https://api.cloudsmith.io",
+        cdn_host="dl.cloudsmith.io",
+        upload_host="maven.cloudsmith.io",
+        registry_id="cloudsmith",
+    )
+    plugin_config.set_plugin("maven", entry)
+
+    loaded = plugin_config.get_plugin("maven")
+    assert loaded == entry
+    # Persisted on disk as an INI section in the CLI config dir.
+    text = plugin_config.config_path().read_text(encoding="utf-8")
+    assert "[package-manager:maven]" in text
+    assert "owner = acme" in text
+    assert "cdn_host = dl.cloudsmith.io" in text
+
+
+def test_get_plugin_absent_returns_none(_home):
+    """get_plugin returns None for a format with no entry."""
+    assert plugin_config.get_plugin("maven") is None
+
+
+def test_remove_plugin(_home):
+    """remove_plugin deletes the entry (True), and is a no-op (False) afterwards."""
+    plugin_config.set_plugin(
+        "maven",
+        plugin_config.PluginEntry(
+            owner="acme",
+            repo="prod",
+            api_host="https://api.cloudsmith.io",
+            cdn_host="dl.cloudsmith.io",
+            upload_host="maven.cloudsmith.io",
+            registry_id="cloudsmith",
+        ),
+    )
+    assert plugin_config.remove_plugin("maven") is True
+    assert plugin_config.get_plugin("maven") is None
+    assert plugin_config.remove_plugin("maven") is False
+
+
+def test_plugin_entry_from_dict_tolerates_missing_optionals(_home):
+    """PluginEntry.from_dict fills defaults for absent host/registry_id keys."""
+    entry = plugin_config.PluginEntry.from_dict({"owner": "acme", "repo": "prod"})
+    assert entry.owner == "acme"
+    assert entry.repo == "prod"
+    assert entry.cdn_host == "dl.cloudsmith.io"
+    assert entry.upload_host == "maven.cloudsmith.io"
+    assert entry.registry_id == "cloudsmith"
+
+
+# ---------------------------------------------------------------------------
+# 2. maven.build_settings_xml + MavenPlugin
+# ---------------------------------------------------------------------------
+
+
+def test_build_settings_xml_server_and_active_profile():
+    """settings.xml carries one <server> + an active download <profile>."""
+    from ....credential_helpers.shellplugin.maven import build_settings_xml
+
+    xml = build_settings_xml(
+        owner="acme",
+        repo="prod",
+        token="k_abc",
+        cdn_host="dl.cloudsmith.io",
+        server_id="cloudsmith",
+    )
+
+    assert "<id>cloudsmith</id>" in xml
+    assert "<username>token</username>" in xml
+    assert "<password>k_abc</password>" in xml
+    # Download repository + plugin repository point at the CDN basic endpoint.
+    assert "https://dl.cloudsmith.io/basic/acme/prod/maven/" in xml
+    assert "<repository>" in xml
+    assert "<pluginRepository>" in xml
+    # Profile is active by default.
+    assert "<activeProfile>cloudsmith</activeProfile>" in xml
+
+
+def test_build_settings_xml_custom_cdn_host_is_org_scoped():
+    """A custom download domain is org-scoped: the <org> segment is dropped."""
+    from ....credential_helpers.shellplugin.maven import build_settings_xml
+
+    xml = build_settings_xml(
+        owner="acme",
+        repo="prod",
+        token="k_abc",
+        cdn_host="dl.acme.example.com",
+        server_id="my-cs",
+    )
+    # Custom domain → /basic/<repo>/maven/ (no <org>); default keeps the org.
+    assert "https://dl.acme.example.com/basic/prod/maven/" in xml
+    assert "/basic/acme/prod/maven/" not in xml
+    assert "<id>my-cs</id>" in xml
+    assert "<activeProfile>my-cs</activeProfile>" in xml
+
+
+def test_repo_path_segment_org_scoping():
+    """Standard hosts keep <owner>/<repo>; custom domains drop the org."""
+    from ....credential_helpers.common import (
+        is_standard_cloudsmith_host,
+        repo_path_segment,
+    )
+
+    assert is_standard_cloudsmith_host("dl.cloudsmith.io") is True
+    assert is_standard_cloudsmith_host("maven.cloudsmith.com") is True
+    assert is_standard_cloudsmith_host("dl-prod.iduffy.cloudsmith.sh") is False
+
+    assert repo_path_segment("acme", "prod", "dl.cloudsmith.io") == "acme/prod"
+    assert repo_path_segment("acme", "prod", "dl-prod.iduffy.example.sh") == "prod"
+
+
+def test_maven_download_url_default_keeps_org_custom_drops_it():
+    """download_url keeps <org> for dl.cloudsmith.io, drops it for custom domains."""
+    from ....credential_helpers.shellplugin.maven import download_url
+
+    assert (
+        download_url("acme", "prod", "dl.cloudsmith.io")
+        == "https://dl.cloudsmith.io/basic/acme/prod/maven/"
+    )
+    assert (
+        download_url("acme", "prod", "dl.acme.example.com")
+        == "https://dl.acme.example.com/basic/prod/maven/"
+    )
+
+
+def test_maven_upload_url_default_keeps_org_custom_drops_it():
+    """upload_url keeps <org> for maven.cloudsmith.io, drops it for custom domains."""
+    from ....credential_helpers.shellplugin.maven import upload_url
+
+    assert (
+        upload_url("acme", "prod", "maven.cloudsmith.io")
+        == "https://maven.cloudsmith.io/acme/prod/"
+    )
+    assert (
+        upload_url("acme", "prod", "maven.acme.example.com")
+        == "https://maven.acme.example.com/prod/"
+    )
+
+
+def test_build_settings_xml_escapes_token():
+    """A token with XML metacharacters is escaped in the password element."""
+    from ....credential_helpers.shellplugin.maven import build_settings_xml
+
+    xml = build_settings_xml(
+        owner="acme",
+        repo="prod",
+        token="a<b&c",
+        cdn_host="dl.cloudsmith.io",
+        server_id="cloudsmith",
+    )
+    assert "<password>a&lt;b&amp;c</password>" in xml
+    assert "a<b&c" not in xml
+
+
+def test_maven_plugin_identity_and_skip_auth():
+    """MavenPlugin exposes name/binary_name and skips auth for help/version."""
+    from ....credential_helpers.shellplugin.maven import MavenPlugin
+
+    plugin = MavenPlugin()
+    assert plugin.name == "maven"
+    assert plugin.binary_name == "mvn"
+    assert "--version" in plugin.skip_auth_args()
+    assert "--help" in plugin.skip_auth_args()
+
+
+def test_maven_plugin_provision_writes_settings_and_prepends_s():
+    """provision() writes a 0600 settings.xml and returns ['-s', path]."""
+    import stat
+
+    from ....credential_helpers.shellplugin.maven import MavenPlugin, build_settings_xml
+
+    entry = plugin_config.PluginEntry(
+        owner="acme",
+        repo="prod",
+        api_host="https://api.cloudsmith.io",
+        cdn_host="dl.cloudsmith.io",
+        upload_host="maven.cloudsmith.io",
+        registry_id="cloudsmith",
+    )
+    result = MavenPlugin().provision(entry, token="k_abc", args=["install"])
+
+    assert result.prepend_args[0] == "-s"
+    settings_path = Path(result.prepend_args[1])
+    assert settings_path.exists()
+    assert settings_path.read_text(encoding="utf-8") == build_settings_xml(
+        owner="acme",
+        repo="prod",
+        token="k_abc",
+        cdn_host="dl.cloudsmith.io",
+        server_id="cloudsmith",
+    )
+    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o600
+    assert result.temp_dirs == [str(settings_path.parent)]
+    assert not result.env
+
+
+# ---------------------------------------------------------------------------
+# 3. shims — write_shim / remove_shim
+# ---------------------------------------------------------------------------
+
+
+def test_write_shim_execs_the_exec_command(tmp_path):
+    """write_shim writes an executable that re-execs `credential-helper exec`."""
+    import stat
+
+    from ....credential_helpers.shellplugin.shims import write_shim
+
+    dest = write_shim(tmp_path, "mvn")
+    assert dest == tmp_path / "mvn"
+    assert (
+        dest.read_text(encoding="utf-8")
+        == '#!/bin/sh\nexec cloudsmith exec -- mvn "$@"\n'
+    )
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o755
+
+
+def test_remove_shim(tmp_path):
+    """remove_shim returns True when present, False when already gone."""
+    from ....credential_helpers.shellplugin.shims import remove_shim, write_shim
+
+    write_shim(tmp_path, "mvn")
+    assert remove_shim(tmp_path, "mvn") is True
+    assert not (tmp_path / "mvn").exists()
+    assert remove_shim(tmp_path, "mvn") is False
+
+
+# ---------------------------------------------------------------------------
+# 4. shellinit — generate_init / detect_shell
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh"])
+def test_generate_init_posix_prepends_shims_dir(_home, shell):
+    """bash/zsh init prepends the shims dir to PATH."""
+    from ....credential_helpers.shellplugin import config
+    from ....credential_helpers.shellplugin.shellinit import generate_init
+
+    out = generate_init(shell)
+    assert f'export PATH="{config.shims_dir()}:$PATH"' in out
+
+
+def test_generate_init_fish_uses_fish_add_path(_home):
+    """fish init uses fish_add_path, not export PATH."""
+    from ....credential_helpers.shellplugin import config
+    from ....credential_helpers.shellplugin.shellinit import generate_init
+
+    out = generate_init("fish")
+    assert f'fish_add_path "{config.shims_dir()}"' in out
+    assert "export PATH" not in out
+
+
+def test_generate_init_unknown_shell_raises():
+    """An unsupported shell name is a clear error."""
+    from ....credential_helpers.shellplugin.shellinit import generate_init
+
+    with pytest.raises(ValueError):
+        generate_init("powershell")
+
+
+@pytest.mark.parametrize(
+    "shell_env,expected",
+    [
+        ("/bin/zsh", "zsh"),
+        ("/usr/bin/fish", "fish"),
+        ("/bin/bash", "bash"),
+        ("", "bash"),
+    ],
+)
+def test_detect_shell(monkeypatch, shell_env, expected):
+    """detect_shell maps $SHELL to a supported shell, defaulting to bash."""
+    from ....credential_helpers.shellplugin.shellinit import detect_shell
+
+    monkeypatch.setenv("SHELL", shell_env)
+    assert detect_shell() == expected
+
+
+# ---------------------------------------------------------------------------
+# 5. runner — resolve_real_binary + run
+# ---------------------------------------------------------------------------
+
+
+def _make_executable(directory: Path, name: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_resolve_real_binary_skips_excluded_dir(tmp_path, monkeypatch):
+    """resolve_real_binary skips the shims dir and finds the real binary."""
+    from ....credential_helpers.shellplugin.runner import resolve_real_binary
+
+    shims = tmp_path / "shims"
+    real = tmp_path / "real"
+    _make_executable(shims, "mvn")
+    real_mvn = _make_executable(real, "mvn")
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shims), str(real)]))
+
+    resolved = resolve_real_binary("mvn", exclude_dirs=[str(shims)])
+    assert resolved == str(real_mvn)
+
+
+def test_resolve_real_binary_none_when_only_excluded(tmp_path, monkeypatch):
+    """resolve_real_binary returns None when the only match is excluded."""
+    from ....credential_helpers.shellplugin.runner import resolve_real_binary
+
+    shims = tmp_path / "shims"
+    _make_executable(shims, "mvn")
+    monkeypatch.setenv("PATH", str(shims))
+
+    assert resolve_real_binary("mvn", exclude_dirs=[str(shims)]) is None
+
+
+def test_run_skip_auth_passes_through_without_provisioning(_home, monkeypatch):
+    """`mvn --version` execs the real binary directly, no settings.xml."""
+    from ....core.credentials.models import CredentialResult
+    from ....credential_helpers.shellplugin import runner
+
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/mvn")
+    captured = {}
+
+    def _fake_run_process(path, args, env):
+        captured["path"] = path
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(runner, "_run_process", _fake_run_process)
+
+    code = runner.run(
+        ["mvn", "--version"],
+        credential=CredentialResult(api_key="k_abc", source_name="test"),
+        owner="acme",
+        repo="prod",
+    )
+
+    assert code == 0
+    assert captured["path"] == "/usr/bin/mvn"
+    assert captured["args"] == ["--version"]
+    # No temp settings dir left behind.
+    assert not list(_home.glob("**/settings.xml"))
+
+
+def test_run_provisions_prepends_s_and_cleans_up(_home, monkeypatch):
+    """Auth path: provisions settings.xml, prepends -s, cleans up temp dir."""
+    from ....core.credentials.models import CredentialResult
+    from ....credential_helpers.shellplugin import config, runner
+
+    config.set_plugin(
+        "maven",
+        config.PluginEntry(
+            owner="acme",
+            repo="prod",
+            api_host="https://api.cloudsmith.io",
+            cdn_host="dl.cloudsmith.io",
+            upload_host="maven.cloudsmith.io",
+            registry_id="cloudsmith",
+        ),
+    )
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/mvn")
+
+    captured = {}
+
+    def _fake_run_process(path, args, env):
+        captured["path"] = path
+        captured["args"] = args
+        # Settings file must still exist while the child runs.
+        captured["settings_exists"] = Path(args[1]).exists()
+        return 7
+
+    monkeypatch.setattr(runner, "_run_process", _fake_run_process)
+
+    code = runner.run(
+        ["mvn", "install"],
+        credential=CredentialResult(api_key="k_abc", source_name="test"),
+        owner="acme",
+        repo="prod",
+    )
+
+    assert code == 7
+    assert captured["args"][0] == "-s"
+    assert captured["args"][-1] == "install"
+    assert captured["settings_exists"] is True
+    # Temp dir cleaned up after the child exits.
+    assert not Path(captured["args"][1]).exists()
+
+
+def test_run_empty_command_returns_nonzero(_home):
+    """exec with no command is a usage error."""
+    from ....credential_helpers.shellplugin import runner
+
+    assert runner.run([], credential=None) != 0
+
+
+def test_run_unmatched_command_runs_generically(_home, monkeypatch):
+    """A command with no matching plugin runs as-is, with no provisioning."""
+    from ....credential_helpers.shellplugin import runner
+
+    monkeypatch.setattr(
+        runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/whoami"
+    )
+    captured = {}
+
+    def _fake_run_process(path, args, env):
+        captured["path"] = path
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(runner, "_run_process", _fake_run_process)
+
+    code = runner.run(["whoami"], credential=None)
+    assert code == 0
+    assert captured["path"] == "/usr/bin/whoami"
+    assert captured["args"] == []
+    assert not list(_home.glob("**/settings.xml"))
+
+
+def test_run_provision_failure_is_clean_no_traceback(_home, monkeypatch):
+    """A provisioning error returns a non-zero code, not a traceback."""
+    from ....core.credentials.models import CredentialResult
+    from ....credential_helpers.shellplugin import config, plugin, runner
+
+    config.set_plugin("maven", config.PluginEntry(owner="acme", repo="prod"))
+
+    class _BoomPlugin:
+        name = "maven"
+        binary_name = "mvn"
+
+        def skip_auth_args(self):
+            return []
+
+        def provision(self, *_a, **_k):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(plugin, "get_by_binary", lambda _b: _BoomPlugin())
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/mvn")
+
+    code = runner.run(
+        ["mvn", "install"],
+        credential=CredentialResult(api_key="k", source_name="t"),
+    )
+    assert code != 0
+
+
+def test_maven_provision_cleans_temp_dir_on_failure(monkeypatch, tmp_path):
+    """If writing settings.xml fails, provision removes its temp dir and re-raises."""
+    from ....credential_helpers.shellplugin import config, maven
+
+    leak = tmp_path / "leak-dir"
+
+    def _fake_mkdtemp(*_a, **_k):
+        leak.mkdir()
+        return str(leak)
+
+    def _boom(**_k):
+        raise OSError("boom")
+
+    monkeypatch.setattr(maven.tempfile, "mkdtemp", _fake_mkdtemp)
+    monkeypatch.setattr(maven, "build_settings_xml", _boom)
+
+    with pytest.raises(OSError):
+        maven.MavenPlugin().provision(
+            config.PluginEntry(owner="acme", repo="prod"), "tok", []
+        )
+    assert not leak.exists()
+
+
+def test_run_no_token_warns_but_proceeds(_home, monkeypatch):
+    """No credential on an auth path still runs (public repos), with a warning."""
+    from ....credential_helpers.shellplugin import config, runner
+
+    config.set_plugin("maven", config.PluginEntry(owner="acme", repo="prod"))
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/mvn")
+    captured = {}
+
+    def _fake_run_process(path, args, env):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(runner, "_run_process", _fake_run_process)
+
+    code = runner.run(["mvn", "install"], credential=None)
+    assert code == 0
+    assert captured["args"][0] == "-s"
+
+
+def test_run_binary_not_found_returns_nonzero(_home, monkeypatch):
+    """When the real binary cannot be resolved, run returns non-zero."""
+    from ....core.credentials.models import CredentialResult
+    from ....credential_helpers.shellplugin import runner
+
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: None)
+    code = runner.run(
+        ["mvn", "install"],
+        credential=CredentialResult(api_key="k", source_name="t"),
+        owner="acme",
+        repo="prod",
+    )
+    assert code != 0
+
+
+# ---------------------------------------------------------------------------
+# 6. MavenInstaller
+# ---------------------------------------------------------------------------
+
+_INSTALLER_GET_CUSTOM_DOMAINS = (
+    "cloudsmith_cli.credential_helpers.maven.installer.get_custom_domains"
+)
+
+
+def _fake_discovery(monkeypatch, *, cdn_host=None, upload_host=None, raises=False):
+    """Mock get_custom_domains: CDN domains carry backend_kind None; Maven == MAVEN."""
+    from ....credential_helpers.backends import BackendKind
+    from ....credential_helpers.custom_domains import CustomDomain
+
+    domains = []
+    if cdn_host:
+        domains.append(
+            CustomDomain(host=cdn_host, backend_kind=None, enabled=True, validated=True)
+        )
+    if upload_host:
+        domains.append(
+            CustomDomain(
+                host=upload_host,
+                backend_kind=int(BackendKind.MAVEN),
+                enabled=True,
+                validated=True,
+            )
+        )
+
+    def _fake(org, **_kw):
+        if raises:
+            raise RuntimeError("network down")
+        return domains
+
+    monkeypatch.setattr(_INSTALLER_GET_CUSTOM_DOMAINS, _fake)
+
+
+def test_maven_install_discovers_both_hosts_and_persists(_home, monkeypatch):
+    """install writes the shim and persists discovered CDN + upload hosts."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    _fake_discovery(monkeypatch, cdn_host="dl.acme.com", upload_host="maven.acme.com")
+
+    MavenInstaller().install(org="acme", repo="prod", api_key="k", discover=True)
+
+    assert (config.shims_dir() / "mvn").exists()
+    entry = config.get_plugin("maven")
+    assert entry.owner == "acme"
+    assert entry.repo == "prod"
+    assert entry.cdn_host == "dl.acme.com"
+    assert entry.upload_host == "maven.acme.com"
+    assert entry.registry_id == "cloudsmith"
+
+
+def test_maven_install_defaults_when_no_discovery(_home, monkeypatch):
+    """discover=False keeps the *.cloudsmith.io default hosts."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    MavenInstaller().install(org="acme", repo="prod", discover=False)
+
+    entry = config.get_plugin("maven")
+    assert entry.cdn_host == "dl.cloudsmith.io"
+    assert entry.upload_host == "maven.cloudsmith.io"
+
+
+def test_maven_install_domain_override(_home, monkeypatch):
+    """--domain overrides the discovered/default download CDN host."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    MavenInstaller().install(
+        org="acme", repo="prod", domains=("my.cdn.example.com",), discover=False
+    )
+    assert config.get_plugin("maven").cdn_host == "my.cdn.example.com"
+
+
+def test_maven_install_custom_registry_id(_home, monkeypatch):
+    """--registry-id is persisted for use in settings.xml + pom snippet."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    MavenInstaller().install(
+        org="acme", repo="prod", discover=False, registry_id="my-cs"
+    )
+    assert config.get_plugin("maven").registry_id == "my-cs"
+
+
+def test_maven_install_prints_distribution_management_snippet(_home, monkeypatch):
+    """install surfaces a distributionManagement snippet for opt-in deploy."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    actions = MavenInstaller().install(org="acme", repo="prod", discover=False)
+
+    joined = "\n".join(actions)
+    assert "distributionManagement" in joined
+    assert "https://maven.cloudsmith.io/acme/prod/" in joined
+    assert "<id>cloudsmith</id>" in joined
+
+
+def test_maven_install_snippet_custom_upload_domain_drops_org(_home, monkeypatch):
+    """With a custom upload domain, the deploy snippet URL is org-scoped."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    _fake_discovery(monkeypatch, upload_host="maven.acme.example.com")
+
+    actions = MavenInstaller().install(
+        org="acme", repo="prod", api_key="k", discover=True
+    )
+    joined = "\n".join(actions)
+    assert "https://maven.acme.example.com/prod/" in joined
+    assert "maven.acme.example.com/acme/prod/" not in joined
+
+
+def test_maven_install_dry_run_writes_nothing(_home, monkeypatch):
+    """dry_run: no shim, no plugins.json entry, returns 'would' actions."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    actions = MavenInstaller().install(
+        org="acme", repo="prod", discover=False, dry_run=True
+    )
+    assert not (config.shims_dir() / "mvn").exists()
+    assert config.get_plugin("maven") is None
+    assert any("would" in a.lower() for a in actions)
+
+
+def test_maven_install_path_warning(_home, monkeypatch):
+    """A WARNING is returned when the shims dir is not on PATH."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+
+    monkeypatch.setenv("PATH", "/usr/bin:/usr/local/bin")
+    actions = MavenInstaller().install(org="acme", repo="prod", discover=False)
+    warnings = [a for a in actions if a.startswith("WARNING")]
+    assert warnings
+    assert any("PATH" in a for a in warnings)
+
+
+def test_maven_install_discovery_failure_is_graceful(_home, monkeypatch):
+    """Discovery errors degrade to a WARNING; defaults still install."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    _fake_discovery(monkeypatch, raises=True)
+
+    actions = MavenInstaller().install(
+        org="acme", repo="prod", api_key="k", discover=True
+    )
+    assert (config.shims_dir() / "mvn").exists()
+    assert config.get_plugin("maven").cdn_host == "dl.cloudsmith.io"
+    assert any(a.startswith("WARNING") for a in actions)
+
+
+def test_maven_uninstall_removes_shim_and_entry(_home, monkeypatch):
+    """uninstall removes the shim and drops the plugins.json entry."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    installer = MavenInstaller()
+    installer.install(org="acme", repo="prod", discover=False)
+    assert (config.shims_dir() / "mvn").exists()
+
+    installer.uninstall()
+    assert not (config.shims_dir() / "mvn").exists()
+    assert config.get_plugin("maven") is None
+
+
+def test_maven_status_launcher_is_str_or_none(_home, monkeypatch):
+    """status()['launcher'] is None before install and a str afterwards."""
+    from ....credential_helpers.maven.installer import MavenInstaller
+    from ....credential_helpers.shellplugin import config
+
+    monkeypatch.setenv("PATH", str(config.shims_dir()))
+    installer = MavenInstaller()
+
+    assert installer.status()["launcher"] is None
+
+    installer.install(org="acme", repo="prod", discover=False)
+    launcher = installer.status()["launcher"]
+    assert isinstance(launcher, str)
+    assert launcher.endswith("mvn")
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI wiring — exec + shell-init + manage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cli_runner():
+    import click.testing
+
+    return click.testing.CliRunner()
+
+
+def test_exec_cmd_passes_command_through_and_propagates_exit_code(
+    cli_runner, monkeypatch
+):
+    """`cloudsmith exec -- mvn install` calls runner.run([...]) and returns its code."""
+    from ....cli.commands.exec_ import exec_
+    from ....credential_helpers.shellplugin import runner
+
+    captured = {}
+
+    def _fake_run(command, **kwargs):
+        captured["command"] = command
+        return 7
+
+    monkeypatch.setattr(runner, "run", _fake_run)
+
+    result = cli_runner.invoke(exec_, ["--", "mvn", "install", "-DskipTests"])
+    assert result.exit_code == 7
+    assert captured["command"] == ["mvn", "install", "-DskipTests"]
+
+
+def test_shell_init_cmd_explicit_shell(cli_runner, _home):
+    """`shell-init --shell bash` prints the PATH prepend for the shims dir."""
+    from ....cli.commands.credential_helper.shell import shell_init
+    from ....credential_helpers.shellplugin import config
+
+    result = cli_runner.invoke(shell_init, ["--shell", "bash"])
+    assert result.exit_code == 0
+    assert f'export PATH="{config.shims_dir()}:$PATH"' in result.output
+
+
+def test_shell_init_cmd_detects_fish(cli_runner, monkeypatch):
+    """`shell-init` with $SHELL=fish emits fish syntax."""
+    from ....cli.commands.credential_helper.shell import shell_init
+
+    monkeypatch.setenv("SHELL", "/usr/bin/fish")
+    result = cli_runner.invoke(shell_init, [])
+    assert result.exit_code == 0
+    assert "fish_add_path" in result.output
+
+
+def test_manage_list_includes_maven(cli_runner):
+    """`credential-helper list` shows the maven helper."""
+    from ....cli.commands.credential_helper.manage import list_cmd
+
+    result = cli_runner.invoke(list_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert "maven" in result.output
+
+
+def test_manage_install_maven_dry_run(cli_runner, _home):
+    """`install maven --org --repo --no-discover --dry-run` exits 0 with a plan."""
+    from ....cli.commands.credential_helper.manage import install_cmd
+
+    result = cli_runner.invoke(
+        install_cmd,
+        ["maven", "--org", "acme", "--repo", "prod", "--no-discover", "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "would" in result.output.lower() or "dry run" in result.output.lower()
+
+
+def test_manage_install_maven_ignores_bin_dir(cli_runner, _home, tmp_path):
+    """--bin-dir does not apply to shell plugins: the shim lands in the shims dir."""
+    from ....cli.commands.credential_helper.manage import install_cmd
+    from ....credential_helpers.shellplugin import config
+
+    other = tmp_path / "other-bin"
+    result = cli_runner.invoke(
+        install_cmd,
+        [
+            "maven",
+            "--org",
+            "acme",
+            "--repo",
+            "prod",
+            "--no-discover",
+            "--bin-dir",
+            str(other),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (config.shims_dir() / "mvn").exists()
+    assert not (other / "mvn").exists()
+
+
+def test_manage_install_maven_requires_repo(cli_runner, _home):
+    """Installing maven without --repo fails clearly."""
+    from ....cli.commands.credential_helper.manage import install_cmd
+
+    result = cli_runner.invoke(install_cmd, ["maven", "--org", "acme", "--no-discover"])
+    assert result.exit_code != 0

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_maven.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_maven.py
@@ -12,13 +12,13 @@ import pytest
 from ....credential_helpers.shellplugin import config as plugin_config
 
 # ---------------------------------------------------------------------------
-# 1. config — PluginEntry + plugins.json
+# 1. config — PluginEntry + package-managers.ini
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
 def _home(tmp_path, monkeypatch):
-    """Point the CLI config dir at a tmp dir so plugins.json/shims land under it."""
+    """Point the CLI config dir at a tmp dir so package-managers.ini/shims land under it."""
     monkeypatch.setattr(
         "cloudsmith_cli.credential_helpers.shellplugin.config.get_default_config_path",
         lambda: str(tmp_path),
@@ -33,7 +33,7 @@ def test_config_path_and_shims_dir_in_config_dir(_home):
 
 
 def test_load_plugins_missing_file_returns_empty(_home):
-    """load_plugins() returns {} when plugins.json does not exist."""
+    """load_plugins() returns {} when package-managers.ini does not exist."""
     assert plugin_config.load_plugins() == {}
 
 
@@ -527,6 +527,32 @@ def test_run_no_token_warns_but_proceeds(_home, monkeypatch):
     assert captured["args"][0] == "-s"
 
 
+def test_run_explicit_org_repo_override_stored_entry(_home, monkeypatch):
+    """Explicit --org/--repo on exec take precedence over the stored binding."""
+    from ....core.credentials.models import CredentialResult
+    from ....credential_helpers.shellplugin import config, runner
+
+    config.set_plugin("maven", config.PluginEntry(owner="acme", repo="prod"))
+    monkeypatch.setattr(runner, "resolve_real_binary", lambda *_a, **_k: "/usr/bin/mvn")
+    captured = {}
+
+    def _fake_run_process(path, args, env):
+        captured["settings"] = Path(args[1]).read_text(encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(runner, "_run_process", _fake_run_process)
+
+    code = runner.run(
+        ["mvn", "install"],
+        credential=CredentialResult(api_key="k", source_name="t"),
+        owner="other",
+        repo="dev",
+    )
+    assert code == 0
+    assert "/basic/other/dev/maven/" in captured["settings"]
+    assert "/basic/acme/prod/maven/" not in captured["settings"]
+
+
 def test_run_binary_not_found_returns_nonzero(_home, monkeypatch):
     """When the real binary cannot be resolved, run returns non-zero."""
     from ....core.credentials.models import CredentialResult
@@ -666,7 +692,7 @@ def test_maven_install_snippet_custom_upload_domain_drops_org(_home, monkeypatch
 
 
 def test_maven_install_dry_run_writes_nothing(_home, monkeypatch):
-    """dry_run: no shim, no plugins.json entry, returns 'would' actions."""
+    """dry_run: no shim, no package-managers.ini entry, returns 'would' actions."""
     from ....credential_helpers.maven.installer import MavenInstaller
     from ....credential_helpers.shellplugin import config
 
@@ -706,7 +732,7 @@ def test_maven_install_discovery_failure_is_graceful(_home, monkeypatch):
 
 
 def test_maven_uninstall_removes_shim_and_entry(_home, monkeypatch):
-    """uninstall removes the shim and drops the plugins.json entry."""
+    """uninstall removes the shim and drops the package-managers.ini entry."""
     from ....credential_helpers.maven.installer import MavenInstaller
     from ....credential_helpers.shellplugin import config
 
@@ -833,9 +859,21 @@ def test_manage_install_maven_ignores_bin_dir(cli_runner, _home, tmp_path):
     assert not (other / "mvn").exists()
 
 
-def test_manage_install_maven_requires_repo(cli_runner, _home):
+def test_manage_install_maven_requires_repo(cli_runner, _home, monkeypatch):
     """Installing maven without --repo fails clearly."""
     from ....cli.commands.credential_helper.manage import install_cmd
 
+    monkeypatch.delenv("CLOUDSMITH_REPO", raising=False)
     result = cli_runner.invoke(install_cmd, ["maven", "--org", "acme", "--no-discover"])
+    assert result.exit_code != 0
+
+
+def test_manage_install_maven_requires_org(cli_runner, _home, monkeypatch):
+    """Installing maven without --org fails clearly (no malformed empty-org URLs)."""
+    from ....cli.commands.credential_helper.manage import install_cmd
+
+    monkeypatch.delenv("CLOUDSMITH_ORG", raising=False)
+    result = cli_runner.invoke(
+        install_cmd, ["maven", "--repo", "prod", "--no-discover"]
+    )
     assert result.exit_code != 0

--- a/cloudsmith_cli/cli/tests/commands/test_default_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_default_domains.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the built-in default domain table and its config override."""
+
+import pytest
+
+from ....credential_helpers.backends import BackendKind
+from ....credential_helpers.default_domains import (
+    BUILTIN_DOMAINS,
+    CDN_HOST,
+    DefaultDomain,
+    builtin_host,
+    load_default_domains,
+    untrusted_config_declares_domains,
+)
+
+
+def _by_host(domains):
+    """Index a list of DefaultDomain records by host."""
+    return {domain.host: domain for domain in domains}
+
+
+def test_builtin_table_has_expected_size():
+    """The built-in table is a fixed, reviewed list."""
+    assert len(BUILTIN_DOMAINS) == 21
+
+
+def test_builtin_table_is_io_only():
+    """Only .io hosts ship; .com mirrors and media/web hosts are excluded."""
+    for domain in BUILTIN_DOMAINS:
+        assert domain.host.endswith(".cloudsmith.io"), domain.host
+
+
+def test_builtin_table_excludes_prd_and_api_hosts():
+    """Internal -prd variants and the API endpoint are not package hosts."""
+    hosts = {domain.host for domain in BUILTIN_DOMAINS}
+    for host in hosts:
+        assert "-prd" not in host
+        assert not host.startswith("api.")
+        assert not host.startswith("api-")
+
+
+@pytest.mark.parametrize(
+    "host,label,kind",
+    [
+        ("python.cloudsmith.io", "python", BackendKind.PYTHON),
+        ("docker.cloudsmith.io", "docker", BackendKind.DOCKER),
+        ("maven.cloudsmith.io", "maven", BackendKind.MAVEN),
+        ("golang.cloudsmith.io", "go", BackendKind.GO),
+        ("helm.oci.cloudsmith.io", "helm", BackendKind.HELM),
+        # Serve every format, so no single BackendKind applies.
+        ("dl.cloudsmith.io", "-", None),
+        ("upload.cloudsmith.io", "-", None),
+        ("nix.cloudsmith.io", "nix", BackendKind.NIX),
+    ],
+)
+def test_builtin_entries_map_to_expected_kinds(host, label, kind):
+    """Each built-in host carries the right label and backend kind."""
+    domain = _by_host(BUILTIN_DOMAINS)[host]
+
+    assert domain.format_label == label
+    assert domain.backend_kind == kind
+
+
+def test_load_returns_builtins_when_no_config(tmp_path):
+    """With no config file present, the built-in table is used."""
+    assert load_default_domains(config_path=tmp_path / "absent.ini") == list(
+        BUILTIN_DOMAINS
+    )
+
+
+def test_config_section_replaces_builtins_wholesale(tmp_path):
+    """A [domains] section replaces the built-in table entirely."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[domains]\n"
+        "packages.internal.example.com = python\n"
+        "cdn.internal.example.com =\n",
+        encoding="utf-8",
+    )
+
+    domains = load_default_domains(config_path=config)
+
+    assert len(domains) == 2
+    indexed = _by_host(domains)
+    assert indexed["packages.internal.example.com"].backend_kind == (BackendKind.PYTHON)
+    assert indexed["packages.internal.example.com"].format_label == "python"
+    # An empty value means "no single format".
+    assert indexed["cdn.internal.example.com"].backend_kind is None
+    assert indexed["cdn.internal.example.com"].format_label == "-"
+
+
+def test_config_label_without_backend_kind_is_preserved(tmp_path):
+    """A label with no matching BackendKind keeps the label, with a None kind."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[domains]\nwidget.internal.example.com = widget\n", encoding="utf-8"
+    )
+
+    domain = _by_host(load_default_domains(config_path=config))[
+        "widget.internal.example.com"
+    ]
+
+    assert domain.format_label == "widget"
+    assert domain.backend_kind is None
+
+
+def test_config_without_domains_section_falls_back_to_builtins(tmp_path):
+    """A config file that has no [domains] section changes nothing."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[default]\napi_host = https://api.cloudsmith.io\n", encoding="utf-8"
+    )
+
+    assert load_default_domains(config_path=config) == list(BUILTIN_DOMAINS)
+
+
+def test_unreadable_config_falls_back_to_builtins(tmp_path):
+    """A malformed config must not break the command."""
+    config = tmp_path / "config.ini"
+    config.write_text("this is not valid ini [[[", encoding="utf-8")
+
+    assert load_default_domains(config_path=config) == list(BUILTIN_DOMAINS)
+
+
+def test_untrusted_cwd_config_is_not_honoured(tmp_path, monkeypatch):
+    """A [domains] section in a cwd config.ini is ignored, and detectable.
+
+    config.ini is searched in the working directory first, so a repository can
+    ship one. Honouring it here would let a malicious repo declare its own host
+    a Cloudsmith host and harvest a token.
+    """
+    monkeypatch.chdir(tmp_path)
+    # Pin the trusted lookup to "nothing found" so the developer's real
+    # config.ini cannot influence what this test observes.
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.default_domains._trusted_config_path",
+        lambda: None,
+    )
+    (tmp_path / "config.ini").write_text(
+        "[domains]\nevil.example.com = python\n", encoding="utf-8"
+    )
+
+    domains = load_default_domains()
+
+    assert all(domain.host != "evil.example.com" for domain in domains)
+    assert untrusted_config_declares_domains() is True
+
+
+def test_untrusted_config_predicate_false_without_section(tmp_path, monkeypatch):
+    """No [domains] section in the cwd config means nothing to warn about."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.ini").write_text("[default]\n", encoding="utf-8")
+
+    assert untrusted_config_declares_domains() is False
+
+
+def test_cdn_host_is_in_builtin_table():
+    """The exported CDN host constant and the table stay in sync."""
+    assert CDN_HOST == "dl.cloudsmith.io"
+    assert any(domain.host == CDN_HOST for domain in BUILTIN_DOMAINS)
+
+
+def test_builtin_host_resolves_backend_kind():
+    """builtin_host maps a backend kind to its built-in service host."""
+    assert builtin_host(BackendKind.MAVEN) == "maven.cloudsmith.io"
+    assert builtin_host(BackendKind.PYTHON) == "python.cloudsmith.io"
+
+
+def test_builtin_host_rejects_kind_without_dedicated_host():
+    """Formats served only via the CDN have no dedicated built-in host."""
+    with pytest.raises(ValueError):
+        builtin_host(BackendKind.DEB)
+
+
+def test_default_domain_is_frozen():
+    """Records are immutable so callers cannot mutate the shared table."""
+    domain = DefaultDomain(
+        host="a.cloudsmith.io", format_label="python", backend_kind=3
+    )
+
+    with pytest.raises(Exception):
+        domain.host = "b.cloudsmith.io"

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -1,5 +1,4 @@
 import html
-import os
 import socket
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -7,6 +6,7 @@ from urllib.parse import parse_qsl, unquote, urlparse
 
 import click
 
+from .. import templates
 from ..core.api.exceptions import ApiException
 from ..core.api.init import initialise_api
 from ..core.credentials.models import CredentialResult
@@ -16,32 +16,12 @@ from .saml import exchange_2fa_token
 
 def get_template_path(template_name):
     """Get the absolute path to a template file."""
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_dir, "templates", template_name)
+    return templates.template_path(template_name)
 
 
 def render_template(template_name, **context):
-    """
-    Render a template with the given context.
-
-    Args:
-        template_name: Name of the template file
-        context: Dictionary of variables to replace in the template
-
-    Returns:
-        Rendered HTML content
-    """
-    template_path = get_template_path(template_name)
-
-    with open(template_path, encoding="utf-8") as file:
-        content = file.read()
-
-    # Replace placeholders with context values
-    for key, value in context.items():
-        placeholder = f"<!-- {key.upper()}_PLACEHOLDER -->"
-        content = content.replace(placeholder, value if value else "")
-
-    return content
+    """Render a template with the given context (see :func:`templates.render`)."""
+    return templates.render(template_name, **context)
 
 
 class AuthenticationWebServer(HTTPServer):

--- a/cloudsmith_cli/credential_helpers/backends.py
+++ b/cloudsmith_cli/credential_helpers/backends.py
@@ -38,4 +38,5 @@ class BackendKind(IntEnum):
     GENERIC = 28
     VSX = 29
     MCP = 30
+    NIX = 31
     DEFAULT = 99

--- a/cloudsmith_cli/credential_helpers/common.py
+++ b/cloudsmith_cli/credential_helpers/common.py
@@ -48,6 +48,32 @@ def extract_hostname(url):
     return hostname
 
 
+def is_standard_cloudsmith_host(url):
+    """Return True if *url*'s host is a standard Cloudsmith host.
+
+    Standard hosts are ``cloudsmith.io``/``cloudsmith.com`` and their
+    subdomains.  Anything else is treated as a custom domain.
+    """
+    hostname = extract_hostname(url)
+    return (
+        hostname in ("cloudsmith.io", "cloudsmith.com")
+        or hostname.endswith(".cloudsmith.io")
+        or hostname.endswith(".cloudsmith.com")
+    )
+
+
+def repo_path_segment(owner, repo, host):
+    """Return the org-qualified path segment for a Cloudsmith URL.
+
+    Standard hosts include the org (``<owner>/<repo>``); a custom domain is
+    bound to a single org, so the org is omitted (``<repo>``).  This rule is
+    Cloudsmith-wide, not format-specific.
+    """
+    if is_standard_cloudsmith_host(host):
+        return f"{owner}/{repo}"
+    return repo
+
+
 def is_cloudsmith_domain(
     url, api_key=None, auth_type="api_key", api_host=None, backend_kind=None
 ):
@@ -74,11 +100,7 @@ def is_cloudsmith_domain(
         return False
 
     # Standard Cloudsmith domains — no auth needed, always match regardless of backend_kind
-    if (
-        hostname in ("cloudsmith.io", "cloudsmith.com")
-        or hostname.endswith(".cloudsmith.io")
-        or hostname.endswith(".cloudsmith.com")
-    ):
+    if is_standard_cloudsmith_host(hostname):
         return True
 
     # Custom domains require org + auth

--- a/cloudsmith_cli/credential_helpers/default_domains.py
+++ b/cloudsmith_cli/credential_helpers/default_domains.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Built-in Cloudsmith service hosts, with a trusted-config override.
+
+The table below lists the standard ``*.cloudsmith.io`` service hosts and the
+package format each one serves. A deployment with its own package-serving
+domains — dedicated or on-premise — can replace the table via a ``[domains]``
+section in ``config.ini``, mapping hostname to package format.
+
+The override is honoured only from trusted locations. ``config.ini`` is
+searched in the current working directory first (``cli/config.py``), so a
+``config.ini`` committed to a repository is attacker-controlled input; this
+module therefore never reads the domain table from a directory-relative
+config, mirroring the split ``_guard_untrusted_endpoints``
+(``cli/decorators.py``) already applies to ``api_host``/``api_proxy``.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..cli.config import get_default_config_path
+from .backends import BackendKind
+
+logger = logging.getLogger(__name__)
+
+CDN_HOST = "dl.cloudsmith.io"
+
+
+@dataclass(frozen=True)
+class DefaultDomain:
+    """A built-in or config-declared default Cloudsmith host."""
+
+    host: str
+    format_label: str
+    backend_kind: int | None
+
+
+BUILTIN_DOMAINS: tuple[DefaultDomain, ...] = (
+    DefaultDomain("cargo.cloudsmith.io", "cargo", BackendKind.CARGO),
+    DefaultDomain("composer.cloudsmith.io", "composer", BackendKind.COMPOSER),
+    DefaultDomain("conan.cloudsmith.io", "conan", BackendKind.CONAN),
+    DefaultDomain("conda.cloudsmith.io", "conda", BackendKind.CONDA),
+    DefaultDomain("dart.cloudsmith.io", "dart", BackendKind.DART),
+    DefaultDomain(CDN_HOST, "-", None),
+    DefaultDomain("docker.cloudsmith.io", "docker", BackendKind.DOCKER),
+    DefaultDomain("generic.cloudsmith.io", "generic", BackendKind.GENERIC),
+    DefaultDomain("golang.cloudsmith.io", "go", BackendKind.GO),
+    DefaultDomain("helm.oci.cloudsmith.io", "helm", BackendKind.HELM),
+    DefaultDomain("hex.cloudsmith.io", "hex", BackendKind.HEX),
+    DefaultDomain("huggingface.cloudsmith.io", "huggingface", BackendKind.HUGGINGFACE),
+    DefaultDomain("maven.cloudsmith.io", "maven", BackendKind.MAVEN),
+    DefaultDomain("nix.cloudsmith.io", "nix", BackendKind.NIX),
+    DefaultDomain("npm.cloudsmith.io", "npm", BackendKind.NPM),
+    DefaultDomain("nuget.cloudsmith.io", "nuget", BackendKind.NUGET),
+    DefaultDomain("python.cloudsmith.io", "python", BackendKind.PYTHON),
+    DefaultDomain("ruby.cloudsmith.io", "ruby", BackendKind.RUBY),
+    DefaultDomain("swift.cloudsmith.io", "swift", BackendKind.SWIFT),
+    DefaultDomain("terraform.cloudsmith.io", "terraform", BackendKind.TERRAFORM),
+    DefaultDomain("upload.cloudsmith.io", "-", None),
+)
+
+
+def builtin_host(backend_kind: int) -> str:
+    """Return the built-in Cloudsmith service host for `backend_kind`.
+
+    Raises ValueError for formats served only via the CDN, which have no
+    dedicated built-in host.
+    """
+    for domain in BUILTIN_DOMAINS:
+        if domain.backend_kind == backend_kind:
+            return domain.host
+    raise ValueError(f"No built-in Cloudsmith host for backend kind {backend_kind}")
+
+
+def _resolve_backend_kind(label: str) -> int | None:
+    """Resolve a config-declared label to a BackendKind member, if any."""
+    if not label:
+        return None
+    return BackendKind.__members__.get(label.upper())
+
+
+def _trusted_config_path() -> Path | None:
+    """Return the first existing config.ini from a trusted location, if any."""
+    for directory in (get_default_config_path(), os.path.expanduser("~/.cloudsmith")):
+        candidate = Path(directory) / "config.ini"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _domains_from_config(path: Path) -> list[DefaultDomain] | None:
+    """Parse a [domains] section at `path`, or None if absent/unreadable."""
+    parser = configparser.ConfigParser()
+    try:
+        read_files = parser.read(path, encoding="utf-8")
+    except (OSError, configparser.Error) as exc:
+        logger.debug("Failed to read config file %s: %s", path, exc)
+        return None
+
+    if not read_files or not parser.has_section("domains"):
+        return None
+
+    domains = [
+        DefaultDomain(
+            host=host,
+            format_label=label if label else "-",
+            backend_kind=_resolve_backend_kind(label),
+        )
+        for host, label in parser.items("domains")
+    ]
+    return sorted(domains, key=lambda domain: domain.host)
+
+
+def load_default_domains(config_path: Path | str | None = None) -> list[DefaultDomain]:
+    """Return the default domain table, honouring a trusted config override.
+
+    When `config_path` is given, that file is read directly. Otherwise
+    `config.ini` is looked up in trusted locations only -
+    `get_default_config_path()` then `~/.cloudsmith` - never the current
+    working directory. A malformed or unreadable file falls back to the
+    built-in table.
+    """
+    if config_path is not None:
+        path = Path(config_path)
+    else:
+        path = _trusted_config_path()
+
+    if path is None:
+        return list(BUILTIN_DOMAINS)
+
+    domains = _domains_from_config(path)
+    if domains is None:
+        return list(BUILTIN_DOMAINS)
+
+    return domains
+
+
+def untrusted_config_declares_domains() -> bool:
+    """True if a directory-relative config.ini declares a [domains] section.
+
+    Such a section is deliberately ignored: config.ini is searched in the
+    current working directory first, so a repository can ship one, and this
+    command decides which hosts may receive a Cloudsmith token. Honouring it
+    would let a malicious repo harvest a live credential - the same vector
+    ``_guard_untrusted_endpoints`` closes for api_host. The caller warns so
+    the omission is visible rather than silent.
+    """
+    parser = configparser.ConfigParser()
+    try:
+        read_files = parser.read("config.ini", encoding="utf-8")
+    except (OSError, configparser.Error) as exc:
+        logger.debug("Failed to read cwd config.ini: %s", exc)
+        return False
+
+    return bool(read_files) and parser.has_section("domains")

--- a/cloudsmith_cli/credential_helpers/generic.py
+++ b/cloudsmith_cli/credential_helpers/generic.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Cloudsmith Ltd
+"""
+Generic credential helper runtime.
+
+Emits a versioned JSON credential document.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = 1
+
+_REFUSAL_MESSAGE = (
+    "Error: Unable to retrieve credentials. "
+    "Provide credentials via the CLOUDSMITH_API_KEY environment variable, "
+    "credentials.ini, the system keyring, or an OIDC service. "
+    "Verify current authentication with `cloudsmith whoami --verbose`."
+)
+
+
+def build_response(credential):
+    """
+    Build the versioned credential document.
+
+    Args:
+        credential: Pre-resolved CredentialResult from the provider chain
+
+    Returns:
+        dict: The credential document, or None when no credential is available
+    """
+    if not credential or not credential.api_key:
+        return None
+
+    return {
+        "version": PROTOCOL_VERSION,
+        "username": "token",
+        "password": credential.api_key,
+    }
+
+
+def execute(credential=None) -> tuple[int, str | None, str | None]:
+    """
+    Resolve a credential into a versioned JSON document.
+
+    Args:
+        credential: Pre-resolved CredentialResult from the provider chain
+
+    Returns:
+        A (exit_code, stdout_text, stderr_text) tuple.  Either text value may
+        be None if there is nothing to write to that stream.  The document is
+        serialised in one step, so a partial document can never be emitted.
+    """
+    try:
+        response = build_response(credential)
+        if response is None:
+            return (1, None, _REFUSAL_MESSAGE)
+
+        return (0, json.dumps(response), None)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug("generic credential-helper failed: %s", exc, exc_info=True)
+        return (1, None, _REFUSAL_MESSAGE)

--- a/cloudsmith_cli/credential_helpers/maven/__init__.py
+++ b/cloudsmith_cli/credential_helpers/maven/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Maven credential support (shell-plugin installer)."""

--- a/cloudsmith_cli/credential_helpers/maven/installer.py
+++ b/cloudsmith_cli/credential_helpers/maven/installer.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Installer for the Maven shell-plugin credential helper.
+
+Writes an ``mvn`` shim into the Cloudsmith shims dir, records the repo binding
+and resolved hosts in the CLI config, and surfaces the ``distributionManagement``
+snippet needed for ``mvn deploy``.  Download resolution works transparently once
+the shims dir is on PATH (via ``credential-helper shell-init``); upload is opt-in.
+
+Maven uses two distinct endpoints, so two custom-domain kinds matter:
+- **download** (dependency resolution) goes via the download CDN; its custom
+  domains carry ``backend_kind is None`` (the generic download domain).
+- **upload** (``distributionManagement``) goes via the native Maven endpoint;
+  its custom domains carry ``BackendKind.MAVEN``.
+"""
+
+from __future__ import annotations
+
+import logging
+from xml.sax.saxutils import escape
+
+from ...templates import render
+from ..backends import BackendKind
+from ..custom_domains import CustomDomain, get_custom_domains
+from ..launchers import is_on_path
+from ..shellplugin import config
+from ..shellplugin.maven import upload_url
+from ..shellplugin.shims import remove_shim, write_shim
+
+logger = logging.getLogger(__name__)
+
+_DISTRIBUTION_MANAGEMENT_TEMPLATE = "maven_distribution_management.xml.tmpl"
+
+
+def _deploy_snippet(owner: str, repo: str, upload_host: str, registry_id: str) -> str:
+    """Return the pom.xml distributionManagement snippet for opt-in deploy."""
+    snippet = render(
+        _DISTRIBUTION_MANAGEMENT_TEMPLATE,
+        server_id=escape(registry_id),
+        url=escape(upload_url(owner, repo, upload_host)),
+    )
+    return (
+        "To publish with `mvn deploy`, add this to your pom.xml "
+        "(the id must match the server id):\n" + snippet
+    )
+
+
+def _first_host(domains: list[CustomDomain], backend_kind: int | None) -> str | None:
+    """Return the first enabled+validated host matching *backend_kind*."""
+    for domain in domains:
+        if domain.backend_kind == backend_kind and domain.enabled and domain.validated:
+            return domain.host
+    return None
+
+
+class MavenInstaller:
+    """Installs the Maven shell plugin (shim + config entry)."""
+
+    BINARY_NAME = "mvn"
+    name = "maven"
+    summary = "Maven shell plugin for Cloudsmith repositories"
+    requires_repo = True
+
+    def _discover_domains(
+        self,
+        *,
+        org: str | None,
+        api_key: str | None,
+        auth_type: str,
+        api_host: str | None,
+        refresh: bool,
+        actions: list[str],
+    ) -> list[CustomDomain]:
+        """Fetch the org's custom domains (best-effort; failure → WARNING + [])."""
+        if not (org and api_key):
+            return []
+        try:
+            return get_custom_domains(
+                org,
+                api_key=api_key,
+                auth_type=auth_type,
+                api_host=api_host,
+                refresh=refresh,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            # Discovery boundary: never let a lookup failure abort the install.
+            actions.append(f"WARNING: custom-domain discovery failed: {exc}")
+            return []
+
+    def _resolve_hosts(
+        self,
+        *,
+        domains_override: tuple[str, ...],
+        discover: bool,
+        org: str | None,
+        api_key: str | None,
+        auth_type: str,
+        api_host: str | None,
+        refresh: bool,
+        actions: list[str],
+    ) -> tuple[str, str]:
+        """Resolve (cdn_host, upload_host) from overrides, discovery, defaults."""
+        discovered: list[CustomDomain] = []
+        if discover:
+            discovered = self._discover_domains(
+                org=org,
+                api_key=api_key,
+                auth_type=auth_type,
+                api_host=api_host,
+                refresh=refresh,
+                actions=actions,
+            )
+
+        if domains_override:
+            cdn_host = domains_override[0]
+        else:
+            cdn_host = _first_host(discovered, None) or config.DEFAULT_CDN_HOST
+        upload_host = (
+            _first_host(discovered, BackendKind.MAVEN) or config.DEFAULT_UPLOAD_HOST
+        )
+        return cdn_host, upload_host
+
+    def install(
+        self,
+        *,
+        domains: tuple[str, ...] = (),
+        discover: bool = True,
+        refresh: bool = False,
+        org: str | None = None,
+        repo: str | None = None,
+        registry_id: str = config.DEFAULT_REGISTRY_ID,
+        api_key: str | None = None,
+        auth_type: str = "api_key",
+        api_host: str | None = None,
+        dry_run: bool = False,
+    ) -> list[str]:
+        """Install the Maven shell plugin; return human-readable actions."""
+        owner = org
+        actions: list[str] = []
+
+        cdn_host, upload_host = self._resolve_hosts(
+            domains_override=domains,
+            discover=discover,
+            org=owner,
+            api_key=api_key,
+            auth_type=auth_type,
+            api_host=api_host,
+            refresh=refresh,
+            actions=actions,
+        )
+
+        shims_dir = config.shims_dir()
+        shim_path = shims_dir / self.BINARY_NAME
+
+        if dry_run:
+            actions.append(f"would write shim {shim_path}")
+            actions.append(
+                f"would configure maven for {owner}/{repo} "
+                f"(download {cdn_host}, upload {upload_host})"
+            )
+            actions.append(
+                _deploy_snippet(owner or "", repo or "", upload_host, registry_id)
+            )
+            return actions
+
+        write_shim(shims_dir, self.BINARY_NAME)
+        actions.append(f"wrote shim {shim_path}")
+
+        config.set_plugin(
+            self.name,
+            config.PluginEntry(
+                owner=owner or "",
+                repo=repo or "",
+                api_host=api_host or config.DEFAULT_API_HOST,
+                cdn_host=cdn_host,
+                upload_host=upload_host,
+                registry_id=registry_id,
+            ),
+        )
+        actions.append(
+            f"configured maven for {owner}/{repo} "
+            f"(download {cdn_host}, upload {upload_host})"
+        )
+
+        if not is_on_path(shims_dir):
+            actions.append(
+                f"WARNING: {shims_dir} is not on PATH — add it with "
+                '`eval "$(cloudsmith credential-helper shell-init)"`'
+            )
+
+        actions.append(
+            _deploy_snippet(owner or "", repo or "", upload_host, registry_id)
+        )
+        return actions
+
+    def uninstall(self, *, dry_run: bool = False) -> list[str]:
+        """Remove the Maven shim and drop its config entry."""
+        shims_dir = config.shims_dir()
+        shim_path = shims_dir / self.BINARY_NAME
+        actions: list[str] = []
+
+        if dry_run:
+            if shim_path.exists():
+                actions.append(f"would remove shim {shim_path}")
+            else:
+                actions.append(f"shim not found at {shim_path} (nothing to remove)")
+            if config.get_plugin(self.name) is not None:
+                actions.append("would remove maven from the package-manager config")
+            else:
+                actions.append("maven not configured (nothing to remove)")
+            return actions
+
+        if remove_shim(shims_dir, self.BINARY_NAME):
+            actions.append(f"removed shim {shim_path}")
+        else:
+            actions.append(f"shim not found at {shim_path} (nothing to remove)")
+
+        if config.remove_plugin(self.name):
+            actions.append("removed maven from the package-manager config")
+        else:
+            actions.append("maven not configured (nothing to remove)")
+        return actions
+
+    def status(self) -> dict:
+        """Return shim path (str|None) and configured hosts for `list`."""
+        shim_path = config.shims_dir() / self.BINARY_NAME
+        launcher = str(shim_path) if shim_path.exists() else None
+
+        entry = config.get_plugin(self.name)
+        hosts: list[str] = []
+        if entry is not None:
+            hosts = [
+                f"{entry.owner}/{entry.repo}",
+                f"download:{entry.cdn_host}",
+                f"upload:{entry.upload_host}",
+            ]
+        return {"launcher": launcher, "hosts": hosts}

--- a/cloudsmith_cli/credential_helpers/shellplugin/__init__.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Shell-plugin credential support (shim + exec) for package managers like Maven."""

--- a/cloudsmith_cli/credential_helpers/shellplugin/config.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/config.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Persistent state for shell-plugin credential helpers.
+
+Records which package-manager formats are enabled and the org/repo + resolved
+hosts each is bound to, as ``[package-manager:<format>]`` sections in
+``package-managers.ini`` inside the CLI config directory (alongside
+``config.ini`` / ``credentials.ini``).
+"""
+
+from __future__ import annotations
+
+import configparser
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from ...cli.config import get_default_config_path
+
+DEFAULT_CDN_HOST = "dl.cloudsmith.io"
+DEFAULT_UPLOAD_HOST = "maven.cloudsmith.io"
+DEFAULT_REGISTRY_ID = "cloudsmith"
+DEFAULT_API_HOST = "https://api.cloudsmith.io"
+
+_SECTION_PREFIX = "package-manager:"
+
+
+@dataclass(frozen=True)
+class PluginEntry:
+    """A single enabled shell-plugin's binding (org/repo + resolved hosts)."""
+
+    owner: str
+    repo: str
+    api_host: str = DEFAULT_API_HOST
+    cdn_host: str = DEFAULT_CDN_HOST
+    upload_host: str = DEFAULT_UPLOAD_HOST
+    registry_id: str = DEFAULT_REGISTRY_ID
+
+    @classmethod
+    def from_dict(cls, data) -> PluginEntry:
+        """Build an entry from a config section, filling defaults."""
+        return cls(
+            owner=data.get("owner", ""),
+            repo=data.get("repo", ""),
+            api_host=data.get("api_host") or DEFAULT_API_HOST,
+            cdn_host=data.get("cdn_host") or DEFAULT_CDN_HOST,
+            upload_host=data.get("upload_host") or DEFAULT_UPLOAD_HOST,
+            registry_id=data.get("registry_id") or DEFAULT_REGISTRY_ID,
+        )
+
+    def to_dict(self) -> dict:
+        """Return the entry as a flat string mapping for the INI section."""
+        return asdict(self)
+
+
+def config_path() -> Path:
+    """Return the path to ``package-managers.ini`` in the CLI config dir."""
+    return Path(get_default_config_path()) / "package-managers.ini"
+
+
+def shims_dir() -> Path:
+    """Return the directory that holds package-manager shims on PATH."""
+    return Path(get_default_config_path()) / "shims"
+
+
+def _read() -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(interpolation=None)
+    path = config_path()
+    if path.exists():
+        parser.read(path, encoding="utf-8")
+    return parser
+
+
+def _write(parser: configparser.ConfigParser) -> None:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        parser.write(handle)
+
+
+def load_plugins() -> dict[str, PluginEntry]:
+    """Return the enabled plugins keyed by format name (``{}`` when none)."""
+    parser = _read()
+    return {
+        section[len(_SECTION_PREFIX) :]: PluginEntry.from_dict(parser[section])
+        for section in parser.sections()
+        if section.startswith(_SECTION_PREFIX)
+    }
+
+
+def get_plugin(name: str) -> PluginEntry | None:
+    """Return the stored entry for *name*, or ``None`` when not enabled."""
+    parser = _read()
+    section = _SECTION_PREFIX + name
+    if not parser.has_section(section):
+        return None
+    return PluginEntry.from_dict(parser[section])
+
+
+def set_plugin(name: str, entry: PluginEntry) -> None:
+    """Record (or replace) the entry for *name* and persist."""
+    parser = _read()
+    parser[_SECTION_PREFIX + name] = entry.to_dict()
+    _write(parser)
+
+
+def remove_plugin(name: str) -> bool:
+    """Drop the entry for *name*; return True if one was removed."""
+    parser = _read()
+    section = _SECTION_PREFIX + name
+    if not parser.has_section(section):
+        return False
+    parser.remove_section(section)
+    _write(parser)
+    return True

--- a/cloudsmith_cli/credential_helpers/shellplugin/config.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/config.py
@@ -14,9 +14,11 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from ...cli.config import get_default_config_path
+from ..backends import BackendKind
+from ..default_domains import CDN_HOST, builtin_host
 
-DEFAULT_CDN_HOST = "dl.cloudsmith.io"
-DEFAULT_UPLOAD_HOST = "maven.cloudsmith.io"
+DEFAULT_CDN_HOST = CDN_HOST
+DEFAULT_UPLOAD_HOST = builtin_host(BackendKind.MAVEN)
 DEFAULT_REGISTRY_ID = "cloudsmith"
 DEFAULT_API_HOST = "https://api.cloudsmith.io"
 

--- a/cloudsmith_cli/credential_helpers/shellplugin/maven.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/maven.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Maven shell plugin.
+
+Maven has no credential helper, so we inject an ephemeral ``settings.xml`` via
+``mvn -s`` for the duration of a single invocation.  The file carries a
+``<server>`` (matched by id to both our injected download profile and the
+user's ``distributionManagement``) plus an active profile whose repositories
+point at the Cloudsmith download CDN — so dependency resolution works with no
+``pom.xml`` edits.  Upload (deploy) reuses the same ``<server>`` credentials;
+its URL comes from the user's ``distributionManagement``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from xml.sax.saxutils import escape
+
+from ...templates import render
+from ..common import repo_path_segment
+from .config import PluginEntry
+from .plugin import ProvisionResult
+
+_SKIP_AUTH_ARGS = ["--help", "--version", "-v", "help"]
+_SETTINGS_TEMPLATE = "maven_settings.xml.tmpl"
+
+
+def download_url(owner: str, repo: str, cdn_host: str) -> str:
+    """Return the Maven download (dependency-resolution) repository URL."""
+    return f"https://{cdn_host}/basic/{repo_path_segment(owner, repo, cdn_host)}/maven/"
+
+
+def upload_url(owner: str, repo: str, upload_host: str) -> str:
+    """Return the native Maven upload (distributionManagement) URL."""
+    return f"https://{upload_host}/{repo_path_segment(owner, repo, upload_host)}/"
+
+
+def build_settings_xml(
+    owner: str, repo: str, token: str, cdn_host: str, server_id: str
+) -> str:
+    """Return a Maven ``settings.xml`` body for the given repo + credentials."""
+    return render(
+        _SETTINGS_TEMPLATE,
+        server_id=escape(server_id),
+        token=escape(token),
+        url=escape(download_url(owner, repo, cdn_host)),
+    )
+
+
+class MavenPlugin:
+    """Provisions an ephemeral ``settings.xml`` and runs ``mvn`` with ``-s``."""
+
+    name = "maven"
+    binary_name = "mvn"
+
+    def skip_auth_args(self) -> list[str]:
+        """Args for which Maven needs no Cloudsmith credentials."""
+        return list(_SKIP_AUTH_ARGS)
+
+    def provision(
+        self, entry: PluginEntry, token: str, args: list[str]
+    ) -> ProvisionResult:
+        """Write a 0600 ``settings.xml`` and return ``-s <path>`` to prepend.
+
+        Atomic: if writing fails the temp dir is removed before re-raising, so
+        a partial provisioning never leaks a directory.
+        """
+        temp_dir = tempfile.mkdtemp(prefix="cloudsmith-maven-")
+        written = False
+        try:
+            settings_path = os.path.join(temp_dir, "settings.xml")
+            content = build_settings_xml(
+                owner=entry.owner,
+                repo=entry.repo,
+                token=token,
+                cdn_host=entry.cdn_host,
+                server_id=entry.registry_id,
+            )
+            with open(settings_path, "w", encoding="utf-8") as handle:
+                handle.write(content)
+            os.chmod(settings_path, 0o600)
+            written = True
+            return ProvisionResult(
+                prepend_args=["-s", settings_path],
+                temp_dirs=[temp_dir],
+            )
+        finally:
+            if not written:
+                shutil.rmtree(temp_dir, ignore_errors=True)

--- a/cloudsmith_cli/credential_helpers/shellplugin/plugin.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/plugin.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Plugin protocol and registry for shell-plugin credential helpers.
+
+A *plugin* knows how to provision ephemeral credentials for one package
+manager that lacks a native credential helper (e.g. Maven).  The runner looks
+a plugin up by the command being run (its binary name) and asks it to
+provision per-invocation config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .config import PluginEntry
+
+
+@dataclass
+class ProvisionResult:
+    """The per-invocation provisioning a plugin produces for one command.
+
+    ``env`` are extra environment variables to set on the child process,
+    ``prepend_args`` are inserted before the user's arguments, and
+    ``temp_dirs`` are removed after the child exits.
+    """
+
+    env: dict[str, str] = field(default_factory=dict)
+    prepend_args: list[str] = field(default_factory=list)
+    temp_dirs: list[str] = field(default_factory=list)
+
+
+class Plugin(Protocol):
+    """A package-manager shell plugin."""
+
+    name: str
+    binary_name: str
+
+    def skip_auth_args(self) -> list[str]:
+        """Args that mean 'no credentials needed' (e.g. ``--version``)."""
+
+    def provision(
+        self, entry: PluginEntry, token: str, args: list[str]
+    ) -> ProvisionResult:
+        """Write ephemeral credentials and return how to run the binary."""
+
+
+def _registry() -> dict[str, Plugin]:
+    """Build the plugin registry (imported lazily to avoid import cycles)."""
+    from .maven import MavenPlugin
+
+    return {"maven": MavenPlugin()}
+
+
+def get(name: str) -> Plugin | None:
+    """Return the registered plugin for *name*, or ``None``."""
+    return _registry().get(name)
+
+
+def get_by_binary(binary_name: str) -> Plugin | None:
+    """Return the plugin whose ``binary_name`` matches, or ``None``."""
+    for plugin in _registry().values():
+        if plugin.binary_name == binary_name:
+            return plugin
+    return None
+
+
+def names() -> list[str]:
+    """Return the sorted names of registered plugins."""
+    return sorted(_registry())

--- a/cloudsmith_cli/credential_helpers/shellplugin/runner.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/runner.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Run a command with Cloudsmith credentials provisioned for it.
+
+``cloudsmith exec -- <command>`` (or a shim that forwards to it) lands here.
+The plugin is inferred from the command's binary name; when one matches we
+provision ephemeral credentials, run the *real* binary (resolved with the
+shims dir excluded to avoid recursion), and clean up.  Commands with no
+matching plugin run unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+from . import config, plugin
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_real_binary(binary_name: str, exclude_dirs: list[str]) -> str | None:
+    """Return the first ``$PATH`` match for *binary_name* outside *exclude_dirs*.
+
+    Excluding the shims dir prevents a shim from re-invoking itself.
+    """
+    excluded = {os.path.normcase(os.path.normpath(d)) for d in exclude_dirs}
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        if os.path.normcase(os.path.normpath(entry)) in excluded:
+            continue
+        candidate = shutil.which(binary_name, path=entry)
+        if candidate:
+            return candidate
+    return None
+
+
+def _run_process(path: str, args: list[str], env: dict[str, str]) -> int:
+    """Run *path* with *args* and *env*, returning its exit code."""
+    completed = subprocess.run([path, *args], env=env, check=False)
+    return completed.returncode
+
+
+def _resolve_entry(
+    format_name: str, owner: str | None, repo: str | None, api_host: str | None
+) -> config.PluginEntry:
+    """Load the stored entry for *format_name*, else build one from inputs."""
+    entry = config.get_plugin(format_name)
+    if entry is not None:
+        return entry
+    return config.PluginEntry.from_dict(
+        {
+            "owner": owner or "",
+            "repo": repo or "",
+            "api_host": api_host or config.DEFAULT_API_HOST,
+        }
+    )
+
+
+def _needs_auth(args: list[str], skip_auth_args: list[str]) -> bool:
+    """Return False when any arg signals an auth-free command (help/version).
+
+    Matching anywhere in the command is intentional: these flags (e.g. Maven's
+    ``--version``/``help``) short-circuit the tool regardless of position, so
+    there is nothing to authenticate.
+    """
+    skip = set(skip_auth_args)
+    return not any(arg in skip for arg in args)
+
+
+def run(
+    command: list[str],
+    credential=None,
+    owner: str | None = None,
+    repo: str | None = None,
+    api_host: str | None = None,
+) -> int:
+    """Run *command* with credentials provisioned for its package manager.
+
+    Returns the child process exit code, or non-zero on a setup error.
+    """
+    if not command:
+        print("cloudsmith: exec requires a command to run", file=sys.stderr)
+        return 2
+
+    binary_name, args = command[0], command[1:]
+    real_binary = resolve_real_binary(
+        binary_name, exclude_dirs=[str(config.shims_dir())]
+    )
+    if real_binary is None:
+        print(f"cloudsmith: command not found: {binary_name}", file=sys.stderr)
+        return 127
+
+    impl = plugin.get_by_binary(binary_name)
+    if impl is None or not _needs_auth(args, impl.skip_auth_args()):
+        return _run_process(real_binary, args, dict(os.environ))
+
+    token = getattr(credential, "api_key", None) if credential else None
+    if not token:
+        print(
+            "cloudsmith: warning: no credential resolved — set CLOUDSMITH_API_KEY "
+            "or configure OIDC",
+            file=sys.stderr,
+        )
+
+    entry = _resolve_entry(impl.name, owner, repo, api_host)
+    try:
+        result = impl.provision(entry, token or "", args)
+    except OSError as exc:
+        # Boundary: a failed provisioning must not crash the wrapped tool with
+        # a traceback. provision() cleans up its own temp dir before raising.
+        print(f"cloudsmith: failed to provision credentials: {exc}", file=sys.stderr)
+        return 1
+    try:
+        env = {**os.environ, **result.env}
+        return _run_process(real_binary, [*result.prepend_args, *args], env)
+    finally:
+        for temp_dir in result.temp_dirs:
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/cloudsmith_cli/credential_helpers/shellplugin/runner.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/runner.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import subprocess
 import sys
+from dataclasses import replace
 
 from . import config, plugin
 
@@ -47,17 +48,26 @@ def _run_process(path: str, args: list[str], env: dict[str, str]) -> int:
 def _resolve_entry(
     format_name: str, owner: str | None, repo: str | None, api_host: str | None
 ) -> config.PluginEntry:
-    """Load the stored entry for *format_name*, else build one from inputs."""
+    """Load the stored entry for *format_name*, else build one from inputs.
+
+    Explicit owner/repo (e.g. ``exec --org/--repo``) override the stored
+    binding for this invocation.
+    """
     entry = config.get_plugin(format_name)
-    if entry is not None:
-        return entry
-    return config.PluginEntry.from_dict(
-        {
-            "owner": owner or "",
-            "repo": repo or "",
-            "api_host": api_host or config.DEFAULT_API_HOST,
-        }
-    )
+    if entry is None:
+        return config.PluginEntry.from_dict(
+            {
+                "owner": owner or "",
+                "repo": repo or "",
+                "api_host": api_host or config.DEFAULT_API_HOST,
+            }
+        )
+    overrides = {
+        key: value for key, value in (("owner", owner), ("repo", repo)) if value
+    }
+    if overrides:
+        entry = replace(entry, **overrides)
+    return entry
 
 
 def _needs_auth(args: list[str], skip_auth_args: list[str]) -> bool:

--- a/cloudsmith_cli/credential_helpers/shellplugin/shellinit.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/shellinit.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Shell initialisation for the package-manager shims.
+
+Prints a snippet for ``eval "$(cloudsmith credential-helper shell-init)"`` that
+prepends the Cloudsmith shims directory to ``$PATH`` so the shims shadow the
+real binaries.  A single PATH prepend covers every enabled format (the shims
+dir holds them all).
+"""
+
+from __future__ import annotations
+
+import os
+
+from .config import shims_dir
+
+
+def _posix_init(path: str) -> str:
+    return (
+        "# Put Cloudsmith package-manager shims ahead of the real binaries\n"
+        f'export PATH="{path}:$PATH"\n'
+    )
+
+
+def _fish_init(path: str) -> str:
+    return (
+        "# Put Cloudsmith package-manager shims ahead of the real binaries\n"
+        f'fish_add_path "{path}"\n'
+    )
+
+
+_BUILDERS = {"bash": _posix_init, "zsh": _posix_init, "fish": _fish_init}
+
+
+def generate_init(shell: str) -> str:
+    """Return the shell-init snippet for *shell* (bash/zsh/fish)."""
+    try:
+        builder = _BUILDERS[shell]
+    except KeyError:
+        supported = ", ".join(sorted(_BUILDERS))
+        raise ValueError(
+            f"unsupported shell {shell!r}; choose one of: {supported}"
+        ) from None
+    return builder(str(shims_dir()))
+
+
+def detect_shell() -> str:
+    """Best-effort shell detection from ``$SHELL``, defaulting to bash."""
+    name = os.path.basename(os.environ.get("SHELL", ""))
+    return name if name in _BUILDERS else "bash"

--- a/cloudsmith_cli/credential_helpers/shellplugin/shims.py
+++ b/cloudsmith_cli/credential_helpers/shellplugin/shims.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Shim writer for shell-plugin package managers.
+
+A shim is a tiny launcher (reusing the credential-helper launcher body) named
+after the real binary (e.g. ``mvn``) that re-execs ``cloudsmith exec -- <bin>
+"$@"``.  Placed first on PATH (via ``credential-helper shell-init``), it
+shadows the real binary so every invocation is wrapped with Cloudsmith
+credentials; ``exec`` infers the right plugin from the binary name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..launchers import remove_launcher, write_launcher
+
+
+def shim_target_cmd(binary_name: str) -> str:
+    """Return the command a shim for *binary_name* forwards to."""
+    return f"cloudsmith exec -- {binary_name}"
+
+
+def write_shim(shims_dir: Path, binary_name: str) -> Path:
+    """Write a shim named *binary_name* that wraps it via ``cloudsmith exec``."""
+    return write_launcher(shims_dir, binary_name, shim_target_cmd(binary_name))
+
+
+def remove_shim(shims_dir: Path, binary_name: str) -> bool:
+    """Remove a shim previously created by :func:`write_shim`."""
+    return remove_launcher(shims_dir, binary_name)

--- a/cloudsmith_cli/templates/__init__.py
+++ b/cloudsmith_cli/templates/__init__.py
@@ -1,3 +1,27 @@
+"""Templates for the Cloudsmith CLI (HTML pages, config-file templates).
+
+Templates use ``<!-- KEY_PLACEHOLDER -->`` markers so the files stay valid
+HTML/XML and get normal editor validation; :func:`render` substitutes them.
 """
-HTML templates for Cloudsmith CLI interface.
-"""
+
+import os
+
+
+def template_path(name):
+    """Return the absolute path to the template *name* in this package."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+
+
+def render(name, **context):
+    """Render template *name*, replacing ``<!-- KEY_PLACEHOLDER -->`` markers.
+
+    Each ``context`` key ``foo`` replaces ``<!-- FOO_PLACEHOLDER -->`` with its
+    value (empty string when falsy).  Callers are responsible for escaping
+    values for the target format (e.g. XML-escaping).
+    """
+    with open(template_path(name), encoding="utf-8") as handle:
+        content = handle.read()
+    for key, value in context.items():
+        placeholder = f"<!-- {key.upper()}_PLACEHOLDER -->"
+        content = content.replace(placeholder, value if value else "")
+    return content

--- a/cloudsmith_cli/templates/maven_distribution_management.xml.tmpl
+++ b/cloudsmith_cli/templates/maven_distribution_management.xml.tmpl
@@ -1,0 +1,10 @@
+<distributionManagement>
+  <repository>
+    <id><!-- SERVER_ID_PLACEHOLDER --></id>
+    <url><!-- URL_PLACEHOLDER --></url>
+  </repository>
+  <snapshotRepository>
+    <id><!-- SERVER_ID_PLACEHOLDER --></id>
+    <url><!-- URL_PLACEHOLDER --></url>
+  </snapshotRepository>
+</distributionManagement>

--- a/cloudsmith_cli/templates/maven_settings.xml.tmpl
+++ b/cloudsmith_cli/templates/maven_settings.xml.tmpl
@@ -1,0 +1,29 @@
+<settings>
+  <servers>
+    <server>
+      <id><!-- SERVER_ID_PLACEHOLDER --></id>
+      <username>token</username>
+      <password><!-- TOKEN_PLACEHOLDER --></password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id><!-- SERVER_ID_PLACEHOLDER --></id>
+      <repositories>
+        <repository>
+          <id><!-- SERVER_ID_PLACEHOLDER --></id>
+          <url><!-- URL_PLACEHOLDER --></url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id><!-- SERVER_ID_PLACEHOLDER --></id>
+          <url><!-- URL_PLACEHOLDER --></url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile><!-- SERVER_ID_PLACEHOLDER --></activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
# Description

Adds a **Maven credential helper** to the CLI. Maven has no native credential-helper protocol, so this uses a *shell-plugin* approach: a `mvn` shim (placed first on `PATH` via `cloudsmith credential-helper shell-init`) transparently forwards to `cloudsmith exec -- mvn …`, which provisions an ephemeral `settings.xml` from the resolved credential (API key **or** OIDC), runs the real `mvn`, and cleans up afterwards.

Highlights:

- **`cloudsmith exec`** — a generic, top-level command that runs any command with Cloudsmith credentials provisioned for it; the package manager is inferred from the command (no format argument), and commands with no integration run unchanged. Plus `credential-helper shell-init` and `install maven` (with `--repo` / `--server-id`).
- A single injected `<server>` authenticates **both** dependency resolution (download CDN) and `distributionManagement` (native Maven upload) — Maven matches it by `<id>`, not host.
- **Custom-domain aware, generically**: a reusable `common.repo_path_segment` helper org-scopes Cloudsmith URLs (a custom domain is bound to one org, so the `<org>` path segment is dropped; the `*.cloudsmith.io` defaults keep it). Used by both the download and upload URLs.
- `settings.xml` lives in `cloudsmith_cli/templates/maven_settings.xml.tmpl` (real XML, editor-validated) and is rendered via the shared `templates.render()` extracted in #329 (stacked base PR).
- Shell-plugin state (`package-managers.ini`, shims) lives in the CLI config dir (`get_default_config_path()`), consistent with the custom-domain cache.
- Built test-first: full suite (552) and pre-commit hooks green.

Proven end-to-end with **GitHub OIDC (no API key anywhere)** — install, build (download), and a native `mvn clean deploy` (upload), with `~/.m2` caching:

- Example workflow: https://github.com/cloudsmith-iduffy/cloudsmith-cli-oidc-test/blob/main/.github/workflows/maven-oidc.yml
- Successful run logs: https://github.com/cloudsmith-iduffy/cloudsmith-cli-oidc-test/actions/runs/27446939107/job/81133936145#step:5:1

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

- The linked test-repo workflow doubles as a real-world usage example and a living smoke test (OIDC auth, custom-domain discovery, dependency caching). The whole Cloudsmith story is three bare commands: `install maven`, `eval "$(… shell-init)"`, `mvn clean deploy`.
- New subpackages and the template file are picked up by `find_packages` / existing `package_data`; no packaging changes needed.

