### PR TITLE
fix(no-ticket): stricter acceptance of api hosts and proxies

### DIFF
--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -156,6 +156,30 @@ class ConfigReader(ConfigFileReader):
         return False
 
     @classmethod
+    def read_relative_config_value(cls, key, profile=None):
+        """Read `key` as loaded from directory-relative (untrusted) configs only.
+
+        Loads via the normal machinery but through a reader narrowed to the
+        relative search paths/files (e.g. the current working directory);
+        absolute/user-level paths and any explicit ``--config-file`` are
+        excluded. The value is parsed and quote-stripped exactly as a real run
+        would. Returns None when the key is absent or empty.
+        """
+        relative_searchpath = [p for p in cls.config_searchpath if not os.path.isabs(p)]
+        relative_files = [f for f in cls.config_files if not os.path.isabs(f)]
+        if not relative_searchpath or not relative_files:
+            return None
+
+        relative_reader = type(
+            "RelativeConfigReader",
+            (cls,),
+            {"config_searchpath": relative_searchpath, "config_files": relative_files},
+        )
+        probe = Options()
+        relative_reader.load_config(probe, profile=profile)
+        return probe.opts.get(key)
+
+    @classmethod
     def load_config(cls, opts, path=None, profile=None):
         """Load a configuration file into an options object."""
         if path and os.path.exists(path):

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -255,6 +255,40 @@ def common_api_auth_options(f):
     return wrapper
 
 
+def _parse_suffixes(value):
+    """Split a CSV of trusted host suffixes into a normalised tuple."""
+    return tuple(
+        token.strip().lstrip(".") for token in (value or "").split(",") if token.strip()
+    )
+
+
+def _guard_untrusted_endpoints(ctx, opts, host_suffixes, proxy_suffixes):
+    """Reject api_host/api_proxy redirections from directory-relative config.
+
+    Enforcement applies only when the effective value originated from an
+    untrusted (relative) config file and was not supplied via a CLI flag or
+    environment variable. Both must match their allow-listed host suffixes;
+    api_proxy has no public default suffixes, so it is rejected unless one is
+    supplied via the environment.
+    """
+    trusted_sources = (ParameterSource.COMMANDLINE, ParameterSource.ENVIRONMENT)
+    profile = ctx.meta.get("profile")
+
+    if ctx.get_parameter_source("api_host") not in trusted_sources:
+        relative_host = config.ConfigReader.read_relative_config_value(
+            "api_host", profile=profile
+        )
+        if relative_host and opts.api_host == relative_host:
+            validators.validate_untrusted_api_host(opts.api_host, host_suffixes)
+
+    if ctx.get_parameter_source("api_proxy") not in trusted_sources:
+        relative_proxy = config.ConfigReader.read_relative_config_value(
+            "api_proxy", profile=profile
+        )
+        if relative_proxy and opts.api_proxy == relative_proxy:
+            validators.validate_untrusted_api_proxy(opts.api_proxy, proxy_suffixes)
+
+
 def initialise_session(f):
     """Create a shared HTTP session with proxy/SSL/user-agent settings."""
 
@@ -286,11 +320,25 @@ def initialise_session(f):
         envvar="CLOUDSMITH_API_HEADERS",
         help="A CSV list of extra headers (key=value) to send to the API.",
     )
+    @click.option(
+        "--allowed-api-host-suffixes",
+        envvar="CLOUDSMITH_ALLOWED_API_HOST_SUFFIXES",
+        hidden=True,
+        help="Comma-separated extra trusted api_host suffixes (internal use).",
+    )
+    @click.option(
+        "--allowed-api-proxy-suffixes",
+        envvar="CLOUDSMITH_ALLOWED_API_PROXY_SUFFIXES",
+        hidden=True,
+        help="Comma-separated trusted api_proxy host suffixes (internal use).",
+    )
     @click.pass_context
     @functools.wraps(f)
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
         opts = config.get_or_create_options(ctx)
+        host_suffixes = _parse_suffixes(kwargs.pop("allowed_api_host_suffixes"))
+        proxy_suffixes = _parse_suffixes(kwargs.pop("allowed_api_proxy_suffixes"))
         opts.api_host = kwargs.pop("api_host")
         opts.api_proxy = kwargs.pop("api_proxy")
         opts.api_ssl_verify = _pop_boolean_flag(
@@ -298,6 +346,8 @@ def initialise_session(f):
         )
         opts.api_user_agent = kwargs.pop("api_user_agent")
         opts.api_headers = kwargs.pop("api_headers")
+
+        _guard_untrusted_endpoints(ctx, opts, host_suffixes, proxy_suffixes)
 
         opts.session = _create_session(
             proxy=opts.api_proxy,

--- a/cloudsmith_cli/cli/tests/test_api_host_validation.py
+++ b/cloudsmith_cli/cli/tests/test_api_host_validation.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for api_host / api_proxy allow-list validation."""
+
+import click
+import pytest
+from click.core import ParameterSource
+
+from ..config import ConfigReader, Options
+from ..decorators import _guard_untrusted_endpoints, _parse_suffixes
+from ..validators import (
+    PUBLIC_API_HOST_SUFFIXES,
+    is_trusted_api_host,
+    validate_untrusted_api_host,
+    validate_untrusted_api_proxy,
+)
+
+
+class TestIsTrustedApiHost:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "https://api.cloudsmith.io",
+            "https://upload.cloudsmith.com",
+            "https://cloudsmith.io",
+            "https://cloudsmith.com",
+            "https://api.cloudsmith.io:443/v1/",
+        ],
+    )
+    def test_public_hosts_are_trusted(self, host):
+        assert is_trusted_api_host(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "https://evil.example.com",
+            "https://api.cloudsmith.io.evil.com",
+            "https://api.cloudsmith.io@evil.com",
+            "https://cloudsmith.io.evil.com",
+            "https://notcloudsmith.io",
+            "https://cloudsmith.org",
+            "",
+            "   ",
+        ],
+    )
+    def test_other_hosts_are_untrusted(self, host):
+        assert is_trusted_api_host(host) is False
+
+    def test_extra_suffix_is_accepted(self):
+        assert (
+            is_trusted_api_host("https://api.internal.example", ["internal.example"])
+            is True
+        )
+
+
+class TestValidateUntrustedApiHost:
+    def test_trusted_host_passes(self):
+        validate_untrusted_api_host("https://api.cloudsmith.io")
+
+    def test_untrusted_host_raises_usage_error(self):
+        bad_host = "https://evil.example.com"
+        with pytest.raises(click.UsageError) as exc:
+            validate_untrusted_api_host(bad_host)
+        message = str(exc.value)
+        assert bad_host in message
+        assert "--config-file" in message
+        for suffix in PUBLIC_API_HOST_SUFFIXES:
+            assert suffix in message
+
+    def test_extra_suffix_makes_host_pass(self):
+        validate_untrusted_api_host(
+            "https://api.internal.example", ["internal.example"]
+        )
+
+
+class TestValidateUntrustedApiProxy:
+    def test_proxy_without_allowed_suffixes_raises(self):
+        bad_proxy = "http://attacker.example.com:3128"
+        with pytest.raises(click.UsageError) as exc:
+            validate_untrusted_api_proxy(bad_proxy)
+        message = str(exc.value)
+        assert bad_proxy in message
+        assert "--api-proxy" in message
+        assert "--config-file" in message
+
+    def test_proxy_matching_allowed_suffix_passes(self):
+        validate_untrusted_api_proxy(
+            "http://proxy.internal.example:3128", ["internal.example"]
+        )
+
+
+class TestReadRelativeConfigValue:
+    def test_reads_api_host_from_relative_config(self, tmp_path, monkeypatch):
+        (tmp_path / "config.ini").write_text(
+            "[default]\napi_host = https://evil.example.com\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        assert (
+            ConfigReader.read_relative_config_value("api_host")
+            == "https://evil.example.com"
+        )
+
+    def test_strips_surrounding_quotes(self, tmp_path, monkeypatch):
+        (tmp_path / "config.ini").write_text(
+            '[default]\napi_host = "https://evil.example.com"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert (
+            ConfigReader.read_relative_config_value("api_host")
+            == "https://evil.example.com"
+        )
+
+    def test_profile_section_overrides_default(self, tmp_path, monkeypatch):
+        (tmp_path / "config.ini").write_text(
+            "[default]\napi_host = https://a.cloudsmith.io\n"
+            "[profile:ci]\napi_host = https://evil.example.com\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        assert (
+            ConfigReader.read_relative_config_value("api_host", profile="ci")
+            == "https://evil.example.com"
+        )
+
+    def test_missing_key_returns_none(self, tmp_path, monkeypatch):
+        (tmp_path / "config.ini").write_text("[default]\napi_proxy = \n")
+        monkeypatch.chdir(tmp_path)
+        assert ConfigReader.read_relative_config_value("api_host") is None
+
+    def test_no_config_file_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert ConfigReader.read_relative_config_value("api_host") is None
+
+
+class _FakeContext:
+    def __init__(self, sources, profile=None):
+        self._sources = sources
+        self.meta = {"profile": profile}
+
+    def get_parameter_source(self, name):
+        return self._sources.get(name, ParameterSource.DEFAULT)
+
+
+def _write_cwd_config(tmp_path, monkeypatch, body):
+    (tmp_path / "config.ini").write_text(body)
+    monkeypatch.chdir(tmp_path)
+
+
+class TestParseSuffixes:
+    def test_splits_and_strips_csv(self):
+        assert _parse_suffixes(" a.internal , b.internal ") == (
+            "a.internal",
+            "b.internal",
+        )
+
+    def test_strips_leading_dot(self):
+        assert _parse_suffixes(" .internal.example , .b.com ") == (
+            "internal.example",
+            "b.com",
+        )
+
+    def test_none_is_empty(self):
+        assert not _parse_suffixes(None)
+
+
+class TestGuardUntrustedEndpoints:
+    def test_untrusted_bad_host_raises(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = https://evil.example.com\n"
+        )
+        opts = Options()
+        opts.api_host = "https://evil.example.com"
+        ctx = _FakeContext({})
+        with pytest.raises(click.UsageError):
+            _guard_untrusted_endpoints(ctx, opts, (), ())
+
+    def test_untrusted_cloudsmith_host_passes(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = https://api.cloudsmith.io\n"
+        )
+        opts = Options()
+        opts.api_host = "https://api.cloudsmith.io"
+        _guard_untrusted_endpoints(_FakeContext({}), opts, (), ())
+
+    def test_flag_source_bypasses_enforcement(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = https://evil.example.com\n"
+        )
+        opts = Options()
+        opts.api_host = "https://evil.example.com"
+        ctx = _FakeContext({"api_host": ParameterSource.COMMANDLINE})
+        _guard_untrusted_endpoints(ctx, opts, (), ())
+
+    def test_effective_host_differs_from_relative_is_not_enforced(
+        self, tmp_path, monkeypatch
+    ):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = https://evil.example.com\n"
+        )
+        opts = Options()
+        opts.api_host = "https://my.dedicated.example.com"  # overridden by home config
+        _guard_untrusted_endpoints(_FakeContext({}), opts, (), ())
+
+    def test_extra_suffix_allows_untrusted_host(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path,
+            monkeypatch,
+            "[default]\napi_host = https://api.internal.example\n",
+        )
+        opts = Options()
+        opts.api_host = "https://api.internal.example"
+        _guard_untrusted_endpoints(_FakeContext({}), opts, ("internal.example",), ())
+
+    def test_untrusted_proxy_without_allowed_suffix_raises(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path,
+            monkeypatch,
+            "[default]\napi_proxy = http://attacker.example.com:3128\n",
+        )
+        opts = Options()
+        opts.api_proxy = "http://attacker.example.com:3128"
+        with pytest.raises(click.UsageError):
+            _guard_untrusted_endpoints(_FakeContext({}), opts, (), ())
+
+    def test_untrusted_proxy_with_allowed_suffix_passes(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path,
+            monkeypatch,
+            "[default]\napi_proxy = http://proxy.internal.example:3128\n",
+        )
+        opts = Options()
+        opts.api_proxy = "http://proxy.internal.example:3128"
+        _guard_untrusted_endpoints(_FakeContext({}), opts, (), ("internal.example",))
+
+    def test_trusted_proxy_source_bypasses(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path,
+            monkeypatch,
+            "[default]\napi_proxy = http://attacker.example.com:3128\n",
+        )
+        opts = Options()
+        opts.api_proxy = "http://corp.example.com:3128"  # from env, differs
+        ctx = _FakeContext({"api_proxy": ParameterSource.ENVIRONMENT})
+        _guard_untrusted_endpoints(ctx, opts, (), ())

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -2,6 +2,7 @@
 
 import base64
 from datetime import datetime
+from urllib.parse import urlsplit
 
 import click
 from click.core import ParameterSource
@@ -11,6 +12,7 @@ from .types import ExpandPath
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 BAD_API_HEADERS = ("user-agent", "host")
 API_HEADER_TRANSFORMS = {}
+PUBLIC_API_HOST_SUFFIXES = ("cloudsmith.io", "cloudsmith.com")
 
 
 class IntOrWildcard(click.ParamType):
@@ -82,6 +84,48 @@ def validate_api_headers(param, value):
         headers[k] = v
 
     return headers
+
+
+def host_matches_suffixes(url, suffixes):
+    """True if url's hostname equals or is a subdomain of one of the suffixes.
+
+    Parsing the hostname (rather than substring-matching the URL) ensures
+    userinfo, port, and path components cannot smuggle a host past the check.
+    """
+    hostname = (urlsplit(url).hostname or "").lower()
+    return bool(hostname) and any(
+        hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes
+    )
+
+
+def is_trusted_api_host(host, extra_suffixes=()):
+    """True if host is an allowed Cloudsmith host (or matches an extra suffix)."""
+    return host_matches_suffixes(host, PUBLIC_API_HOST_SUFFIXES + tuple(extra_suffixes))
+
+
+def validate_untrusted_api_host(host, extra_suffixes=()):
+    """Raise if an api_host from an untrusted config is not an allowed host."""
+    if is_trusted_api_host(host, extra_suffixes):
+        return
+    raise click.UsageError(
+        f'api_host "{host}" is set by a config file in the current directory '
+        "and is not an allowed Cloudsmith host. Allowed hosts must be under "
+        "*.cloudsmith.io or *.cloudsmith.com. To use a custom host, set it via "
+        "--api-host, the CLOUDSMITH_API_HOST environment variable, an explicit "
+        "--config-file, or your user-level config."
+    )
+
+
+def validate_untrusted_api_proxy(proxy, allowed_suffixes=()):
+    """Raise if an api_proxy from an untrusted config is not an allowed proxy."""
+    if host_matches_suffixes(proxy, allowed_suffixes):
+        return
+    raise click.UsageError(
+        f'api_proxy "{proxy}" is set by a config file in the current directory '
+        "and is not an allowed proxy. To use a proxy, set it via --api-proxy, "
+        "the CLOUDSMITH_API_PROXY environment variable, an explicit "
+        "--config-file, or your user-level config."
+    )
 
 
 def validate_slashes(


### PR DESCRIPTION
# Description

Directory-relative config files (`config.ini` is searched in the current working directory **first**) can set `api_host` / `api_proxy` to an arbitrary endpoint. Because credentials are attached to whatever host/proxy is configured, a malicious repository shipping a `./config.ini` could cause the next `cloudsmith` command run inside it to leak the user's API key or bearer token to an attacker-controlled endpoint.

This change enforces an allow-list **only on untrusted (directory-relative) sources**:

- When the effective `api_host` originates from a cwd config and was **not** supplied via `--api-host` / `CLOUDSMITH_API_HOST`, it must be under `*.cloudsmith.io` or `*.cloudsmith.com`.
- Any `api_proxy` originating from such a source is rejected outright (there is no sensible domain allow-list for proxies).
- Trusted sources — CLI flags, environment variables, user/home config, and an explicit `--config-file` — are unaffected, preserving dedicated/on-prem deployments that use custom hosts.

Hostname matching parses the URL netloc (defending `…cloudsmith.io.evil.com`, `…cloudsmith.io@evil.com`, port/userinfo tricks). Additional trusted suffixes can be supplied via the hidden `--allowed-api-host-suffixes` option / `CLOUDSMITH_ALLOWED_API_HOST_SUFFIXES` env var — wired through Click only, never the config-file schema, so an untrusted config cannot whitelist its own domain.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

Low blast radius: only a directory-relative `config.ini` setting a non-cloudsmith `api_host` or any `api_proxy` is affected — exactly the credential-redirection cases reported. Values from env vars, flags, and user/home config are untouched.

Follow-ups noted but intentionally out of scope: `api_ssl_verify=false` and `api_headers` from untrusted config are the same MITM class and could be guarded similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
