### PR TITLE
fix(no-ticket): sync BackendKind with the server-side enum

### DIFF
--- a/cloudsmith_cli/credential_helpers/backends.py
+++ b/cloudsmith_cli/credential_helpers/backends.py
@@ -38,4 +38,5 @@ class BackendKind(IntEnum):
     GENERIC = 28
     VSX = 29
     MCP = 30
+    NIX = 31
     DEFAULT = 99


### PR DESCRIPTION
## Description

`cloudsmith_cli/credential_helpers/backends.py` mirrors `BackendKind` from the server side.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

Stacked on #314. One line of production code; the full suite passes (612 passed, 40 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)