### PR TITLE
refactor(no-ticket): extract shared templates.render() from webserver

### DIFF
--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -1,5 +1,4 @@
 import html
-import os
 import socket
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -7,6 +6,7 @@ from urllib.parse import parse_qsl, unquote, urlparse
 
 import click
 
+from .. import templates
 from ..core.api.exceptions import ApiException
 from ..core.api.init import initialise_api
 from ..core.credentials.models import CredentialResult
@@ -16,32 +16,12 @@ from .saml import exchange_2fa_token
 
 def get_template_path(template_name):
     """Get the absolute path to a template file."""
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_dir, "templates", template_name)
+    return templates.template_path(template_name)
 
 
 def render_template(template_name, **context):
-    """
-    Render a template with the given context.
-
-    Args:
-        template_name: Name of the template file
-        context: Dictionary of variables to replace in the template
-
-    Returns:
-        Rendered HTML content
-    """
-    template_path = get_template_path(template_name)
-
-    with open(template_path, encoding="utf-8") as file:
-        content = file.read()
-
-    # Replace placeholders with context values
-    for key, value in context.items():
-        placeholder = f"<!-- {key.upper()}_PLACEHOLDER -->"
-        content = content.replace(placeholder, value if value else "")
-
-    return content
+    """Render a template with the given context (see :func:`templates.render`)."""
+    return templates.render(template_name, **context)
 
 
 class AuthenticationWebServer(HTTPServer):

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -20,7 +20,7 @@ def get_template_path(template_name):
 
 
 def render_template(template_name, **context):
-    """Render a template with the given context (see :func:`templates.render`)."""
+    """Render a template with the given context (see :func:`cloudsmith_cli.templates.render`)."""
     return templates.render(template_name, **context)
 
 

--- a/cloudsmith_cli/templates/__init__.py
+++ b/cloudsmith_cli/templates/__init__.py
@@ -1,3 +1,27 @@
+"""Templates for the Cloudsmith CLI (HTML pages, config-file templates).
+
+Templates use ``<!-- KEY_PLACEHOLDER -->`` markers so the files stay valid
+HTML/XML and get normal editor validation; :func:`render` substitutes them.
 """
-HTML templates for Cloudsmith CLI interface.
-"""
+
+import os
+
+
+def template_path(name):
+    """Return the absolute path to the template *name* in this package."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+
+
+def render(name, **context):
+    """Render template *name*, replacing ``<!-- KEY_PLACEHOLDER -->`` markers.
+
+    Each ``context`` key ``foo`` replaces ``<!-- FOO_PLACEHOLDER -->`` with its
+    value (empty string when falsy).  Callers are responsible for escaping
+    values for the target format (e.g. XML-escaping).
+    """
+    with open(template_path(name), encoding="utf-8") as handle:
+        content = handle.read()
+    for key, value in context.items():
+        placeholder = f"<!-- {key.upper()}_PLACEHOLDER -->"
+        content = content.replace(placeholder, value if value else "")
+    return content


### PR DESCRIPTION
# Description

Prep refactor split out of #314 (stacked: this PR merges first).

Moves the placeholder-based template renderer out of `cloudsmith_cli/cli/webserver.py` into the `templates` package as a shared `templates.render()` (+ `template_path()`), so non-HTML callers — the Maven credential helper in #314 renders its `settings.xml` with it — can reuse it. `webserver.py` keeps thin wrappers delegating to the new functions; rendering behavior is unchanged (`<!-- KEY_PLACEHOLDER -->` substitution, empty string for falsy values).

No functional changes intended; existing webserver/login tests cover the moved code paths.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (please describe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
