### PR TITLE
fix: stop Homebrew rewriting bundled dylib IDs on macOS

### DIFF
--- a/packaging/homebrew/cloudsmith-cli.rb.tmpl
+++ b/packaging/homebrew/cloudsmith-cli.rb.tmpl
@@ -30,6 +30,12 @@ class CloudsmithCli < Formula
     regex(/^version=(\d+(?:\.\d+)+)$/i)
   end
 
+  # The bundled libraries are private to the PyInstaller bundle and are resolved
+  # via @rpath, so Homebrew must not rewrite their dylib IDs: the absolute Cellar
+  # path does not fit in the Mach-O header padding of prebuilt wheels such as
+  # pydantic_core, which fails the install.
+  preserve_rpath
+
   def install
     # PyInstaller onedir bundle: the executable must stay next to _internal/.
     libexec.install Dir["*"]


### PR DESCRIPTION
Adds `preserve_rpath` to the Homebrew formula template so macOS installs stop failing.

Companion to cloudsmith-io/homebrew-cloudsmith-cli#28, which fixed the tap. **This change is what stops the next release reverting that fix**, because `publish-homebrew` copies the rendered template over `Formula/cloudsmith-cli.rb` wholesale.

## The bug

Since 1.20.1 the Homebrew formula ships the PyInstaller onedir bundle, so the keg contains 65 prebuilt Mach-O files where the zipapp had none. Homebrew rewrites the dylib ID of every one to an absolute Cellar path, and that name does not fit the header padding of `pydantic_core`'s prebuilt wheel:

```
Error: Failed changing dylib ID of .../libexec/_internal/pydantic_core/_pydantic_core.cpython-312-darwin.so
  from @rpath/pydantic_core._pydantic_core.cpython-312-darwin.so
    to /opt/homebrew/opt/cloudsmith-cli/libexec/_internal/pydantic_core/pydantic_core._pydantic_core...
Error: Failed to fix install linkage
```

Measured against the published 1.20.2 archives — the new ID needs 56 more bytes than are available:

| archive | header slack | needed | result |
| --- | --- | --- | --- |
| arm64 `_pydantic_core.so` | 48 bytes | 56 | **fails** |
| x86_64 `_pydantic_core.so` | 32 bytes | 56 | **fails** |
| arm64 `rpds.so` | 48 bytes | 40 | passes by 8 bytes |

Both macOS architectures are affected, and the margin elsewhere is thin. The install does link and the CLI runs, but `brew` exits non-zero, which breaks `brew upgrade` and any automation around it. Reported by a customer upgrading 1.19.0 → 1.20.1.

## Why `preserve_rpath` rather than a build change

`_pydantic_core.so` is a prebuilt maturin wheel from PyPI that PyInstaller copies verbatim, so linking it with `-headerpad_max_install_names` would mean building pydantic-core from source.

The rewrite is also pointless. Every non-system linkage in the bundle is `@rpath`-relative and private to it, and nothing outside links against them. Homebrew already skips `@rpath` install names and rpaths via `grep_v(VARIABLE_REFERENCE_RX)`; the dylib ID is the one path lacking that exemption, and `preserve_rpath` supplies it. All six dylibs in the bundle use `@rpath` IDs, so it covers every one.

## Verification

Rendered with 1.20.2's version and checksums, this template produces a formula **byte-identical** to the one merged in the tap, and:

- `brew style` — no offenses
- `brew audit` — clean
- the tap's macOS CI installs, uninstalls, upgrades, downgrades and pins it on both arm64 and Intel

Before the fix the install reproduced the error above and exited 1; after it, exit 0 with all six dylib IDs left as `@rpath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)