### PR TITLE
fix(no-ticket): whoami exits 1 when not authenticated

### DIFF
--- a/cloudsmith_cli/cli/commands/whoami.py
+++ b/cloudsmith_cli/cli/commands/whoami.py
@@ -172,12 +172,14 @@ def whoami(ctx, opts):
         data["auth"] = _get_verbose_auth_data(opts, api_host)
 
     if utils.maybe_print_as_json(opts, data):
+        if not is_auth:
+            ctx.exit(1)
         return
 
     if not is_auth:
         click.echo("You are authenticated as:")
         click.secho("Nobody (i.e. anonymous user)", fg="yellow")
-        return
+        ctx.exit(1)
 
     if opts.verbose:
         _print_verbose_text(data)

--- a/cloudsmith_cli/cli/tests/commands/test_whoami.py
+++ b/cloudsmith_cli/cli/tests/commands/test_whoami.py
@@ -1,0 +1,73 @@
+import json
+from unittest.mock import patch
+
+import click.testing
+import pytest
+
+from ...commands.whoami import whoami
+
+HOST = "https://api.example.com"
+ARGS = ["--api-host", HOST, "--api-key", "fake-api-key"]
+
+
+@pytest.fixture()
+def runner():
+    return click.testing.CliRunner()
+
+
+def invoke_whoami(runner, user_brief, extra_args=None):
+    """Invoke whoami with get_user_brief mocked to return user_brief."""
+    with patch(
+        "cloudsmith_cli.cli.commands.whoami.get_user_brief"
+    ) as get_user_brief_mock:
+        get_user_brief_mock.return_value = user_brief
+        return runner.invoke(whoami, ARGS + (extra_args or []))
+
+
+class TestWhoamiCommand:
+    """Tests for the cloudsmith whoami command."""
+
+    def test_authenticated_exits_zero(self, runner):
+        result = invoke_whoami(
+            runner, (True, "test-user", "test@example.com", "Test User")
+        )
+
+        assert result.exit_code == 0
+        output = result.output.splitlines()
+        assert output[0] == "Retrieving your authentication status from the API ... OK"
+        assert output[1] == "You are authenticated as:"
+        assert output[2] == "User: Test User (slug: test-user, email: test@example.com)"
+
+    def test_unauthenticated_exits_one(self, runner):
+        result = invoke_whoami(runner, (False, None, None, None))
+
+        assert result.exit_code == 1
+        output = result.output.splitlines()
+        assert output[0] == "Retrieving your authentication status from the API ... OK"
+        assert output[1] == "You are authenticated as:"
+        assert output[2] == "Nobody (i.e. anonymous user)"
+
+    def test_json_authenticated_exits_zero(self, runner):
+        result = invoke_whoami(
+            runner,
+            (True, "test-user", "test@example.com", "Test User"),
+            extra_args=["--output-format", "json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(
+            "".join(line for line in result.output.splitlines() if line.startswith("{"))
+        )
+        assert payload["data"]["is_authenticated"] is True
+        assert payload["data"]["username"] == "test-user"
+
+    def test_json_unauthenticated_exits_one(self, runner):
+        result = invoke_whoami(
+            runner, (False, None, None, None), extra_args=["--output-format", "json"]
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(
+            "".join(line for line in result.output.splitlines() if line.startswith("{"))
+        )
+        assert payload["data"]["is_authenticated"] is False


### PR DESCRIPTION
# Description

`cloudsmith whoami` always exited with code 0, even when the request was anonymous. Scripts and CI pipelines could not rely on the exit code to verify credentials and instead had to parse `--output-format json` for `"is_authenticated": false`.

The command now exits with code 1 when `is_authenticated` is false and 0 when true, across all output formats (human, `json`, `pretty_json`). 

Includes new tests for the `whoami` command (none existed previously): authenticated and anonymous cases.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes


(Release notes for this will be added at the end of merging the draft PRs)
**Behavior change — flag in release notes:** callers that run `whoami` while unauthenticated and expect exit 0 will now receive exit 1. This is the intended, correct behavior, since the exit code should reflect authentication status.