### PR TITLE
feat(ENG-13681): add `cloudsmith domains list` with custom-domain discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `cloudsmith domains list` lists the hosts Cloudsmith can authenticate as a versioned JSON document: `{"version": 1, "domains": [{"host": ..., "format": ..., "type": ..., "domain_type": ..., "org": ..., "repository": ..., "primary": ..., "created_at": ...}]}`. The built-in list can be replaced by a `[domains]` section in a trusted `config.ini` — each entry maps a hostname to the format it serves, or to `download`/`upload` — for dedicated deployments. An organisation's own custom domains are listed ahead of the built-in hosts, and a custom domain that is disabled or not yet validated is left out entirely, since it serves nothing. `--format` and `--repo` narrow the list to the hosts usable for a package format or repository, most-preferred first, and `--domain-type` to those with one purpose: `download`, `upload`, `api` or `native_api`.
+- The Cloudsmith organisation is now named by `--org`, with `--organization` and `--oidc-org` accepted as aliases for the same option, and `org`, `organization` or `oidc_org` accepted in `config.ini`. `--oidc-org` named the setting after the first feature that wanted it; it is read by custom-domain discovery as well as OIDC token exchange, so it is now named after what it is. The `CLOUDSMITH_ORG` environment variable is unchanged, and `credential-helper install` no longer has a separate `--org` of its own.
+
 ## [1.21.0] - 2026-08-03
 
 ### Added

--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from . import (
     delete,
     dependencies,
     docs,
+    domains,
     download,
     entitlements,
     help_,

--- a/cloudsmith_cli/cli/commands/credential_helper/docker.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/docker.py
@@ -29,7 +29,8 @@ def docker(opts, operation):
 
     Provides credentials for all Cloudsmith Docker registries: ``*.cloudsmith.io``,
     ``*.cloudsmith.com``, and any custom domains configured for the organisation
-    (requires CLOUDSMITH_ORG and a valid API key/token).
+    (requires an organisation - ``--org``, CLOUDSMITH_ORG or ``org`` in
+    ``config.ini`` - and a valid API key/token).
 
     Input (stdin):
         Server URL as plain text (e.g. "docker.cloudsmith.io")
@@ -57,6 +58,7 @@ def docker(opts, operation):
         sys.stdin,
         credential=opts.credential,
         api_host=opts.api_host,
+        org=opts.org,
     )
 
     if stdout is not None:

--- a/cloudsmith_cli/cli/commands/credential_helper/manage.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/manage.py
@@ -8,7 +8,6 @@ Provides ``credential-helper install``, ``credential-helper uninstall``, and
 
 from __future__ import annotations
 
-import os
 import sys
 
 import click
@@ -94,11 +93,6 @@ def _get_installer(name: str):
     default=False,
     help="Bypass the custom-domain cache and fetch fresh data from the API.",
 )
-@click.option(
-    "--org",
-    default=None,
-    help="Cloudsmith organisation slug for custom-domain discovery.",
-)
 @common_cli_config_options
 @common_cli_output_options
 @common_api_auth_options
@@ -113,7 +107,6 @@ def install_cmd(
     dry_run: bool,
     no_discover: bool,
     refresh: bool,
-    org: str | None,
 ) -> None:
     """Install a credential helper launcher and configure the package manager.
 
@@ -138,7 +131,6 @@ def install_cmd(
         $ cloudsmith credential-helper install docker --no-discover
     """
     installer = _get_installer(helper)
-    org = org or os.environ.get("CLOUDSMITH_ORG", "").strip() or None
     try:
         actions = installer.install(
             bin_dir=bin_dir,
@@ -146,7 +138,7 @@ def install_cmd(
             dry_run=dry_run,
             discover=not no_discover,
             refresh=refresh,
-            org=org,
+            org=opts.org,
             credential=opts.credential,
             api_host=opts.api_host,
         )

--- a/cloudsmith_cli/cli/commands/credential_helper/manage.py
+++ b/cloudsmith_cli/cli/commands/credential_helper/manage.py
@@ -139,12 +139,6 @@ def install_cmd(
     """
     installer = _get_installer(helper)
     org = org or os.environ.get("CLOUDSMITH_ORG", "").strip() or None
-    api_key = opts.credential.api_key if opts.credential else None
-    auth_type = (
-        getattr(opts.credential, "auth_type", "api_key")
-        if opts.credential
-        else "api_key"
-    )
     try:
         actions = installer.install(
             bin_dir=bin_dir,
@@ -153,8 +147,7 @@ def install_cmd(
             discover=not no_discover,
             refresh=refresh,
             org=org,
-            api_key=api_key,
-            auth_type=auth_type,
+            credential=opts.credential,
             api_host=opts.api_host,
         )
     except OSError as exc:

--- a/cloudsmith_cli/cli/commands/domains.py
+++ b/cloudsmith_cli/cli/commands/domains.py
@@ -12,8 +12,10 @@ import json
 import os
 
 import click
+from click.core import ParameterSource
 
 from ...core.api.exceptions import ApiException
+from ...core.pagination import PageInfo
 from ...credential_helpers.custom_domains import (
     get_custom_domains,
     order_by_precedence,
@@ -30,6 +32,7 @@ from ..config import get_default_config_path
 from ..decorators import (
     common_api_auth_options,
     common_cli_config_options,
+    common_cli_list_options,
     initialise_api,
 )
 from .main import main
@@ -109,6 +112,7 @@ def domains_():
     "Drops custom domains bound to a different repository.",
 )
 @common_cli_config_options
+@common_cli_list_options
 @common_api_auth_options
 @initialise_api
 @click.pass_context
@@ -119,6 +123,9 @@ def list_domains(  # pylint: disable=too-many-arguments
     format_: str | None,
     domain_type: str | None,
     repo: str | None,
+    page: int,
+    page_size: int,
+    page_all: bool,
 ) -> None:
     """Emit the Cloudsmith hosts and their package formats as JSON.
 
@@ -147,10 +154,21 @@ def list_domains(  # pylint: disable=too-many-arguments
     Cloudsmith would bind; ``--repo`` is what lets the repository-bound hosts
     take part in it.
 
+    Results support the same --page/--page-size (-p/-l) options as other
+    `list` commands, selecting a page of the combined, filtered list. Unlike
+    those commands, this one defaults to --page-all (--show-all): the
+    combined list is small and built from a local cache rather than a live
+    paginated endpoint, so there is no benefit to hiding entries by default.
+    Passing --page or --page-size switches to paged output.
+
     Output (stdout):
         JSON: {"version": 1, "domains": [{"host": ..., "format": ...,
         "type": ..., "domain_type": ..., "org": ..., "repository": ...,
-        "primary": ..., "created_at": ...}]}
+        "primary": ..., "created_at": ...}], "meta": {"pagination": {...}}}
+
+        "meta" is only present when the result is paginated (i.e. not
+        --page-all), and mirrors the pagination metadata other `list`
+        commands emit for `-F json`.
 
     Examples:
 
@@ -170,6 +188,24 @@ def list_domains(  # pylint: disable=too-many-arguments
         # Where to upload to
         $ cloudsmith domains list --org my-org --domain-type upload
     """
+    if not page_all:
+        explicit_sources = {
+            src
+            for src in (
+                ParameterSource.COMMANDLINE,
+                ParameterSource.ENVIRONMENT,
+                getattr(ParameterSource, "PROMPT", None),
+            )
+            if src is not None
+        }
+        page_explicit = ctx.get_parameter_source("page") in explicit_sources
+        page_size_explicit = ctx.get_parameter_source("page_size") in explicit_sources
+        if not page_explicit and not page_size_explicit:
+            # Unlike other `list` commands, domains list defaults to showing
+            # everything: the combined list is small and built from a local
+            # cache, so paging by default would hide entries for no benefit.
+            page_all = True
+
     explicit_config = ctx.meta.get("config_file")
     if explicit_config and os.path.isdir(explicit_config):
         explicit_config = os.path.join(explicit_config, "config.ini")
@@ -243,4 +279,23 @@ def list_domains(  # pylint: disable=too-many-arguments
 
     data = _custom_entries(records) + default_entries
 
-    click.echo(json.dumps({"version": PROTOCOL_VERSION, "domains": data}))
+    document = {"version": PROTOCOL_VERSION, "domains": data}
+
+    if not page_all:
+        if page < 1 or page_size < 1:
+            raise click.UsageError("--page and --page-size must be positive.")
+
+        total = len(data)
+        start = (page - 1) * page_size
+        page_info = PageInfo()
+        page_info.count = total
+        page_info.page = page
+        page_info.page_size = page_size
+        page_info.page_total = -(-total // page_size) or 1
+
+        document["domains"] = data[start : start + page_size]
+        document["meta"] = {
+            "pagination": page_info.as_dict(num_results=len(document["domains"]))
+        }
+
+    click.echo(json.dumps(document))

--- a/cloudsmith_cli/cli/commands/domains.py
+++ b/cloudsmith_cli/cli/commands/domains.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Cloudsmith Ltd
+"""List the hosts Cloudsmith can authenticate: built-in and custom domains.
+
+The built-in ``*.cloudsmith.io`` service hosts ship with the CLI so that every
+consumer shares one authoritative table; custom domains cannot be inferred, so
+discovering them requires an API lookup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import click
+
+from ...core.api.exceptions import ApiException
+from ...credential_helpers.custom_domains import (
+    get_custom_domains,
+    order_by_precedence,
+    read_all_cached_domains,
+)
+from ...credential_helpers.default_domains import (
+    DomainType,
+    format_for_backend_kind,
+    load_default_domains,
+    untrusted_config_declares_domains,
+)
+from .. import command
+from ..config import get_default_config_path
+from ..decorators import (
+    common_api_auth_options,
+    common_cli_config_options,
+    initialise_api,
+)
+from .main import main
+
+PROTOCOL_VERSION = 1
+
+
+def _label(value: str | None) -> str | None:
+    """Normalise a filter value for comparison, or None if it is empty."""
+    return (value or "").strip().lower() or None
+
+
+def _serves_format(entry_format: str | None, wanted: str | None) -> bool:
+    """Whether an entry's format satisfies a ``--format`` filter."""
+    return wanted is None or entry_format is None or entry_format == wanted
+
+
+def _is_domain_type(domain_type: DomainType, wanted: str | None) -> bool:
+    """Whether a host's purpose satisfies a ``--domain-type`` filter."""
+    return wanted is None or domain_type.value == wanted
+
+
+def _custom_entries(records) -> list[dict]:
+    """Render custom-domain records as document entries, in the order given."""
+    return [
+        {
+            "host": record.host,
+            "format": format_for_backend_kind(record.backend_kind),
+            "type": "custom",
+            "domain_type": record.domain_type.value,
+            "org": record.org,
+            "repository": record.repository,
+            "primary": record.primary,
+            "created_at": record.created_at,
+        }
+        for record in records
+    ]
+
+
+@main.group(name="domains", cls=command.AliasGroup, aliases=["domain"])
+def domains_():
+    """
+    Inspect the Cloudsmith domains the CLI can authenticate.
+
+    See the help for subcommands for more information on each.
+    """
+
+
+@domains_.command(name="list", aliases=["ls"])
+@click.option(
+    "--refresh",
+    is_flag=True,
+    default=False,
+    help="Bypass the custom-domain cache and fetch fresh data from the API.",
+)
+@click.option(
+    "--format",
+    "format_",
+    default=None,
+    help="Only list hosts usable for this package format. Hosts that serve no "
+    "single format (the download CDN, the generic upload endpoint) serve every "
+    "format and are always listed.",
+)
+@click.option(
+    "--domain-type",
+    "domain_type",
+    default=None,
+    help="Only list hosts with this purpose: download, upload, api, or "
+    "native_api. Every host has exactly one, so this is an exact match.",
+)
+@click.option(
+    "--repo",
+    "--repository",
+    "repo",
+    default=None,
+    help="Only list hosts usable for this repository, most-preferred first. "
+    "Drops custom domains bound to a different repository.",
+)
+@common_cli_config_options
+@common_api_auth_options
+@initialise_api
+@click.pass_context
+def list_domains(  # pylint: disable=too-many-arguments
+    ctx,
+    opts,
+    refresh: bool,
+    format_: str | None,
+    domain_type: str | None,
+    repo: str | None,
+) -> None:
+    """Emit the Cloudsmith hosts and their package formats as JSON.
+
+    Machine-readable output for programmatic consumers. It lists the built-in
+    ``*.cloudsmith.io`` service hosts alongside custom domains, with ``type``
+    distinguishing ``default`` from ``custom`` and ``domain_type`` saying what
+    each host is for: ``download``, ``upload``, or ``native_api`` for a host
+    speaking one package format's own protocol. An organisation's own custom
+    domains are listed ahead of the built-in hosts, which serve as the
+    fallback. Only usable hosts are listed: a custom domain that is disabled or
+    not yet validated serves nothing, so it is left out rather than offered as
+    somewhere to publish to. Check it in the Cloudsmith UI if one you expect is
+    missing here.
+
+    Built-in hosts are always listed and need no organisation or authentication.
+    An organisation from ``--org``, CLOUDSMITH_ORG or ``org`` in ``config.ini``
+    adds its custom domains, and a failed lookup exits non-zero rather than
+    rendering as "no domains". With no organisation the command lists whatever
+    earlier runs cached and makes no API call; ``--refresh`` bypasses that cache
+    for a configured organisation.
+
+    Where two custom domains could serve the same request Cloudsmith picks the
+    one bound to the repository in hand, then ``primary`` over secondary, then
+    the oldest — so ``created_at`` is reported to make that order reproducible.
+
+    Output (stdout):
+        JSON: {"version": 1, "domains": [{"host": ..., "format": ...,
+        "type": ..., "domain_type": ..., "org": ..., "repository": ...,
+        "primary": ..., "created_at": ...}]}
+
+    Examples:
+
+    \b
+        # List built-in hosts plus any custom domains already cached
+        $ cloudsmith domains list
+
+    \b
+        # List built-in hosts plus an organisation's custom domains
+        $ cloudsmith domains list --org my-org
+
+    \b
+        # The hosts usable for one repository, most-preferred first
+        $ cloudsmith domains list --org my-org --repo my-repo --format maven
+
+    \b
+        # Where to upload to
+        $ cloudsmith domains list --org my-org --domain-type upload
+    """
+    explicit_config = ctx.meta.get("config_file")
+    if explicit_config and os.path.isdir(explicit_config):
+        explicit_config = os.path.join(explicit_config, "config.ini")
+
+    if explicit_config is None and untrusted_config_declares_domains():
+        click.secho(
+            "Warning: ignoring [domains] section in ./config.ini -- config.ini "
+            "in the current directory is untrusted. Put it in "
+            f"{get_default_config_path()} or ~/.cloudsmith instead.",
+            fg="yellow",
+            err=True,
+        )
+
+    wanted_format = _label(format_)
+    wanted_type = _label(domain_type)
+    repository = _label(repo)
+
+    default_entries = [
+        {
+            "host": domain.host,
+            "format": domain.format_label,
+            "type": "default",
+            "domain_type": domain.domain_type.value,
+            "org": None,
+            "repository": None,
+            "primary": True,
+            "created_at": None,
+        }
+        for domain in load_default_domains(config_path=explicit_config)
+        if _serves_format(domain.format_label, wanted_format)
+        and _is_domain_type(domain.domain_type, wanted_type)
+    ]
+
+    org = opts.org
+    if org:
+        try:
+            records = get_custom_domains(
+                org,
+                credential=opts.credential,
+                api_host=opts.api_host,
+                refresh=refresh,
+                strict=True,
+                configure_api=False,
+            )
+        except ApiException as exc:
+            raise click.ClickException(
+                f"Failed to fetch custom domains for {org!r}: {exc}"
+            ) from exc
+    else:
+        if refresh:
+            click.secho(
+                "Warning: --refresh needs an organisation to fetch from, so the "
+                "cached custom domains below are unchanged. Set --org, "
+                "CLOUDSMITH_ORG or org in config.ini.",
+                fg="yellow",
+                err=True,
+            )
+        records = read_all_cached_domains()
+
+    records = [
+        record
+        for record in records
+        if _serves_format(format_for_backend_kind(record.backend_kind), wanted_format)
+        and _is_domain_type(record.domain_type, wanted_type)
+        and record.is_active
+        and (repository is None or record.serves_repository(repository))
+    ]
+    if repository:
+        records = order_by_precedence(records, repository)
+    else:
+        records = sorted(records, key=lambda record: (record.org, record.host))
+
+    data = _custom_entries(records) + default_entries
+
+    click.echo(json.dumps({"version": PROTOCOL_VERSION, "domains": data}))

--- a/cloudsmith_cli/cli/commands/domains.py
+++ b/cloudsmith_cli/cli/commands/domains.py
@@ -97,8 +97,8 @@ def domains_():
     "--domain-type",
     "domain_type",
     default=None,
-    help="Only list hosts with this purpose: download, upload, api, or "
-    "native_api. Every host has exactly one, so this is an exact match.",
+    help="Only list hosts with this purpose: download, upload, or native_api. "
+    "Every host has exactly one, so this is an exact match.",
 )
 @click.option(
     "--repo",
@@ -143,6 +143,9 @@ def list_domains(  # pylint: disable=too-many-arguments
     Where two custom domains could serve the same request Cloudsmith picks the
     one bound to the repository in hand, then ``primary`` over secondary, then
     the oldest — so ``created_at`` is reported to make that order reproducible.
+    The custom domains are always listed in that order, so the first is the one
+    Cloudsmith would bind; ``--repo`` is what lets the repository-bound hosts
+    take part in it.
 
     Output (stdout):
         JSON: {"version": 1, "domains": [{"host": ..., "format": ...,
@@ -234,10 +237,9 @@ def list_domains(  # pylint: disable=too-many-arguments
         and record.is_active
         and (repository is None or record.serves_repository(repository))
     ]
-    if repository:
-        records = order_by_precedence(records, repository)
-    else:
-        records = sorted(records, key=lambda record: (record.org, record.host))
+    records = sorted(
+        order_by_precedence(records, repository), key=lambda record: record.org
+    )
 
     data = _custom_entries(records) + default_entries
 

--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -67,6 +67,8 @@ class ConfigSchema:
         mcp_allowed_tools = ConfigParam(name="mcp_allowed_tools", type=str)
         mcp_allowed_tool_groups = ConfigParam(name="mcp_allowed_tool_groups", type=str)
         oidc_audience = ConfigParam(name="oidc_audience", type=str)
+        org = ConfigParam(name="org", type=str)
+        organization = ConfigParam(name="organization", type=str)
         oidc_org = ConfigParam(name="oidc_org", type=str)
         oidc_service_slug = ConfigParam(name="oidc_service_slug", type=str)
         oidc_detector_order = ConfigParam(name="oidc_detector_order", type=str)
@@ -484,14 +486,36 @@ class Options:  # pylint: disable=too-many-public-methods
         self._set_option("oidc_audience", value)
 
     @property
+    def org(self):
+        """Get value for the Cloudsmith organisation slug."""
+        return self._get_option("org")
+
+    @org.setter
+    def org(self, value):
+        """Set value for the Cloudsmith organisation slug."""
+        if isinstance(value, str):
+            value = value.strip() or None
+        self._set_option("org", value)
+
+    @property
+    def organization(self):
+        """Get the organisation slug, spelled in full."""
+        return self.org
+
+    @organization.setter
+    def organization(self, value):
+        """Set the organisation slug, spelled in full."""
+        self.org = value
+
+    @property
     def oidc_org(self):
-        """Get value for OIDC organisation slug."""
-        return self._get_option("oidc_org")
+        """Get the organisation slug under its original OIDC-era name."""
+        return self.org
 
     @oidc_org.setter
     def oidc_org(self, value):
-        """Set value for OIDC organisation slug."""
-        self._set_option("oidc_org", value)
+        """Set the organisation slug under its original OIDC-era name."""
+        self.org = value
 
     @property
     def oidc_service_slug(self):

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -412,9 +412,12 @@ def resolve_credentials(f):
         help="The OIDC audience for token requests.",
     )
     @click.option(
+        "--org",
+        "--organization",
         "--oidc-org",
+        "org",
         envvar="CLOUDSMITH_ORG",
-        help="The Cloudsmith organisation slug for OIDC token exchange.",
+        help="The Cloudsmith organisation slug.",
     )
     @click.option(
         "--oidc-service-slug",
@@ -441,15 +444,15 @@ def resolve_credentials(f):
         opts = config.get_or_create_options(ctx)
 
         oidc_audience = kwargs.pop("oidc_audience")
-        oidc_org = kwargs.pop("oidc_org")
+        org = kwargs.pop("org")
         oidc_service_slug = kwargs.pop("oidc_service_slug")
         oidc_discovery_disabled = _pop_boolean_flag(kwargs, "oidc_discovery_disabled")
         oidc_detector_order = kwargs.pop("oidc_detector_order")
 
         if oidc_audience:
             opts.oidc_audience = oidc_audience
-        if oidc_org:
-            opts.oidc_org = oidc_org
+        if org:
+            opts.org = org
         if oidc_service_slug:
             opts.oidc_service_slug = oidc_service_slug
         if oidc_discovery_disabled:
@@ -474,7 +477,7 @@ def resolve_credentials(f):
             profile=ctx.meta.get("profile"),
             debug=opts.debug,
             oidc_audience=opts.oidc_audience,
-            oidc_org=opts.oidc_org,
+            org=opts.org,
             oidc_service_slug=opts.oidc_service_slug,
             oidc_discovery_disabled=opts.oidc_discovery_disabled,
             oidc_detector_order=opts.oidc_detector_order,

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import time
 from unittest.mock import patch
 
 import httpretty
@@ -9,11 +10,13 @@ import httpretty.core
 import pytest
 
 from ....cli.commands.credential_helper.docker import docker
+from ....core.api.exceptions import ApiException
 from ....core.api.init import initialise_api
 from ....core.credentials.models import CredentialResult
 from ....credential_helpers.backends import BackendKind
 from ....credential_helpers.common import is_cloudsmith_domain
 from ....credential_helpers.custom_domains import (
+    CACHE_FORMAT_VERSION,
     CustomDomain,
     get_cache_path,
     get_custom_domains,
@@ -21,6 +24,7 @@ from ....credential_helpers.custom_domains import (
     read_cache,
     write_cache,
 )
+from ....credential_helpers.default_domains import DomainType
 from ....credential_helpers.docker.runtime import (
     _REFUSAL_MESSAGE,
     execute,
@@ -238,10 +242,8 @@ def _cache_dir(tmp_path, monkeypatch):
     [
         # 200 → records built and cached
         (200, True, True),
-        # 402 → [] and cached (feature not enabled)
-        (402, False, True),
-        # 404 → [] and cached (org not found)
-        (404, False, True),
+        # 404 → [] but NOT cached
+        (404, False, False),
         # 403 → [] but NOT cached (may succeed after auth)
         (403, False, False),
         # 401 → [] but NOT cached (same branch as 403)
@@ -304,6 +306,80 @@ def test_get_custom_domains_status_matrix(
         assert httpretty.last_request().headers.get("X-Api-Key") == "k_abc"
 
 
+@pytest.mark.parametrize(
+    "status,expect_raise",
+    [
+        (200, False),
+        (401, True),
+        (403, True),
+        (404, True),
+        (500, True),
+    ],
+)
+@httpretty.activate(allow_net_connect=False)
+def test_get_custom_domains_strict_raises_on_failure(
+    tmp_path, monkeypatch, status, expect_raise
+):
+    """strict=True re-raises failures instead of degrading to [].
+
+    Consumers presenting results to a user (`cloudsmith domains list`) must
+    not render a typo'd org or an unreachable API as "no custom domains".
+    """
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+    body = json.dumps([]) if status == 200 else json.dumps({"detail": "error"})
+    httpretty.register_uri(
+        httpretty.GET,
+        f"{API_HOST}/orgs/acme/custom-domains/",
+        body=body,
+        status=status,
+        content_type="application/json",
+    )
+
+    credential = CredentialResult(api_key="k_abc", source_name="test")
+    if expect_raise:
+        with pytest.raises(ApiException):
+            get_custom_domains(
+                "acme", credential=credential, api_host=API_HOST, strict=True
+            )
+    else:
+        result = get_custom_domains(
+            "acme", credential=credential, api_host=API_HOST, strict=True
+        )
+        assert result == []
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_custom_domains_caches_an_empty_listing(tmp_path, monkeypatch):
+    """An org with no custom domains answers 200 with an empty array.
+
+    That is a real answer rather than a failure, so it is cached like any
+    other: a second lookup within the TTL must be served from the cache
+    instead of asking again.
+    """
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        f"{API_HOST}/orgs/acme/custom-domains/",
+        body=json.dumps([]),
+        status=200,
+        content_type="application/json",
+    )
+    credential = CredentialResult(api_key="k_abc", source_name="test")
+
+    assert get_custom_domains("acme", credential=credential, api_host=API_HOST) == []
+    assert read_cache(get_cache_path("acme")) == []
+    assert len(httpretty.latest_requests()) == 1
+
+    assert get_custom_domains("acme", credential=credential, api_host=API_HOST) == []
+    assert len(httpretty.latest_requests()) == 1
+
+
 @httpretty.activate(allow_net_connect=False)
 def test_get_custom_domains_bearer_credential_sends_authorization_header(
     tmp_path, monkeypatch
@@ -325,8 +401,6 @@ def test_get_custom_domains_bearer_credential_sends_authorization_header(
         content_type="application/json",
     )
 
-    # A previously configured API key must not leak into a bearer-authenticated
-    # request: initialise_api clears the class-default X-Api-Key when switching.
     initialise_api(
         host=API_HOST,
         credential=CredentialResult(api_key="k_stale", source_name="test"),
@@ -357,8 +431,6 @@ def test_get_custom_domains_bearer_credential_sends_authorization_header(
 )
 def test_get_custom_domains_cache_edge(tmp_path, monkeypatch, scenario, expected):
     """Cache format edge cases: legacy string-list is a miss; empty list is a hit."""
-    import time
-
     monkeypatch.setattr(
         "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
         lambda: str(tmp_path),
@@ -367,9 +439,16 @@ def test_get_custom_domains_cache_edge(tmp_path, monkeypatch, scenario, expected
     cache_path = get_cache_path("acme")
 
     if scenario == "legacy_string_list":
+        # A real legacy document predates format_version, which is what makes
+        # it a miss - stamping the current version on it would describe a
+        # document no build has ever written.
         data = {"domains": ["docker.acme.com"], "cached_at": time.time()}
     else:
-        data = {"domains": [], "cached_at": time.time()}
+        data = {
+            "format_version": CACHE_FORMAT_VERSION,
+            "domains": [],
+            "cached_at": time.time(),
+        }
 
     cache_path.write_text(json.dumps(data), encoding="utf-8")
     assert read_cache(cache_path) == expected
@@ -457,7 +536,7 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "host,env_org,cached_domains,backend_kind,expected",
+    "host,org,cached_domains,backend_kind,expected",
     [
         # Standard *.cloudsmith.io → True (no API)
         ("docker.cloudsmith.io", None, None, None, True),
@@ -472,7 +551,12 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
             "acme",
             [
                 CustomDomain(
-                    host="docker.acme.com", backend_kind=6, enabled=True, validated=True
+                    host="docker.acme.com",
+                    backend_kind=6,
+                    domain_type=DomainType.NATIVE_API,
+                    enabled=True,
+                    validated=True,
+                    org="acme",
                 )
             ],
             None,
@@ -486,8 +570,10 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
                 CustomDomain(
                     host="docker.acme.com",
                     backend_kind=6,
+                    domain_type=DomainType.NATIVE_API,
                     enabled=False,
                     validated=True,
+                    org="acme",
                 )
             ],
             None,
@@ -501,8 +587,10 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
                 CustomDomain(
                     host="docker.acme.com",
                     backend_kind=6,
+                    domain_type=DomainType.NATIVE_API,
                     enabled=True,
                     validated=False,
+                    org="acme",
                 )
             ],
             None,
@@ -514,7 +602,12 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
             "acme",
             [
                 CustomDomain(
-                    host="docker.acme.com", backend_kind=6, enabled=True, validated=True
+                    host="docker.acme.com",
+                    backend_kind=6,
+                    domain_type=DomainType.NATIVE_API,
+                    enabled=True,
+                    validated=True,
+                    org="acme",
                 )
             ],
             BackendKind.DOCKER,
@@ -526,7 +619,12 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
             "acme",
             [
                 CustomDomain(
-                    host="npm.acme.com", backend_kind=9, enabled=True, validated=True
+                    host="npm.acme.com",
+                    backend_kind=9,
+                    domain_type=DomainType.NATIVE_API,
+                    enabled=True,
+                    validated=True,
+                    org="acme",
                 )
             ],
             BackendKind.DOCKER,
@@ -539,7 +637,12 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
             "acme",
             [
                 CustomDomain(
-                    host="docker.acme.com", backend_kind=6, enabled=True, validated=True
+                    host="docker.acme.com",
+                    backend_kind=6,
+                    domain_type=DomainType.NATIVE_API,
+                    enabled=True,
+                    validated=True,
+                    org="acme",
                 )
             ],
             BackendKind.DOCKER,
@@ -548,7 +651,7 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
     ],
 )
 def test_is_cloudsmith_domain(
-    tmp_path, monkeypatch, host, env_org, cached_domains, backend_kind, expected
+    tmp_path, monkeypatch, host, org, cached_domains, backend_kind, expected
 ):
     """is_cloudsmith_domain returns correct bool for standard, custom, and edge cases."""
     monkeypatch.setattr(
@@ -556,59 +659,19 @@ def test_is_cloudsmith_domain(
         lambda: str(tmp_path),
     )
 
-    if env_org:
-        monkeypatch.setenv("CLOUDSMITH_ORG", env_org)
-    else:
-        monkeypatch.delenv("CLOUDSMITH_ORG", raising=False)
-
     if cached_domains is not None:
-        write_cache(get_cache_path(env_org), cached_domains)
+        write_cache(get_cache_path(org), cached_domains)
 
     kwargs = {
         "credential": CredentialResult(api_key="k_abc", source_name="test"),
         "api_host": API_HOST,
+        "org": org,
     }
     if backend_kind is not None:
         kwargs["backend_kind"] = backend_kind
 
     result = is_cloudsmith_domain(host, **kwargs)
     assert result is expected
-
-
-@pytest.mark.parametrize(
-    "credential",
-    [
-        # no credential at all
-        None,
-        # a credential carrying no usable key — truthy as an object, so the
-        # guard has to look at api_key, not just the credential
-        CredentialResult(api_key="", source_name="test"),
-    ],
-)
-@httpretty.activate(allow_net_connect=False)
-def test_is_cloudsmith_domain_custom_domain_without_credential(
-    tmp_path, monkeypatch, credential
-):
-    """A custom-domain check without a usable credential refuses without an API call."""
-    monkeypatch.setattr(
-        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
-        lambda: str(tmp_path),
-    )
-    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
-
-    called = []
-    monkeypatch.setattr(
-        "cloudsmith_cli.credential_helpers.custom_domains.list_custom_domains",
-        lambda *_a, **_kw: called.append(True) or [],
-    )
-
-    assert (
-        is_cloudsmith_domain(
-            "docker.acme.com", credential=credential, api_host=API_HOST
-        )
-        is False
-    )
-    assert not called, "the custom-domain API must not be queried without a credential"
 
 
 # ---------------------------------------------------------------------------
@@ -632,7 +695,12 @@ def test_get_credentials_refuses_npm_custom_domain(tmp_path, monkeypatch):
         cache_path,
         [
             CustomDomain(
-                host="npm.acme.com", backend_kind=9, enabled=True, validated=True
+                host="npm.acme.com",
+                backend_kind=9,
+                domain_type=DomainType.NATIVE_API,
+                enabled=True,
+                validated=True,
+                org="acme",
             )
         ],
     )

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
@@ -21,6 +21,7 @@ from ....credential_helpers.custom_domains import (
     get_cache_path,
     get_custom_domains,
     get_format_domains,
+    read_all_cached_domains,
     read_cache,
     write_cache,
 )
@@ -454,6 +455,32 @@ def test_get_custom_domains_cache_edge(tmp_path, monkeypatch, scenario, expected
     assert read_cache(cache_path) == expected
 
 
+def test_cache_that_is_not_utf8_reads_as_a_miss(tmp_path, monkeypatch):
+    """A cache file of undecodable bytes is a miss, not a crash."""
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+
+    cache_path = get_cache_path("acme")
+    cache_path.write_bytes(b"\xff\xfe not utf-8 at all")
+
+    assert read_cache(cache_path) is None
+    assert not read_all_cached_domains()
+
+
+def test_unwritable_config_dir_reads_as_no_cached_domains(tmp_path, monkeypatch):
+    """An unwritable config directory yields no cached domains, not a crash."""
+    read_only = tmp_path / "read-only"
+    read_only.mkdir(mode=0o500)
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(read_only),
+    )
+
+    assert not read_all_cached_domains()
+
+
 # ---------------------------------------------------------------------------
 # 8. get_format_domains
 # ---------------------------------------------------------------------------
@@ -528,6 +555,24 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
     )
 
     assert hosts == ["docker.acme.com"]
+
+
+def test_get_format_domains_forwards_configure_api(monkeypatch):
+    """A caller that has already configured the SDK can say so."""
+    recorded = {}
+
+    def _fake_get_custom_domains(org, **kwargs):
+        recorded.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_custom_domains",
+        _fake_get_custom_domains,
+    )
+
+    get_format_domains("acme", BackendKind.DOCKER, configure_api=False)
+
+    assert recorded["configure_api"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper.py
@@ -9,6 +9,7 @@ import httpretty.core
 import pytest
 
 from ....cli.commands.credential_helper.docker import docker
+from ....core.api.init import unset_api_key
 from ....core.credentials.models import CredentialResult
 from ....credential_helpers.backends import BackendKind
 from ....credential_helpers.custom_domains import (
@@ -157,8 +158,9 @@ def test_get_credentials(server_url, credential, is_cloudsmith_return, expected)
         with patch(
             "cloudsmith_cli.credential_helpers.docker.runtime.is_cloudsmith_domain",
             return_value=is_cloudsmith_return,
-        ):
+        ) as mock_check:
             result = helper_get_credentials(server_url, credential=credential)
+        assert mock_check.call_args.kwargs["credential"] is credential
 
     assert result == expected
 
@@ -281,7 +283,8 @@ def test_get_custom_domains_status_matrix(
         content_type="application/json",
     )
 
-    result = get_custom_domains("acme", api_key="k_abc", api_host=API_HOST)
+    credential = CredentialResult(api_key="k_abc", source_name="test")
+    result = get_custom_domains("acme", credential=credential, api_host=API_HOST)
     cache = read_cache(get_cache_path("acme"))
 
     if expect_domains:
@@ -298,6 +301,40 @@ def test_get_custom_domains_status_matrix(
     # For the 200 case specifically, verify the auth header (X-Api-Key)
     if status == 200:
         assert httpretty.last_request().headers.get("X-Api-Key") == "k_abc"
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_custom_domains_bearer_credential_sends_authorization_header(
+    tmp_path, monkeypatch
+):
+    """A bearer credential authenticates the lookup with its own header scheme.
+
+    The credential object flows through to the API layer unmodified, so an
+    SSO access token goes out as ``Authorization: Bearer``, never ``X-Api-Key``.
+    """
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+    httpretty.register_uri(
+        httpretty.GET,
+        f"{API_HOST}/orgs/acme/custom-domains/",
+        body=json.dumps([]),
+        status=200,
+        content_type="application/json",
+    )
+
+    # initialise_api never clears the class-default api_key dict, so an
+    # X-Api-Key set by an earlier test would otherwise leak into this request.
+    unset_api_key()
+    credential = CredentialResult(
+        api_key="jwt_token", source_name="test", auth_type="bearer"
+    )
+    get_custom_domains("acme", credential=credential, api_host=API_HOST)
+
+    headers = httpretty.last_request().headers
+    assert headers.get("Authorization") == "Bearer jwt_token"
+    assert headers.get("X-Api-Key") is None
 
 
 # ---------------------------------------------------------------------------
@@ -401,7 +438,10 @@ def test_get_format_domains_filters_correctly(tmp_path, monkeypatch):
     )
 
     hosts = get_format_domains(
-        "acme", BackendKind.DOCKER, api_key="k", api_host=API_HOST
+        "acme",
+        BackendKind.DOCKER,
+        credential=CredentialResult(api_key="k", source_name="test"),
+        api_host=API_HOST,
     )
 
     assert hosts == ["docker.acme.com"]
@@ -522,12 +562,24 @@ def test_is_cloudsmith_domain(
     if cached_domains is not None:
         write_cache(get_cache_path(env_org), cached_domains)
 
-    kwargs = {"api_key": "k_abc", "api_host": API_HOST}
+    kwargs = {
+        "credential": CredentialResult(api_key="k_abc", source_name="test"),
+        "api_host": API_HOST,
+    }
     if backend_kind is not None:
         kwargs["backend_kind"] = backend_kind
 
     result = is_cloudsmith_domain(host, **kwargs)
     assert result is expected
+
+
+def test_is_cloudsmith_domain_custom_domain_without_credential(monkeypatch):
+    """A custom-domain check without a credential refuses without an API call."""
+    from ....credential_helpers.common import is_cloudsmith_domain
+
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    assert is_cloudsmith_domain("docker.acme.com", api_host=API_HOST) is False
 
 
 # ---------------------------------------------------------------------------

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
@@ -336,6 +336,8 @@ _INSTALLER_GET_FORMAT_DOMAINS = (
         "no_discover",
         "missing_org",
         "missing_credential",
+        "blank_credential",
+        "dry_run",
         "discovery_raises",
     ],
 )
@@ -386,7 +388,7 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         assert "docker.cloudsmith.io" in cfg["credHelpers"]
         assert "docker.acme.com" not in cfg["credHelpers"]
 
-    elif scenario in ("missing_org", "missing_credential"):
+    elif scenario in ("missing_org", "missing_credential", "blank_credential"):
         called = []
 
         def _should_not_be_called(*_a, **_kw):
@@ -396,15 +398,39 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
         installer = DockerInstaller()
         org = None if scenario == "missing_org" else "acme"
-        creds = None if scenario == "missing_credential" else credential
+        creds = {
+            "missing_org": credential,
+            "missing_credential": None,
+            "blank_credential": CredentialResult(api_key="", source_name="test"),
+        }
         installer.install(
-            bin_dir=str(bin_dir), discover=True, org=org, credential=creds
+            bin_dir=str(bin_dir), discover=True, org=org, credential=creds[scenario]
         )
         assert (
             not called
         ), "get_format_domains must not be called when org/credential absent"
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert cfg["credHelpers"]["docker.cloudsmith.io"] == "cloudsmith"
+
+    elif scenario == "dry_run":
+        called = []
+
+        def _should_not_be_called(*_a, **_kw):
+            called.append(True)
+            return []
+
+        monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
+        installer = DockerInstaller()
+        actions = installer.install(
+            bin_dir=str(bin_dir),
+            discover=True,
+            org="acme",
+            credential=credential,
+            dry_run=True,
+        )
+        assert not called, "a dry run must not query the custom-domain API"
+        assert not (docker_dir / "config.json").exists()
+        assert any("skipped custom-domain auto-discovery" in a for a in actions)
 
     else:  # discovery_raises — graceful failure guard
 

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
@@ -14,6 +14,7 @@ import click.testing
 import pytest
 
 from ....core.credentials.models import CredentialResult
+from ....credential_helpers.default_domains import DomainType
 from ....credential_helpers.docker.installer import DockerInstaller
 from ....credential_helpers.launchers import (
     _launcher_content,
@@ -335,8 +336,6 @@ _INSTALLER_GET_FORMAT_DOMAINS = (
         "no_discover",
         "missing_org",
         "missing_credential",
-        "blank_credential",
-        "dry_run",
         "discovery_raises",
     ],
 )
@@ -387,7 +386,7 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         assert "docker.cloudsmith.io" in cfg["credHelpers"]
         assert "docker.acme.com" not in cfg["credHelpers"]
 
-    elif scenario in ("missing_org", "missing_credential", "blank_credential"):
+    elif scenario in ("missing_org", "missing_credential"):
         called = []
 
         def _should_not_be_called(*_a, **_kw):
@@ -397,39 +396,15 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
         installer = DockerInstaller()
         org = None if scenario == "missing_org" else "acme"
-        creds = {
-            "missing_org": credential,
-            "missing_credential": None,
-            "blank_credential": CredentialResult(api_key="", source_name="test"),
-        }
+        creds = None if scenario == "missing_credential" else credential
         installer.install(
-            bin_dir=str(bin_dir), discover=True, org=org, credential=creds[scenario]
+            bin_dir=str(bin_dir), discover=True, org=org, credential=creds
         )
         assert (
             not called
         ), "get_format_domains must not be called when org/credential absent"
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert cfg["credHelpers"]["docker.cloudsmith.io"] == "cloudsmith"
-
-    elif scenario == "dry_run":
-        called = []
-
-        def _should_not_be_called(*_a, **_kw):
-            called.append(True)
-            return []
-
-        monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
-        installer = DockerInstaller()
-        actions = installer.install(
-            bin_dir=str(bin_dir),
-            discover=True,
-            org="acme",
-            credential=credential,
-            dry_run=True,
-        )
-        assert not called, "a dry run must not query the custom-domain API"
-        assert not (docker_dir / "config.json").exists()
-        assert any("skipped custom-domain auto-discovery" in a for a in actions)
 
     else:  # discovery_raises — graceful failure guard
 
@@ -474,13 +449,23 @@ def test_refresh_flag(tmp_path, monkeypatch, refresh):
 
     cache_path = get_cache_path("acme")
     cached_domain = CustomDomain(
-        host="docker.acme.com", backend_kind=6, enabled=True, validated=True
+        host="docker.acme.com",
+        backend_kind=6,
+        enabled=True,
+        validated=True,
+        org="acme",
+        domain_type=DomainType.NATIVE_API,
     )
     write_cache(cache_path, [cached_domain])
     os.utime(cache_path, (time.time(), time.time()))
 
     fresh_domain = CustomDomain(
-        host="new.acme.com", backend_kind=6, enabled=True, validated=True
+        host="new.acme.com",
+        backend_kind=6,
+        enabled=True,
+        validated=True,
+        org="acme",
+        domain_type=DomainType.NATIVE_API,
     )
     api_calls = []
 
@@ -492,6 +477,8 @@ def test_refresh_flag(tmp_path, monkeypatch, refresh):
                 "backend_kind": 6,
                 "enabled": True,
                 "validated": True,
+                "domain_type": 3,
+                "primary": True,
             }
         ]
 

--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import click.testing
 import pytest
 
+from ....core.credentials.models import CredentialResult
 from ....credential_helpers.docker.installer import DockerInstaller
 from ....credential_helpers.launchers import (
     _launcher_content,
@@ -333,7 +334,7 @@ _INSTALLER_GET_FORMAT_DOMAINS = (
         "discovery_on",
         "no_discover",
         "missing_org",
-        "missing_api_key",
+        "missing_credential",
         "discovery_raises",
     ],
 )
@@ -347,19 +348,25 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
     bin_dir = tmp_path / "bin"
     monkeypatch.setenv("PATH", str(bin_dir))
 
+    credential = CredentialResult(api_key="k_test", source_name="test")
+
     if scenario == "discovery_on":
-        monkeypatch.setattr(
-            _INSTALLER_GET_FORMAT_DOMAINS,
-            lambda *_a, **_kw: ["docker.acme.com"],
-        )
+        captured = {}
+
+        def _fake_get_format_domains(*_a, **kwargs):
+            captured.update(kwargs)
+            return ["docker.acme.com"]
+
+        monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _fake_get_format_domains)
         installer = DockerInstaller()
         actions = installer.install(
-            bin_dir=str(bin_dir), discover=True, org="acme", api_key="k_test"
+            bin_dir=str(bin_dir), discover=True, org="acme", credential=credential
         )
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert cfg["credHelpers"]["docker.cloudsmith.io"] == "cloudsmith"
         assert cfg["credHelpers"]["docker.acme.com"] == "cloudsmith"
         assert any("discovered" in a and "1" in a for a in actions)
+        assert captured["credential"] is credential
 
     elif scenario == "no_discover":
         called = []
@@ -371,14 +378,14 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
         installer = DockerInstaller()
         installer.install(
-            bin_dir=str(bin_dir), discover=False, org="acme", api_key="k_test"
+            bin_dir=str(bin_dir), discover=False, org="acme", credential=credential
         )
         assert not called, "get_format_domains must not be called when discover=False"
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert "docker.cloudsmith.io" in cfg["credHelpers"]
         assert "docker.acme.com" not in cfg["credHelpers"]
 
-    elif scenario in ("missing_org", "missing_api_key"):
+    elif scenario in ("missing_org", "missing_credential"):
         called = []
 
         def _should_not_be_called(*_a, **_kw):
@@ -388,11 +395,11 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         monkeypatch.setattr(_INSTALLER_GET_FORMAT_DOMAINS, _should_not_be_called)
         installer = DockerInstaller()
         org = None if scenario == "missing_org" else "acme"
-        api_key = "k_test" if scenario == "missing_org" else None
-        installer.install(bin_dir=str(bin_dir), discover=True, org=org, api_key=api_key)
+        cred = credential if scenario == "missing_org" else None
+        installer.install(bin_dir=str(bin_dir), discover=True, org=org, credential=cred)
         assert (
             not called
-        ), "get_format_domains must not be called when org/api_key absent"
+        ), "get_format_domains must not be called when org/credential absent"
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert cfg["credHelpers"]["docker.cloudsmith.io"] == "cloudsmith"
 
@@ -405,7 +412,7 @@ def test_autodiscovery(tmp_path, monkeypatch, scenario):
         installer = DockerInstaller()
         # Must NOT raise
         actions = installer.install(
-            bin_dir=str(bin_dir), discover=True, org="acme", api_key="k_test"
+            bin_dir=str(bin_dir), discover=True, org="acme", credential=credential
         )
         cfg = json.loads((docker_dir / "config.json").read_text())
         assert cfg["credHelpers"]["docker.cloudsmith.io"] == "cloudsmith"
@@ -464,7 +471,11 @@ def test_refresh_flag(tmp_path, monkeypatch, refresh):
         "cloudsmith_cli.credential_helpers.custom_domains.list_custom_domains",
         _fake_list,
     ):
-        result = get_custom_domains("acme", api_key="k", refresh=refresh)
+        result = get_custom_domains(
+            "acme",
+            credential=CredentialResult(api_key="k", source_name="test"),
+            refresh=refresh,
+        )
 
     if refresh:
         # API must have been called
@@ -510,6 +521,33 @@ def test_manage_cli_dry_run_exits_0(runner, tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "would" in result.output.lower() or "dry run" in result.output.lower()
+
+
+def test_manage_cli_passes_resolved_credential_to_installer(
+    runner, tmp_path, monkeypatch
+):
+    """install hands the resolved CredentialResult to the installer intact."""
+    monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path / ".docker"))
+
+    from ....cli.commands.credential_helper.manage import install_cmd
+
+    with patch.object(DockerInstaller, "install", return_value=[]) as mock_install:
+        result = runner.invoke(
+            install_cmd,
+            [
+                "docker",
+                "--no-discover",
+                "--bin-dir",
+                str(tmp_path / "bin"),
+                "--api-key",
+                "k_flag",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    credential = mock_install.call_args.kwargs["credential"]
+    assert isinstance(credential, CredentialResult)
+    assert credential.api_key == "k_flag"
 
 
 # ---------------------------------------------------------------------------

--- a/cloudsmith_cli/cli/tests/commands/test_custom_domain_precedence.py
+++ b/cloudsmith_cli/cli/tests/commands/test_custom_domain_precedence.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for custom-domain precedence and the record fields it ranks on.
+
+Those fields have to survive the on-disk cache: a run served from the cache
+must rank domains identically to the run that populated it.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from ....credential_helpers.backends import BackendKind
+from ....credential_helpers.custom_domains import (
+    CustomDomain,
+    _record_from_payload,
+    get_format_domains,
+    read_cache,
+    write_cache,
+)
+from ....credential_helpers.default_domains import DomainType
+
+
+def _domain(
+    host, *, backend_kind=None, primary=True, created_at="2025-01-01T00:00:00Z"
+):
+    """Build a CustomDomain record for a test."""
+    return CustomDomain(
+        host=host,
+        backend_kind=backend_kind,
+        enabled=True,
+        validated=True,
+        org="acme",
+        domain_type=(
+            DomainType.DOWNLOAD if backend_kind is None else DomainType.NATIVE_API
+        ),
+        primary=primary,
+        created_at=created_at,
+    )
+
+
+def test_format_domains_are_returned_in_precedence_order():
+    """The host Cloudsmith treats as active comes first.
+
+    Callers take the first host, so the order is the answer: primary beats
+    secondary, and the oldest breaks a tie between equals.
+    """
+    records = [
+        _domain("second.acme.com", backend_kind=BackendKind.DOCKER, primary=False),
+        _domain(
+            "third.acme.com",
+            backend_kind=BackendKind.DOCKER,
+            created_at="2026-01-01T00:00:00Z",
+        ),
+        _domain(
+            "first.acme.com",
+            backend_kind=BackendKind.DOCKER,
+            created_at="2024-01-01T00:00:00Z",
+        ),
+    ]
+
+    with patch(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_custom_domains",
+        return_value=records,
+    ):
+        hosts = get_format_domains("acme", BackendKind.DOCKER)
+
+    assert hosts == ["first.acme.com", "third.acme.com", "second.acme.com"]
+
+
+def test_precedence_fields_survive_the_api_and_the_cache(tmp_path):
+    """A cached run must rank domains the way the fetching run did.
+
+    The SDK deserialises ``created_at`` into a datetime that JSON cannot hold,
+    so it is normalised on the way in; dropping any of these fields on the way
+    to disk would silently fall back to API order for the whole seven-day TTL.
+    """
+    record = _record_from_payload(
+        {
+            "host": "dl.acme.com",
+            "enabled": True,
+            "validated": True,
+            "primary": False,
+            "repository": {"name": "Prod", "slug": "prod"},
+            "created_at": datetime(2025, 3, 4, 9, 22, 30, tzinfo=timezone.utc),
+        },
+        "acme",
+    )
+
+    assert record.created_at.startswith("2025-03-04T09:22:30")
+    assert record.primary is False
+    assert record.repository == "prod"
+
+    cache_path = tmp_path / "acme.json"
+    write_cache(cache_path, [record])
+
+    assert read_cache(cache_path) == [record]

--- a/cloudsmith_cli/cli/tests/commands/test_custom_domain_precedence.py
+++ b/cloudsmith_cli/cli/tests/commands/test_custom_domain_precedence.py
@@ -66,6 +66,26 @@ def test_format_domains_are_returned_in_precedence_order():
     assert hosts == ["first.acme.com", "third.acme.com", "second.acme.com"]
 
 
+def test_domain_with_no_creation_time_ranks_last_not_first():
+    """An unknown creation time is a last resort, not the oldest domain."""
+    records = [
+        _domain("nodate.acme.com", backend_kind=BackendKind.DOCKER, created_at=None),
+        _domain(
+            "dated.acme.com",
+            backend_kind=BackendKind.DOCKER,
+            created_at="2020-01-01T00:00:00Z",
+        ),
+    ]
+
+    with patch(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_custom_domains",
+        return_value=records,
+    ):
+        hosts = get_format_domains("acme", BackendKind.DOCKER)
+
+    assert hosts == ["dated.acme.com", "nodate.acme.com"]
+
+
 def test_precedence_fields_survive_the_api_and_the_cache(tmp_path):
     """A cached run must rank domains the way the fetching run did.
 

--- a/cloudsmith_cli/cli/tests/commands/test_default_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_default_domains.py
@@ -130,6 +130,14 @@ def test_an_entry_naming_no_format_is_skipped(tmp_path, no_trusted_config, label
     assert set(hosts) == {"packages.internal.example.com"}
 
 
+def test_a_config_that_is_not_utf8_falls_back_to_builtins(tmp_path, no_trusted_config):
+    """An undecodable config.ini falls back rather than aborting the command."""
+    config = tmp_path / "config.ini"
+    config.write_bytes(b"[domains]\nmaven.acme.example.com = maven\n# \xe9\xe8\xf1\n")
+
+    assert load_default_domains(config_path=config) == list(BUILTIN_DOMAINS)
+
+
 def test_trusted_lookup_skips_a_config_without_a_domains_section(tmp_path, monkeypatch):
     """The table comes from the first trusted config that declares one.
 

--- a/cloudsmith_cli/cli/tests/commands/test_default_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_default_domains.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the built-in default domain table and its config override."""
+
+import pytest
+
+from ....cli import config as cli_config
+from ....credential_helpers.backends import BackendKind
+from ....credential_helpers.default_domains import (
+    BUILTIN_DOMAINS,
+    DefaultDomain,
+    DomainType,
+    load_default_domains,
+    untrusted_config_declares_domains,
+)
+
+
+def _by_host(domains):
+    """Index a list of DefaultDomain records by host."""
+    return {domain.host: domain for domain in domains}
+
+
+@pytest.fixture
+def no_trusted_config(tmp_path, monkeypatch):
+    """Pin the trusted search path at an empty directory.
+
+    ``load_default_domains`` falls back to the trusted lookup, so without this
+    the developer's own ``config.ini`` decides what these tests observe.
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(cli_config.ConfigReader, "config_files", ["config.ini"])
+    monkeypatch.setattr(cli_config.ConfigReader, "config_searchpath", [str(empty)])
+
+
+@pytest.mark.parametrize(
+    "host,label,kind",
+    [
+        ("python.cloudsmith.io", "python", BackendKind.PYTHON),
+        ("docker.cloudsmith.io", "docker", BackendKind.DOCKER),
+        ("golang.cloudsmith.io", "go", BackendKind.GO),
+        ("dl.cloudsmith.io", None, None),
+        ("upload.cloudsmith.io", None, None),
+    ],
+)
+def test_builtin_entries_map_to_expected_kinds(host, label, kind):
+    """Each built-in host carries the right label and backend kind."""
+    assert len(BUILTIN_DOMAINS) == 21
+
+    domain = _by_host(BUILTIN_DOMAINS)[host]
+    assert domain.format_label == label
+    assert domain.backend_kind == kind
+
+
+@pytest.mark.parametrize("exists", [False, True], ids=["absent", "no-domains-section"])
+def test_a_config_declaring_no_table_falls_back_to_builtins(
+    tmp_path, no_trusted_config, exists
+):
+    """Only a readable [domains] section replaces the built-in table."""
+    config = tmp_path / "config.ini"
+    if exists:
+        config.write_text(
+            "[default]\napi_host = https://api.cloudsmith.io\n", encoding="utf-8"
+        )
+
+    assert load_default_domains(config_path=config) == list(BUILTIN_DOMAINS)
+
+
+def test_config_section_replaces_builtins_wholesale(tmp_path, no_trusted_config):
+    """A [domains] section replaces the built-in table entirely."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[domains]\n"
+        "packages.internal.example.com = python\n"
+        "cdn.internal.example.com = download\n",
+        encoding="utf-8",
+    )
+
+    domains = load_default_domains(config_path=config)
+
+    assert len(domains) == 2
+    indexed = _by_host(domains)
+    assert indexed["packages.internal.example.com"].backend_kind == BackendKind.PYTHON
+    assert indexed["packages.internal.example.com"].domain_type is DomainType.NATIVE_API
+    assert indexed["cdn.internal.example.com"].format_label is None
+    assert indexed["cdn.internal.example.com"].domain_type is DomainType.DOWNLOAD
+
+
+@pytest.mark.parametrize(
+    "label,domain_type",
+    [("download", DomainType.DOWNLOAD), ("upload", DomainType.UPLOAD)],
+)
+def test_config_reserved_labels_declare_formatless_hosts(
+    tmp_path, no_trusted_config, label, domain_type
+):
+    """`download` and `upload` name the two hosts no package format names.
+
+    A dedicated deployment has to redirect its upload endpoint, and no
+    BackendKind identifies it - without a reserved label the table cannot name
+    it at all.
+    """
+    config = tmp_path / "config.ini"
+    config.write_text(
+        f"[domains]\nhost.internal.example.com = {label}\n", encoding="utf-8"
+    )
+
+    domain = _by_host(load_default_domains(config_path=config))[
+        "host.internal.example.com"
+    ]
+
+    assert domain.domain_type is domain_type
+    assert domain.backend_kind is None
+
+
+@pytest.mark.parametrize("label", ["", "widget"], ids=["empty", "unrecognised"])
+def test_an_entry_naming_no_format_is_skipped(tmp_path, no_trusted_config, label):
+    """A label is required, and a bad one is dropped rather than guessed at.
+
+    Reading it as the download CDN would leave a typo'd format quietly serving
+    the wrong thing, which is far harder to spot than a missing host.
+    """
+    config = tmp_path / "config.ini"
+    config.write_text(
+        f"[domains]\npackages.internal.example.com = python\n"
+        f"broken.internal.example.com = {label}\n",
+        encoding="utf-8",
+    )
+
+    hosts = _by_host(load_default_domains(config_path=config))
+
+    assert set(hosts) == {"packages.internal.example.com"}
+
+
+def test_trusted_lookup_skips_a_config_without_a_domains_section(tmp_path, monkeypatch):
+    """The table comes from the first trusted config that declares one.
+
+    Existence is not enough: an app-dir config.ini holding only [default] api
+    settings would otherwise mask the deployment's [domains] override and
+    silently restore the public *.cloudsmith.io table.
+    """
+    without_domains = tmp_path / "app-dir"
+    with_domains = tmp_path / "home-dir"
+    without_domains.mkdir()
+    with_domains.mkdir()
+    (without_domains / "config.ini").write_text(
+        "[default]\napi_host = https://api.internal.example.com\n", encoding="utf-8"
+    )
+    (with_domains / "config.ini").write_text(
+        "[domains]\ncdn.internal.example.com = download\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(cli_config.ConfigReader, "config_files", ["config.ini"])
+    monkeypatch.setattr(
+        cli_config.ConfigReader,
+        "config_searchpath",
+        [str(without_domains), str(with_domains)],
+    )
+
+    assert load_default_domains() == [
+        DefaultDomain("cdn.internal.example.com", None, DomainType.DOWNLOAD)
+    ]
+
+
+def test_untrusted_cwd_config_is_not_honoured(tmp_path, monkeypatch):
+    """A [domains] section in a cwd config.ini is ignored, and detectable.
+
+    config.ini is searched in the working directory first, so a repository can
+    ship one. Honouring it here would let a malicious repo declare its own host
+    a Cloudsmith host and harvest a token.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.default_domains._trusted_domains",
+        lambda: None,
+    )
+    (tmp_path / "config.ini").write_text(
+        "[domains]\nevil.example.com = python\n", encoding="utf-8"
+    )
+
+    domains = load_default_domains()
+
+    assert all(domain.host != "evil.example.com" for domain in domains)
+    assert untrusted_config_declares_domains() is True

--- a/cloudsmith_cli/cli/tests/commands/test_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_domains.py
@@ -51,6 +51,7 @@ def _domain(
     domain_type=None,
     enabled=True,
     validated=True,
+    primary=True,
 ):
     """Build a CustomDomain record for a test.
 
@@ -71,6 +72,7 @@ def _domain(
         repository=repository,
         domain_type=domain_type,
         created_at=created_at,
+        primary=primary,
     )
 
 
@@ -382,3 +384,67 @@ def test_repo_filter_drops_other_repositories_and_ranks_the_rest(runner, monkeyp
     assert customs == ["dl-prod.acme.example.com", "dl.acme.example.com"]
     # A built-in host serves every repository, so it survives the filter.
     assert "dl.cloudsmith.io" in {entry["host"] for entry in document}
+
+
+def test_custom_domains_are_ranked_by_precedence_without_repo(runner, monkeypatch):
+    """Precedence orders the custom entries whether or not --repo is given.
+
+    The first custom entry is the host Cloudsmith would bind, so sorting by host
+    without --repo would disagree with the credential path about which is active.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain(
+            "alpha.acme.example.com",
+            BackendKind.DOCKER,
+            created_at="2020-01-01T00:00:00Z",
+            primary=False,
+        ),
+        _domain(
+            "zeta.acme.example.com",
+            BackendKind.DOCKER,
+            created_at="2024-01-01T00:00:00Z",
+        ),
+    ]
+
+    result, _ = _invoke(runner, "--format", "docker", custom_domains=records)
+
+    customs = [
+        entry["host"]
+        for entry in json.loads(result.stdout)["domains"]
+        if entry["type"] == "custom"
+    ]
+    assert customs == ["zeta.acme.example.com", "alpha.acme.example.com"]
+
+
+def test_cached_domains_from_several_orgs_are_grouped_by_org(runner, tmp_path):
+    """Cross-org cached records are never interleaved into one ranking.
+
+    A no-org listing spans whatever earlier runs cached, and ranking one
+    organisation's hosts against another's expresses a preference the server
+    never made.
+    """
+    write_cache(
+        get_cache_path("acme"),
+        [_domain("mvn.acme.example.com", BackendKind.MAVEN, org="acme")],
+    )
+    write_cache(
+        get_cache_path("bravo"),
+        [
+            _domain(
+                "mvn.bravo.example.com",
+                BackendKind.MAVEN,
+                org="bravo",
+                created_at="2001-01-01T00:00:00Z",
+            )
+        ],
+    )
+
+    result, _ = _invoke(runner, "--format", "maven")
+
+    customs = [
+        entry["host"]
+        for entry in json.loads(result.stdout)["domains"]
+        if entry["type"] == "custom"
+    ]
+    assert customs == ["mvn.acme.example.com", "mvn.bravo.example.com"]

--- a/cloudsmith_cli/cli/tests/commands/test_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_domains.py
@@ -417,6 +417,99 @@ def test_custom_domains_are_ranked_by_precedence_without_repo(runner, monkeypatc
     assert customs == ["zeta.acme.example.com", "alpha.acme.example.com"]
 
 
+def test_default_shows_everything_with_no_pagination_metadata(runner, monkeypatch):
+    """With no --page/--page-size given, the command defaults to --page-all.
+
+    The combined list is small and built from a local cache, unlike other
+    `list` commands backed by a live paginated endpoint, so there is no
+    upside to hiding entries by default.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [_domain(f"h{i}.acme.example.com", None) for i in range(5)]
+
+    result, _ = _invoke(runner, custom_domains=records)
+
+    document = json.loads(result.stdout)
+    assert "meta" not in document
+    assert len([e for e in document["domains"] if e["type"] == "custom"]) == 5
+
+
+def test_page_size_selects_a_page_and_reports_pagination_metadata(runner, monkeypatch):
+    """Passing --page-size switches the command into paged output."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain(
+            f"h{i}.acme.example.com", None, created_at=f"2020-01-{i + 1:02d}T00:00:00Z"
+        )
+        for i in range(5)
+    ]
+
+    unpaged, _ = _invoke(runner, custom_domains=records)
+    total = len(json.loads(unpaged.stdout)["domains"])
+
+    result, _ = _invoke(
+        runner, "--page-size", "2", "--page", "1", custom_domains=records
+    )
+
+    document = json.loads(result.stdout)
+    assert len(document["domains"]) == 2
+    pagination = document["meta"]["pagination"]
+    assert pagination["page"] == 1
+    assert pagination["page_size"] == 2
+    assert pagination["results_total"] == total
+    assert pagination["page_max"] == -(-total // 2)
+
+
+def test_second_page_continues_where_the_first_left_off(runner, monkeypatch):
+    """Successive pages walk through the full list without gaps or overlap."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain(
+            f"h{i}.acme.example.com", None, created_at=f"2020-01-{i + 1:02d}T00:00:00Z"
+        )
+        for i in range(5)
+    ]
+
+    page_one, _ = _invoke(
+        runner, "--page-size", "2", "--page", "1", custom_domains=records
+    )
+    page_two, _ = _invoke(
+        runner, "--page-size", "2", "--page", "2", custom_domains=records
+    )
+
+    hosts_one = [e["host"] for e in json.loads(page_one.stdout)["domains"]]
+    hosts_two = [e["host"] for e in json.loads(page_two.stdout)["domains"]]
+    assert not set(hosts_one) & set(hosts_two)
+    assert json.loads(page_two.stdout)["meta"]["pagination"]["page"] == 2
+
+
+def test_page_all_shows_everything_even_with_explicit_page_size(runner, monkeypatch):
+    """--page-all still means "everything", overriding any --page-size given."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [_domain(f"h{i}.acme.example.com", None) for i in range(5)]
+
+    result, _ = _invoke(runner, "--page-all", custom_domains=records)
+
+    document = json.loads(result.stdout)
+    assert "meta" not in document
+    assert len([e for e in document["domains"] if e["type"] == "custom"]) == 5
+
+
+def test_page_and_page_all_are_mutually_exclusive(runner, monkeypatch):
+    """Explicit --page together with --page-all is rejected, as elsewhere in the CLI."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    with patch(_PATCH_TARGET, return_value=[]):
+        result = runner.invoke(
+            list_domains,
+            ["--page", "2", "--page-all", *HERMETIC_ARGS],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    assert "--page-all" in result.output or "page-all" in result.output
+
+
 def test_cached_domains_from_several_orgs_are_grouped_by_org(runner, tmp_path):
     """Cross-org cached records are never interleaved into one ranking.
 

--- a/cloudsmith_cli/cli/tests/commands/test_domains.py
+++ b/cloudsmith_cli/cli/tests/commands/test_domains.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the `cloudsmith domains list` command."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ....cli import config as cli_config
+from ....cli.commands.domains import list_domains
+from ....core.api.exceptions import ApiException
+from ....credential_helpers.backends import BackendKind
+from ....credential_helpers.custom_domains import (
+    CustomDomain,
+    get_cache_path,
+    write_cache,
+)
+from ....credential_helpers.default_domains import DomainType
+
+_PATCH_TARGET = "cloudsmith_cli.cli.commands.domains.get_custom_domains"
+
+HERMETIC_ARGS = ["--api-key", "fake-api-key"]
+
+
+@pytest.fixture(autouse=True)
+def hermetic_environment(monkeypatch, tmp_path):
+    """Keep the developer's real environment out of these tests.
+
+    An inherited organisation, config file, [domains] table or custom-domain
+    cache would each replace part of what these tests assert on - and the CLI's
+    Options object and ConfigReader's search path are both process-wide, so
+    they are pinned per test rather than merely cleared.
+    """
+    monkeypatch.delenv("CLOUDSMITH_ORG", raising=False)
+    monkeypatch.delenv("CLOUDSMITH_CONFIG_FILE", raising=False)
+    monkeypatch.delattr(cli_config.OPTIONS, "value", raising=False)
+    monkeypatch.setattr(cli_config.ConfigReader, "config_files", ["config.ini"])
+    monkeypatch.setattr(cli_config.ConfigReader, "config_searchpath", ["."])
+    monkeypatch.setattr(
+        "cloudsmith_cli.credential_helpers.custom_domains.get_default_config_path",
+        lambda: str(tmp_path),
+    )
+
+
+def _domain(
+    host,
+    backend_kind,
+    org="acme",
+    repository=None,
+    created_at=None,
+    domain_type=None,
+    enabled=True,
+    validated=True,
+):
+    """Build a CustomDomain record for a test.
+
+    The server classifies every domain, so a record stands in for one it sent:
+    a host serving a package format speaks that format's protocol, and the
+    format-less ones default to the CDN unless the caller says otherwise.
+    """
+    if domain_type is None:
+        domain_type = (
+            DomainType.NATIVE_API if backend_kind is not None else DomainType.DOWNLOAD
+        )
+    return CustomDomain(
+        host=host,
+        backend_kind=backend_kind,
+        enabled=enabled,
+        validated=validated,
+        org=org,
+        repository=repository,
+        domain_type=domain_type,
+        created_at=created_at,
+    )
+
+
+def _invoke(runner, *args, custom_domains=()):
+    """Run the command with the custom-domain lookup stubbed; assert a clean exit.
+
+    Returns (result, mock_get) so a caller can read stderr or assert on how the
+    lookup was called.
+    """
+    with patch(_PATCH_TARGET, return_value=list(custom_domains)) as mock_get:
+        result = runner.invoke(
+            list_domains, [*args, *HERMETIC_ARGS], catch_exceptions=False
+        )
+
+    assert result.exit_code == 0, result.output
+    return result, mock_get
+
+
+def _by_host(result):
+    """Index the emitted domains document by host."""
+    return {entry["host"]: entry for entry in json.loads(result.stdout)["domains"]}
+
+
+def test_document_has_one_schema_for_both_kinds_of_host(runner, monkeypatch):
+    """Built-in and custom hosts share one entry schema, under a versioned document.
+
+    A key present on custom entries alone raises KeyError on the first built-in
+    host for any consumer filtering the document on it.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    result, _ = _invoke(
+        runner,
+        custom_domains=[
+            _domain("pypi.acme.example.com", 3, created_at="2026-02-06T00:00:00Z")
+        ],
+    )
+
+    document = json.loads(result.stdout)
+    assert set(document) == {"version", "domains"}
+    assert document["version"] == 1
+    assert len({frozenset(entry) for entry in document["domains"]}) == 1
+
+    by_host = _by_host(result)
+    assert by_host["pypi.acme.example.com"] == {
+        "host": "pypi.acme.example.com",
+        "format": "python",
+        "type": "custom",
+        "domain_type": "native_api",
+        "org": "acme",
+        "repository": None,
+        "primary": True,
+        "created_at": "2026-02-06T00:00:00Z",
+    }
+    assert by_host["python.cloudsmith.io"] == {
+        "host": "python.cloudsmith.io",
+        "format": "python",
+        "type": "default",
+        "domain_type": "native_api",
+        "org": None,
+        "repository": None,
+        "primary": True,
+        "created_at": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "host,format_,domain_type",
+    [
+        ("dl.cloudsmith.io", None, "download"),
+        ("upload.cloudsmith.io", None, "upload"),
+        ("maven.cloudsmith.io", "maven", "native_api"),
+    ],
+)
+def test_builtin_hosts_say_what_they_serve(runner, host, format_, domain_type):
+    """The two format-less hosts are download/upload; the rest are native API."""
+    entry = _by_host(_invoke(runner)[0])[host]
+
+    assert entry["format"] == format_
+    assert entry["domain_type"] == domain_type
+
+
+@pytest.mark.parametrize("source", ["env", "config", "flag"])
+def test_the_resolved_organisation_is_looked_up(runner, monkeypatch, tmp_path, source):
+    """However the organisation is configured, that is the one looked up.
+
+    The accepted spellings of the option are covered in test_org_option.py; this
+    only proves the command hands what it resolved to the lookup.
+    """
+    args = []
+    if source == "env":
+        monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    elif source == "config":
+        config = tmp_path / "config.ini"
+        config.write_text("[default]\norg = acme\n", encoding="utf-8")
+        args = ["--config-file", str(config)]
+    else:
+        args = ["--org", "acme"]
+
+    _, mock_get = _invoke(runner, *args)
+
+    assert mock_get.call_args.args[0] == "acme"
+
+
+def test_without_org_no_custom_domain_lookup(runner):
+    """With no organisation configured, no custom-domain lookup is attempted."""
+    _, mock_get = _invoke(runner)
+
+    mock_get.assert_not_called()
+
+
+def test_lookup_is_handed_the_commands_own_settings(runner, monkeypatch):
+    """The lookup runs on the command's terms, not its own defaults.
+
+    ``strict`` so a typo'd org or unreachable API cannot render as "no custom
+    domains"; ``configure_api=False`` because `initialise_api` has already
+    applied the proxy, TLS, user-agent and header settings that a narrower
+    re-initialisation inside the lookup would discard; the resolved credential
+    and ``--refresh`` because neither reaches the lookup any other way.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    _, mock_get = _invoke(runner, "--refresh")
+
+    kwargs = mock_get.call_args.kwargs
+    assert kwargs["strict"] is True
+    assert kwargs["configure_api"] is False
+    assert kwargs["refresh"] is True
+    assert kwargs["credential"].api_key == "fake-api-key"
+
+
+def test_lookup_failure_says_what_went_wrong(runner, monkeypatch):
+    """A failed lookup exits non-zero naming the cause, with no partial document.
+
+    ApiException builds Exception with no args, so interpolating one used to
+    yield a message that stopped dead at the colon.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    with patch(_PATCH_TARGET, side_effect=ApiException(401, detail="Invalid API key")):
+        result = runner.invoke(list_domains, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert result.stdout.strip() == ""
+    assert "Failed to fetch custom domains" in result.stderr
+    assert "401" in result.stderr
+    assert "Invalid API key" in result.stderr
+
+
+def test_explicit_config_file_supplies_default_domains(runner, tmp_path):
+    """An explicit --config-file is a trusted source for [domains]."""
+    config = tmp_path / "config.ini"
+    config.write_text(
+        "[domains]\nindex.internal.example.com = python\n", encoding="utf-8"
+    )
+
+    result, _ = _invoke(runner, "--config-file", str(config))
+
+    assert set(_by_host(result)) == {"index.internal.example.com"}
+
+
+def test_untrusted_config_section_is_ignored_with_a_warning(
+    runner, monkeypatch, tmp_path
+):
+    """A cwd config.ini cannot replace the host table, and says so on stderr.
+
+    That file travels with whatever repository is checked out, and this table
+    decides which hosts may receive a credential.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.ini").write_text(
+        "[domains]\nindex.internal.example.com = python\n", encoding="utf-8"
+    )
+
+    result, _ = _invoke(runner)
+
+    assert "Warning" in result.stderr
+    assert "python.cloudsmith.io" in _by_host(result)
+    assert "index.internal.example.com" not in _by_host(result)
+
+
+def test_lists_cached_domains_when_no_organisation_is_configured(
+    runner, monkeypatch, tmp_path
+):
+    """A run with no org lists what earlier runs cached, without any API call.
+
+    Attribution comes from the record, not the filename: the cache filename is
+    a sanitised slug and cannot be relied on.
+    """
+    called = []
+    monkeypatch.setattr(_PATCH_TARGET, lambda *a, **k: called.append("api") or [])
+    write_cache(get_cache_path("acme"), [_domain("dl.acme.com", None, org="acme")])
+    write_cache(
+        get_cache_path("widgets"), [_domain("dl.widgets.com", None, org="widgets")]
+    )
+
+    result = runner.invoke(list_domains, HERMETIC_ARGS, catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert not called
+    custom = [d for d in json.loads(result.output)["domains"] if d["type"] == "custom"]
+    assert {(d["host"], d["org"]) for d in custom} == {
+        ("dl.acme.com", "acme"),
+        ("dl.widgets.com", "widgets"),
+    }
+
+
+def test_format_filter_keeps_that_format_and_the_formatless_hosts(runner, monkeypatch):
+    """--format answers "what can I use for this format?".
+
+    A formatless host (the download CDN, the generic upload endpoint) serves
+    every format, so excluding it would hide the very host Maven resolves
+    dependencies from.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("mvn.acme.example.com", int(BackendKind.MAVEN)),
+        _domain("pypi.acme.example.com", int(BackendKind.PYTHON)),
+        _domain("dl.acme.example.com", None),
+    ]
+
+    by_host = _by_host(_invoke(runner, "--format", "maven", custom_domains=records)[0])
+
+    assert "mvn.acme.example.com" in by_host
+    assert "dl.acme.example.com" in by_host
+    assert "pypi.acme.example.com" not in by_host
+    # Built-ins are filtered on the same rule.
+    assert "maven.cloudsmith.io" in by_host
+    assert "python.cloudsmith.io" not in by_host
+    assert "dl.cloudsmith.io" in by_host
+
+
+def test_custom_domains_are_listed_before_the_builtin_hosts(runner, monkeypatch):
+    """An organisation's own hosts come first; the built-ins are the fallback.
+
+    A caller reading the document top-down should reach the host bound to its
+    organisation before the public one that merely also works.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+
+    result, _ = _invoke(runner, custom_domains=[_domain("dl.acme.example.com", None)])
+
+    types = [entry["type"] for entry in json.loads(result.stdout)["domains"]]
+    assert types == ["custom"] + ["default"] * (len(types) - 1)
+
+
+def test_a_domain_that_cannot_serve_traffic_is_not_listed(runner, monkeypatch):
+    """The listing answers what is usable, so a host serving nothing is out.
+
+    It needs both flags: a domain is usable only when it is enabled *and*
+    validated. Under ``--repo`` this also keeps a dead host off the top of the
+    list, since one bound to the repository outranks an organisation-wide one
+    whatever its state.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("dl.acme.example.com", None),
+        _domain("disabled.acme.example.com", None, enabled=False),
+        _domain("unvalidated.acme.example.com", None, validated=False),
+    ]
+
+    by_host = _by_host(_invoke(runner, custom_domains=records)[0])
+
+    assert "dl.acme.example.com" in by_host
+    assert "disabled.acme.example.com" not in by_host
+    assert "unvalidated.acme.example.com" not in by_host
+
+
+def test_domain_type_filter_selects_hosts_by_purpose(runner, monkeypatch):
+    """--domain-type answers "which host do I upload to?".
+
+    Unlike --format, every host has exactly one purpose, so this is an exact
+    match: an upload endpoint cannot stand in for the download CDN, and a
+    native-API host speaks one package format's protocol and neither.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("up.acme.example.com", None, domain_type=DomainType.UPLOAD),
+        _domain("dl.acme.example.com", None, domain_type=DomainType.DOWNLOAD),
+        _domain("mvn.acme.example.com", int(BackendKind.MAVEN)),
+    ]
+
+    by_host = _by_host(
+        _invoke(runner, "--domain-type", "upload", custom_domains=records)[0]
+    )
+
+    assert set(by_host) == {"upload.cloudsmith.io", "up.acme.example.com"}
+
+
+def test_repo_filter_drops_other_repositories_and_ranks_the_rest(runner, monkeypatch):
+    """--repo lists the hosts usable for one repository, most-preferred first.
+
+    A repository-scoped host names its own repository in its URLs, so it can
+    never stand in for another; an organisation-wide one serves every
+    repository but ranks behind the domain bound to this one. The first custom
+    entry is what Cloudsmith would actually bind.
+    """
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme")
+    records = [
+        _domain("dl.acme.example.com", None, created_at="2020-01-01T00:00:00Z"),
+        _domain("dl-dev.acme.example.com", None, repository="dev"),
+        _domain("dl-prod.acme.example.com", None, repository="prod"),
+    ]
+
+    result, _ = _invoke(runner, "--repo", "prod", custom_domains=records)
+
+    document = json.loads(result.stdout)["domains"]
+    customs = [entry["host"] for entry in document if entry["type"] == "custom"]
+    assert customs == ["dl-prod.acme.example.com", "dl.acme.example.com"]
+    # A built-in host serves every repository, so it survives the filter.
+    assert "dl.cloudsmith.io" in {entry["host"] for entry in document}

--- a/cloudsmith_cli/cli/tests/test_org_option.py
+++ b/cloudsmith_cli/cli/tests/test_org_option.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the organisation option and its accepted spellings.
+
+The organisation is named three ways for historical reasons: ``--org`` is the
+name to use, ``--organization`` reads naturally in scripts, and ``--oidc-org``
+is what the option was called when only OIDC token exchange consumed it. All
+three are one option, so a consumer never has to know which era it came from.
+"""
+
+import click
+import click.testing
+import pytest
+
+from ..config import OPTIONS, ConfigReader, Options
+from ..decorators import resolve_credentials
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    """Yield a writer for a temporary config.ini, restoring reader state."""
+    original_files = list(ConfigReader.config_files)
+
+    def write(body):
+        path = tmp_path / "config.ini"
+        path.write_text(body)
+        return str(path)
+
+    yield write
+    ConfigReader.config_files = original_files
+
+
+@pytest.fixture
+def org_reporting_command(monkeypatch):
+    """A minimal command carrying the shared credential options.
+
+    The Options object is a process-wide thread-local, so it is cleared per
+    test to stop one invocation's organisation leaking into the next.
+    """
+    monkeypatch.delenv("CLOUDSMITH_ORG", raising=False)
+    monkeypatch.delattr(OPTIONS, "value", raising=False)
+
+    @click.command()
+    @resolve_credentials
+    @click.pass_context
+    def report(ctx, opts):  # pylint: disable=unused-argument
+        click.echo(f"org={opts.org}")
+
+    return report
+
+
+@pytest.mark.parametrize("key", ["org", "organization", "oidc_org"])
+def test_every_config_spelling_sets_the_one_organisation(config_file, key):
+    """The aliases are one value in config.ini, not three independent settings."""
+    opts = Options()
+    opts.load_config_file(config_file(f"[default]\n{key} = acme\n"))
+
+    assert opts.org == "acme"
+    assert opts.organization == "acme"
+    assert opts.oidc_org == "acme"
+
+
+@pytest.mark.parametrize("flag", ["--org", "--organization", "--oidc-org"])
+def test_every_flag_sets_the_organisation(org_reporting_command, flag):
+    """All three flags are one option, so any of them reaches ``opts.org``."""
+    result = click.testing.CliRunner().invoke(org_reporting_command, [flag, "acme"])
+
+    assert result.exit_code == 0, result.output
+    assert "org=acme" in result.output
+
+
+def test_environment_sets_the_organisation(org_reporting_command, monkeypatch):
+    """CLOUDSMITH_ORG is unchanged by the rename, and is still honoured."""
+    monkeypatch.setenv("CLOUDSMITH_ORG", "acme-from-env")
+
+    result = click.testing.CliRunner().invoke(org_reporting_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert "org=acme-from-env" in result.output

--- a/cloudsmith_cli/conftest.py
+++ b/cloudsmith_cli/conftest.py
@@ -1,0 +1,16 @@
+import cloudsmith_api
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_api_configuration_default():
+    """Undo the process-wide SDK configuration a test leaves behind.
+
+    ``initialise_api`` ends in ``Configuration.set_default()``, so a test that
+    sets a proxy, host or credential would otherwise hand it to every test that
+    runs after it. A fresh ``Configuration`` is a copy of the current default,
+    which makes it the snapshot to put back afterwards.
+    """
+    default = cloudsmith_api.Configuration()
+    yield
+    cloudsmith_api.Configuration.set_default(default)

--- a/cloudsmith_cli/core/api/exceptions.py
+++ b/cloudsmith_cli/core/api/exceptions.py
@@ -25,6 +25,17 @@ class ApiException(Exception):
         self.body = body
         self.fields = fields or {}
 
+    def __str__(self) -> str:
+        """Render the status and whatever the API said about it.
+
+        ``Exception`` is initialised with no arguments, so without this the
+        default rendering is the empty string, and every caller interpolating
+        one - ``f"...: {exc}"`` - produced a message that stopped dead at the
+        colon, reporting that something failed but never what. The status
+        description stands in when the API sends no detail of its own.
+        """
+        return f"{self.status} - {self.detail or self.status_description}"
+
 
 @contextlib.contextmanager
 def catch_raise_api_exception():

--- a/cloudsmith_cli/core/credentials/models.py
+++ b/cloudsmith_cli/core/credentials/models.py
@@ -27,7 +27,7 @@ class CredentialContext:
     debug: bool = False
     keyring_refresh_failed: bool = False
     oidc_audience: str | None = None
-    oidc_org: str | None = None
+    org: str | None = None
     oidc_service_slug: str | None = None
     oidc_discovery_disabled: bool = False
     oidc_detector_order: str | None = None

--- a/cloudsmith_cli/core/credentials/providers/oidc_provider.py
+++ b/cloudsmith_cli/core/credentials/providers/oidc_provider.py
@@ -31,7 +31,7 @@ class OidcProvider(CredentialProvider):
                 )
             return None
 
-        org = context.oidc_org
+        org = context.org
         service_slug = context.oidc_service_slug
 
         if not org or not service_slug:

--- a/cloudsmith_cli/credential_helpers/backends.py
+++ b/cloudsmith_cli/credential_helpers/backends.py
@@ -38,4 +38,5 @@ class BackendKind(IntEnum):
     GENERIC = 28
     VSX = 29
     MCP = 30
+    NIX = 31
     DEFAULT = 99

--- a/cloudsmith_cli/credential_helpers/common.py
+++ b/cloudsmith_cli/credential_helpers/common.py
@@ -6,7 +6,6 @@ Provides domain checking used by all credential helpers.
 """
 
 import logging
-import os
 
 from .custom_domains import get_custom_domains, get_format_domains
 
@@ -48,7 +47,9 @@ def extract_hostname(url):
     return hostname
 
 
-def is_cloudsmith_domain(url, credential=None, api_host=None, backend_kind=None):
+def is_cloudsmith_domain(
+    url, credential=None, api_host=None, backend_kind=None, org=None
+):
     """
     Check if a URL points to a Cloudsmith service.
 
@@ -62,6 +63,8 @@ def is_cloudsmith_domain(url, credential=None, api_host=None, backend_kind=None)
         backend_kind: If given, custom domains only match when their backend_kind
             equals it (standard *.cloudsmith.io domains always match regardless).
             When None (default), any enabled+validated custom domain matches.
+        org: Organisation slug whose custom domains to match against, as the
+            CLI resolved it from --org, CLOUDSMITH_ORG or config.ini
 
     Returns:
         bool: True if this is a Cloudsmith domain
@@ -79,7 +82,6 @@ def is_cloudsmith_domain(url, credential=None, api_host=None, backend_kind=None)
         return True
 
     # Custom domains require org + auth
-    org = os.environ.get("CLOUDSMITH_ORG", "").strip()
     if not org:
         return False
 
@@ -100,6 +102,6 @@ def is_cloudsmith_domain(url, credential=None, api_host=None, backend_kind=None)
         hosts = {
             d.host.lower()
             for d in get_custom_domains(org, credential=credential, api_host=api_host)
-            if d.enabled and d.validated
+            if d.is_active
         }
     return hostname in hosts

--- a/cloudsmith_cli/credential_helpers/common.py
+++ b/cloudsmith_cli/credential_helpers/common.py
@@ -48,9 +48,7 @@ def extract_hostname(url):
     return hostname
 
 
-def is_cloudsmith_domain(
-    url, api_key=None, auth_type="api_key", api_host=None, backend_kind=None
-):
+def is_cloudsmith_domain(url, credential=None, api_host=None, backend_kind=None):
     """
     Check if a URL points to a Cloudsmith service.
 
@@ -59,8 +57,7 @@ def is_cloudsmith_domain(
 
     Args:
         url: URL or hostname to check
-        api_key: API key/token for authenticating custom domain lookups
-        auth_type: "api_key" (X-Api-Key header) or "bearer" (Authorization: Bearer)
+        credential: Resolved CredentialResult for authenticating custom domain lookups
         api_host: Cloudsmith API host URL
         backend_kind: If given, custom domains only match when their backend_kind
             equals it (standard *.cloudsmith.io domains always match regardless).
@@ -86,7 +83,7 @@ def is_cloudsmith_domain(
     if not org:
         return False
 
-    if not api_key:
+    if not credential:
         return False
 
     if backend_kind is not None:
@@ -95,17 +92,14 @@ def is_cloudsmith_domain(
             for host in get_format_domains(
                 org,
                 backend_kind,
-                api_key=api_key,
-                auth_type=auth_type,
+                credential=credential,
                 api_host=api_host,
             )
         }
     else:
         hosts = {
             d.host.lower()
-            for d in get_custom_domains(
-                org, api_key=api_key, auth_type=auth_type, api_host=api_host
-            )
+            for d in get_custom_domains(org, credential=credential, api_host=api_host)
             if d.enabled and d.validated
         }
     return hostname in hosts

--- a/cloudsmith_cli/credential_helpers/custom_domains.py
+++ b/cloudsmith_cli/credential_helpers/custom_domains.py
@@ -11,7 +11,6 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
 from ..cli.config import get_default_config_path
 from ..core.api.exceptions import ApiException
@@ -154,8 +153,7 @@ def write_cache(cache_path: Path, domains: list[CustomDomain]) -> None:
 def get_custom_domains(  # pylint: disable=too-many-return-statements
     org: str,
     *,
-    api_key: str | None = None,
-    auth_type: str = "api_key",
+    credential: CredentialResult | None = None,
     api_host: str | None = None,
     refresh: bool = False,
 ) -> list[CustomDomain]:
@@ -166,8 +164,8 @@ def get_custom_domains(  # pylint: disable=too-many-return-statements
 
     Args:
         org: Organization slug
-        api_key: Optional API key/token for authentication
-        auth_type: "api_key" (uses X-Api-Key header) or "bearer" (uses Authorization: Bearer)
+        credential: Optional resolved credential for authentication; it carries
+            its own auth scheme (X-Api-Key vs Authorization: Bearer)
         api_host: Cloudsmith API host URL (including version). Taken from the SDK
             configuration default when not provided.
         refresh: When ``True``, skip the cache read and always fetch from the API.
@@ -192,18 +190,6 @@ def get_custom_domains(  # pylint: disable=too-many-return-statements
 
     logger.debug("Fetching custom domains from API for %s", org)
 
-    normalized_auth_type: Literal["api_key", "bearer"] = (
-        "bearer" if auth_type == "bearer" else "api_key"
-    )
-    credential = (
-        CredentialResult(
-            api_key=api_key,
-            source_name="credential-helper",
-            auth_type=normalized_auth_type,
-        )
-        if api_key
-        else None
-    )
     initialise_api(host=api_host, credential=credential)
 
     try:
@@ -252,8 +238,7 @@ def get_format_domains(
     org: str,
     backend_kind: int,
     *,
-    api_key: str | None = None,
-    auth_type: str = "api_key",
+    credential: CredentialResult | None = None,
     api_host: str | None = None,
     refresh: bool = False,
 ) -> list[str]:
@@ -263,8 +248,7 @@ def get_format_domains(
     Args:
         org: Organization slug
         backend_kind: BackendKind int value (e.g. BackendKind.DOCKER == 6)
-        api_key: Optional API key/token for authentication
-        auth_type: "api_key" or "bearer"
+        credential: Optional resolved credential for authentication
         api_host: Cloudsmith API host URL
         refresh: When ``True``, bypass the cache and fetch fresh data from the API.
 
@@ -272,7 +256,7 @@ def get_format_domains(
         List of hostnames that are enabled, validated, and match the given backend_kind.
     """
     domains = get_custom_domains(
-        org, api_key=api_key, auth_type=auth_type, api_host=api_host, refresh=refresh
+        org, credential=credential, api_host=api_host, refresh=refresh
     )
     return [
         d.host

--- a/cloudsmith_cli/credential_helpers/custom_domains.py
+++ b/cloudsmith_cli/credential_helpers/custom_domains.py
@@ -3,7 +3,13 @@
 Helper for discovering Cloudsmith custom domains.
 
 This module provides functions to fetch custom domains from the Cloudsmith API
-for use in credential helpers. Results are cached on the filesystem.
+for use in credential helpers.
+
+Results are cached on the filesystem. Custom domains change rarely, so the
+cache is long-lived and ``--refresh`` bypasses it when one has just been added
+or validated. Bump ``CACHE_FORMAT_VERSION`` when the cached record shape
+changes, so an older document reads as a miss rather than as a record with the
+new fields defaulted.
 """
 
 import json
@@ -18,11 +24,13 @@ from ..core.api.init import initialise_api
 from ..core.api.orgs import list_custom_domains
 from ..core.cache_utils import atomic_write_json
 from ..core.credentials.models import CredentialResult
+from .default_domains import DomainType, domain_type_from_server
 
 logger = logging.getLogger(__name__)
 
-# Cache custom domains for 1 hour
-CACHE_TTL_SECONDS = 3600
+CACHE_TTL_SECONDS = 7 * 24 * 3600
+
+CACHE_FORMAT_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,20 @@ class CustomDomain:
     backend_kind: int | None
     enabled: bool
     validated: bool
+    org: str
+    domain_type: DomainType
+    repository: str | None = None
+    primary: bool = True
+    created_at: str | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Whether this domain can serve traffic at all."""
+        return self.enabled and self.validated
+
+    def serves_repository(self, repository: str | None) -> bool:
+        """Whether this domain may be used for `repository`."""
+        return not self.repository or self.repository == repository
 
 
 def get_cache_dir() -> Path:
@@ -80,15 +102,73 @@ def is_cache_valid(cache_path: Path) -> bool:
         return False
 
 
-def read_cache(cache_path: Path) -> list[CustomDomain] | None:
+def _repository_slug(raw) -> str | None:
+    """Read a repository slug: the API nests it, the cache stores it flat."""
+    if isinstance(raw, dict):
+        raw = raw.get("slug")
+    return raw or None
+
+
+def _timestamp(raw) -> str | None:
+    """Read a creation time as a string: the SDK gives a datetime, the cache a str.
+
+    ``json.dump`` cannot write a datetime, so it is normalised on the way in
+    rather than at every cache write.
     """
-    Read custom domains from cache file.
+    if raw is None or isinstance(raw, str):
+        return raw or None
+    return raw.isoformat()
 
-    Args:
-        cache_path: Path to cache file
 
-    Returns:
-        List of CustomDomain records or None if cache invalid/missing
+def _record_from_payload(raw: dict, org: str) -> CustomDomain:
+    """Build a CustomDomain from an API or cache payload for *org*."""
+    backend_kind = raw.get("backend_kind")
+    return CustomDomain(
+        host=raw["host"],
+        backend_kind=backend_kind,
+        enabled=bool(raw.get("enabled")),
+        validated=bool(raw.get("validated")),
+        org=org,
+        repository=_repository_slug(raw.get("repository")),
+        domain_type=domain_type_from_server(raw.get("domain_type")),
+        primary=bool(raw.get("primary")),
+        created_at=_timestamp(raw.get("created_at")),
+    )
+
+
+def _precedence_key(domain: CustomDomain, repository: str | None) -> tuple:
+    """Rank a candidate domain, lowest first.
+
+    A domain bound to *repository* beats an organisation-wide one, primary
+    beats secondary, the oldest wins, and the host breaks any remaining tie.
+    """
+    bound_to_repository = repository is not None and domain.repository == repository
+    return (
+        not bound_to_repository,
+        not domain.primary,
+        domain.created_at or "",
+        domain.host,
+    )
+
+
+def order_by_precedence(
+    domains: list[CustomDomain], repository: str | None = None
+) -> list[CustomDomain]:
+    """Return *domains* ranked as Cloudsmith would choose among them.
+
+    The first entry is the one that serves *repository*, so a caller listing
+    candidates shows the same answer the credential path would bind.
+    """
+    return sorted(domains, key=lambda domain: _precedence_key(domain, repository))
+
+
+def read_cache(cache_path: Path) -> list[CustomDomain] | None:
+    """Return the cached custom domains at `cache_path`, or None for a miss.
+
+    ``format_version`` is what separates a document this CLI can read from one
+    an older build wrote, so anything failing that check needs no further
+    handling of its shape - including the versionless documents that stored
+    domains as plain strings.
     """
     if not is_cache_valid(cache_path):
         return None
@@ -96,48 +176,62 @@ def read_cache(cache_path: Path) -> list[CustomDomain] | None:
     try:
         with open(cache_path, encoding="utf-8") as f:
             data = json.load(f)
-            if isinstance(data, dict) and "domains" in data:
-                domains = data["domains"]
-                if isinstance(domains, list):
-                    # Detect legacy format: non-empty list of strings (old build stored
-                    # domains as plain strings, not dicts). Treat as a cache miss so the
-                    # caller re-fetches and rewrites in the current dict format.
-                    if domains and not any(isinstance(d, dict) for d in domains):
-                        logger.debug(
-                            "Stale string-format cache detected at %s, treating as miss",
-                            cache_path,
-                        )
-                        return None
-
-                    records = [
-                        CustomDomain(
-                            host=d["host"],
-                            backend_kind=d.get("backend_kind"),
-                            enabled=bool(d.get("enabled", False)),
-                            validated=bool(d.get("validated", False)),
-                        )
-                        for d in domains
-                        if isinstance(d, dict) and d.get("host")
-                    ]
-                    logger.debug(
-                        "Read %d domains from cache: %s", len(records), cache_path
-                    )
-                    return records
     except (OSError, json.JSONDecodeError) as exc:
         logger.debug("Failed to read cache %s: %s", cache_path, exc)
+        return None
 
-    return None
+    if not isinstance(data, dict) or data.get("format_version") != CACHE_FORMAT_VERSION:
+        logger.debug(
+            "Cache %s is not format version %s - treating as miss",
+            cache_path,
+            CACHE_FORMAT_VERSION,
+        )
+        return None
+
+    domains = data.get("domains")
+    if not isinstance(domains, list):
+        return None
+
+    records = [
+        _record_from_payload(d, d.get("org", ""))
+        for d in domains
+        if isinstance(d, dict) and d.get("host")
+    ]
+    logger.debug("Read %d domains from cache: %s", len(records), cache_path)
+    return records
+
+
+def read_all_cached_domains() -> list[CustomDomain]:
+    """Return every custom domain in a currently-valid cache entry.
+
+    Lets a run with no configured organisation list what earlier runs already
+    fetched, at no API cost.  Each file goes through :func:`read_cache`, so the
+    TTL and format-version gates apply and a stale or unreadable entry is
+    skipped rather than reported.
+    """
+    records: list[CustomDomain] = []
+    for cache_path in sorted(get_cache_dir().glob("*.json")):
+        cached = read_cache(cache_path)
+        if cached:
+            records.extend(cached)
+    return records
 
 
 def write_cache(cache_path: Path, domains: list[CustomDomain]) -> None:
     """Write custom domains to cache file."""
     data = {
+        "format_version": CACHE_FORMAT_VERSION,
         "domains": [
             {
                 "host": d.host,
                 "backend_kind": d.backend_kind,
                 "enabled": d.enabled,
                 "validated": d.validated,
+                "org": d.org,
+                "repository": d.repository,
+                "domain_type": d.domain_type.value,
+                "primary": d.primary,
+                "created_at": d.created_at,
             }
             for d in domains
         ],
@@ -150,17 +244,19 @@ def write_cache(cache_path: Path, domains: list[CustomDomain]) -> None:
         logger.debug("Failed to write cache %s: %s", cache_path, exc)
 
 
-def get_custom_domains(  # pylint: disable=too-many-return-statements
+def get_custom_domains(
     org: str,
     *,
     credential: CredentialResult | None = None,
     api_host: str | None = None,
     refresh: bool = False,
+    strict: bool = False,
+    configure_api: bool = True,
 ) -> list[CustomDomain]:
     """
     Fetch custom domains for a Cloudsmith organization.
 
-    Results are cached on the filesystem for 1 hour to avoid excessive API calls.
+    Results are cached on the filesystem for 7 days to avoid excessive API calls.
 
     Args:
         org: Organization slug
@@ -170,17 +266,28 @@ def get_custom_domains(  # pylint: disable=too-many-return-statements
             configuration default when not provided.
         refresh: When ``True``, skip the cache read and always fetch from the API.
             The fresh result is still written to the cache.
+        strict: When ``True``, a failed lookup re-raises its ``ApiException``
+            instead of degrading to an empty list. Use it for callers that show
+            results to a user, which must not render a typo'd org, a missing
+            permission or an unreachable API as "no custom domains". No failure
+            is ever cached, so a strict lookup can still be served from the
+            cache.
+        configure_api: When ``True`` (default), configure the SDK from
+            ``api_host`` and ``credential``. Pass ``False`` when the caller has
+            already done so, since the CLI's ``initialise_api`` also carries
+            proxy, TLS-verification, user-agent and header settings that this
+            narrower configuration would discard.
 
     Returns:
-        List of CustomDomain records.
-        Empty list if API call fails or org has no custom domains.
+        List of CustomDomain records. Empty if the org has no custom domains,
+        which the API answers as 200 with an empty array and is cached like any
+        other result, or if the call fails and ``strict`` is False.
 
     Note:
-        Only ``ApiException`` is handled here (per-status). Network-layer errors
-        (DNS/timeout/SSL/urllib3) are intentionally NOT caught — they propagate to
-        the caller. The credential-helper protocol boundary (the click command) and
-        the installer are responsible for catching broadly and refusing gracefully,
-        so the library stays free of bare ``except Exception`` (reviewer feedback).
+        The API layer wraps transport failures (DNS/timeout/SSL) into
+        ``ApiException``, so every failure mode lands in the handler below.
+        Helpers degrade rather than break the tool wrapping them; pass
+        ``strict=True`` to fail loudly instead.
     """
     cache_path = get_cache_path(org)
     cached = None if refresh else read_cache(cache_path)
@@ -190,11 +297,14 @@ def get_custom_domains(  # pylint: disable=too-many-return-statements
 
     logger.debug("Fetching custom domains from API for %s", org)
 
-    initialise_api(host=api_host, credential=credential)
+    if configure_api:
+        initialise_api(host=api_host, credential=credential)
 
     try:
         raw_domains = list_custom_domains(org)
     except ApiException as exc:
+        if strict:
+            raise
         if exc.status in (401, 403):
             # Don't cache auth failures - might work later once authenticated.
             logger.debug(
@@ -204,30 +314,13 @@ def get_custom_domains(  # pylint: disable=too-many-return-statements
             return []
 
         if exc.status == 404:
-            # Cache empty result to avoid repeated lookups for a missing org.
             logger.debug("Organization %s not found or has no custom domains", org)
-            write_cache(cache_path, [])
-            return []
-
-        if exc.status == 402:
-            # Custom domains product feature not enabled - treat as none.
-            logger.debug("Custom domains not enabled for %s", org)
-            write_cache(cache_path, [])
             return []
 
         logger.debug("Failed to fetch custom domains for %s: HTTP %s", org, exc.status)
         return []
 
-    records = [
-        CustomDomain(
-            host=d["host"],
-            backend_kind=d.get("backend_kind"),
-            enabled=bool(d.get("enabled", False)),
-            validated=bool(d.get("validated", False)),
-        )
-        for d in raw_domains
-        if d.get("host")
-    ]
+    records = [_record_from_payload(d, org) for d in raw_domains if d.get("host")]
 
     logger.debug("Fetched %d custom domains for %s", len(records), org)
     write_cache(cache_path, records)
@@ -253,13 +346,19 @@ def get_format_domains(
         refresh: When ``True``, bypass the cache and fetch fresh data from the API.
 
     Returns:
-        List of hostnames that are enabled, validated, and match the given backend_kind.
+        Hostnames that are usable and match the given backend_kind, in
+        precedence order - the host Cloudsmith would treat as active first.
     """
     domains = get_custom_domains(
-        org, credential=credential, api_host=api_host, refresh=refresh
+        org,
+        credential=credential,
+        api_host=api_host,
+        refresh=refresh,
     )
-    return [
-        d.host
-        for d in domains
-        if d.backend_kind == int(backend_kind) and d.enabled and d.validated
+    matching = [
+        domain
+        for domain in domains
+        if domain.backend_kind == int(backend_kind) and domain.is_active
     ]
+    matching.sort(key=lambda domain: _precedence_key(domain, None))
+    return [domain.host for domain in matching]

--- a/cloudsmith_cli/credential_helpers/custom_domains.py
+++ b/cloudsmith_cli/credential_helpers/custom_domains.py
@@ -59,10 +59,16 @@ class CustomDomain:
 
 def get_cache_dir() -> Path:
     """
-    Get the cache directory for custom domains.
+    Get the cache directory for custom domains, creating it where possible.
+
+    A directory that cannot be created is not an error: every read path then
+    resolves to a miss, and :func:`write_cache` already degrades on ``OSError``.
     """
     cache_dir = Path(get_default_config_path()) / "custom_domains_cache"
-    cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("Could not create cache directory %s: %s", cache_dir, exc)
     return cache_dir
 
 
@@ -140,12 +146,14 @@ def _precedence_key(domain: CustomDomain, repository: str | None) -> tuple:
     """Rank a candidate domain, lowest first.
 
     A domain bound to *repository* beats an organisation-wide one, primary
-    beats secondary, the oldest wins, and the host breaks any remaining tie.
+    beats secondary, the oldest wins, and the host breaks any remaining tie. A
+    record with no ``created_at`` sorts after every dated one.
     """
     bound_to_repository = repository is not None and domain.repository == repository
     return (
         not bound_to_repository,
         not domain.primary,
+        domain.created_at is None,
         domain.created_at or "",
         domain.host,
     )
@@ -176,7 +184,7 @@ def read_cache(cache_path: Path) -> list[CustomDomain] | None:
     try:
         with open(cache_path, encoding="utf-8") as f:
             data = json.load(f)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         logger.debug("Failed to read cache %s: %s", cache_path, exc)
         return None
 
@@ -334,6 +342,7 @@ def get_format_domains(
     credential: CredentialResult | None = None,
     api_host: str | None = None,
     refresh: bool = False,
+    configure_api: bool = True,
 ) -> list[str]:
     """
     Return enabled and validated custom domain hostnames for a specific backend format.
@@ -344,6 +353,9 @@ def get_format_domains(
         credential: Optional resolved credential for authentication
         api_host: Cloudsmith API host URL
         refresh: When ``True``, bypass the cache and fetch fresh data from the API.
+        configure_api: When ``True`` (default), configure the SDK from
+            ``api_host`` and ``credential``. Pass ``False`` when the caller has
+            already done so, for the reasons :func:`get_custom_domains` gives.
 
     Returns:
         Hostnames that are usable and match the given backend_kind, in
@@ -354,6 +366,7 @@ def get_format_domains(
         credential=credential,
         api_host=api_host,
         refresh=refresh,
+        configure_api=configure_api,
     )
     matching = [
         domain

--- a/cloudsmith_cli/credential_helpers/default_domains.py
+++ b/cloudsmith_cli/credential_helpers/default_domains.py
@@ -1,0 +1,307 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Built-in Cloudsmith service hosts, with a trusted-config override.
+
+The table below lists the standard ``*.cloudsmith.io`` service hosts and the
+package format each one serves. A dedicated deployment, serving packages from
+its own domains, can replace the table via a ``[domains]`` section in
+``config.ini``, mapping each hostname to the package format it serves, or to
+``download``/``upload`` for the two endpoints no format names.
+
+A declared table replaces the built-ins wholesale rather than layering over
+them: a host it omits has no default at all, so resolution raises instead of
+handing back a ``*.cloudsmith.io`` host the operator never listed.
+
+The override is honoured only from trusted locations. ``config.ini`` is
+searched in the current working directory first (``cli/config.py``), so a
+``config.ini`` committed to a repository is attacker-controlled input; this
+module therefore never reads the domain table from a directory-relative
+config, mirroring the split ``_guard_untrusted_endpoints``
+(``cli/decorators.py``) already applies to ``api_host``/``api_proxy``. An
+explicit ``--config-file`` is a user's direct statement of trust regardless of
+where it lives, so it is honoured ahead of the search-path locations.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from ..cli.config import ConfigReader
+from .backends import BackendKind
+
+logger = logging.getLogger(__name__)
+
+
+class DomainType(str, Enum):
+    """What a Cloudsmith host is for.
+
+    A host that serves a single package format speaks that format's native
+    protocol (``NATIVE_API``); the format-less hosts are the download CDN, the
+    generic upload endpoint, and the Cloudsmith API itself.
+    """
+
+    DOWNLOAD = "download"
+    UPLOAD = "upload"
+    API = "api"
+    NATIVE_API = "native_api"
+
+
+SERVER_DOMAIN_TYPES: dict[int, DomainType] = {
+    0: DomainType.DOWNLOAD,
+    1: DomainType.UPLOAD,
+    2: DomainType.API,
+    3: DomainType.NATIVE_API,
+}
+
+
+def format_for_backend_kind(backend_kind: int | None) -> str | None:
+    """Return the package format a backend kind serves, or None.
+
+    A host with no backend kind serves no single format and resolves to
+    ``None``. :class:`BackendKind` is hand-maintained, so a format the CLI does
+    not know yet renders as ``unknown`` rather than breaking its caller.
+    """
+    if backend_kind is None:
+        return None
+
+    try:
+        return BackendKind(backend_kind).name.lower()
+    except ValueError:
+        return "unknown"
+
+
+def domain_type_from_server(value: int | str) -> DomainType:
+    """Resolve a custom domain's type as the server reported it.
+
+    The server classifies every domain and sends the answer as an integer; the
+    on-disk cache stores this enum's own string value. A type this CLI does not
+    know yet reads as a download host rather than breaking the listing.
+    """
+    try:
+        if isinstance(value, str):
+            return DomainType(value)
+        return SERVER_DOMAIN_TYPES[int(value)]
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Unrecognised domain type %r", value)
+        return DomainType.DOWNLOAD
+
+
+@dataclass(frozen=True)
+class DefaultDomain:
+    """A built-in or config-declared default Cloudsmith host."""
+
+    host: str
+    backend_kind: int | None
+    domain_type: DomainType = DomainType.NATIVE_API
+
+    @property
+    def format_label(self) -> str | None:
+        """The package format this host serves, or None for no single format."""
+        return format_for_backend_kind(self.backend_kind)
+
+
+BUILTIN_DOMAINS: tuple[DefaultDomain, ...] = (
+    DefaultDomain("cargo.cloudsmith.io", BackendKind.CARGO),
+    DefaultDomain("composer.cloudsmith.io", BackendKind.COMPOSER),
+    DefaultDomain("conan.cloudsmith.io", BackendKind.CONAN),
+    DefaultDomain("conda.cloudsmith.io", BackendKind.CONDA),
+    DefaultDomain("dart.cloudsmith.io", BackendKind.DART),
+    DefaultDomain("dl.cloudsmith.io", None, DomainType.DOWNLOAD),
+    DefaultDomain("docker.cloudsmith.io", BackendKind.DOCKER),
+    DefaultDomain("generic.cloudsmith.io", BackendKind.GENERIC),
+    DefaultDomain("golang.cloudsmith.io", BackendKind.GO),
+    DefaultDomain("helm.oci.cloudsmith.io", BackendKind.HELM),
+    DefaultDomain("hex.cloudsmith.io", BackendKind.HEX),
+    DefaultDomain("huggingface.cloudsmith.io", BackendKind.HUGGINGFACE),
+    DefaultDomain("maven.cloudsmith.io", BackendKind.MAVEN),
+    DefaultDomain("nix.cloudsmith.io", BackendKind.NIX),
+    DefaultDomain("npm.cloudsmith.io", BackendKind.NPM),
+    DefaultDomain("nuget.cloudsmith.io", BackendKind.NUGET),
+    DefaultDomain("python.cloudsmith.io", BackendKind.PYTHON),
+    DefaultDomain("ruby.cloudsmith.io", BackendKind.RUBY),
+    DefaultDomain("swift.cloudsmith.io", BackendKind.SWIFT),
+    DefaultDomain("terraform.cloudsmith.io", BackendKind.TERRAFORM),
+    DefaultDomain("upload.cloudsmith.io", None, DomainType.UPLOAD),
+)
+
+RESERVED_LABELS: dict[str, DomainType] = {
+    "download": DomainType.DOWNLOAD,
+    "upload": DomainType.UPLOAD,
+}
+
+
+def _resolve_backend_kind(label: str) -> int | None:
+    """Resolve a config-declared label to a BackendKind member, if any."""
+    if not label:
+        return None
+    return BackendKind.__members__.get(label.upper())
+
+
+def _domain_from_config_entry(host: str, label: str) -> DefaultDomain | None:
+    """Build a DefaultDomain from one ``[domains]`` ``host = label`` entry.
+
+    A label names a package format, or one of the two endpoints no format
+    names: ``download`` for the CDN and ``upload`` for the generic upload
+    endpoint, neither of which has a BackendKind to name it by.
+
+    The label is required. An entry naming nothing recognisable is skipped with
+    a warning rather than read as the CDN, since a typo'd format quietly
+    serving downloads is far harder to spot than a host that is simply absent.
+    """
+    normalised = label.strip().lower()
+
+    reserved_type = RESERVED_LABELS.get(normalised)
+    if reserved_type is not None:
+        return DefaultDomain(host=host, backend_kind=None, domain_type=reserved_type)
+
+    backend_kind = _resolve_backend_kind(normalised)
+    if backend_kind is None:
+        logger.warning(
+            "Ignoring %s in the [domains] section: %r names no package format, "
+            "nor download or upload",
+            host,
+            label,
+        )
+        return None
+
+    return DefaultDomain(host=host, backend_kind=backend_kind)
+
+
+def _config_candidates(*, trusted: bool) -> list[Path]:
+    """Return candidate config.ini paths from ConfigReader's search locations.
+
+    The search path lists the current directory first, so absolute entries are
+    the trusted ones and directory-relative entries are not.
+
+    Absolute filenames are skipped. Joining one onto a search directory would
+    yield that same path under every location, handing a trusted file to the
+    untrusted scan; :func:`_explicit_config_candidate` reads it instead.
+    """
+    filenames = [
+        filename
+        for filename in ConfigReader.config_files
+        if not os.path.isabs(filename)
+    ]
+    return [
+        Path(directory) / filename
+        for directory in ConfigReader.config_searchpath
+        if os.path.isabs(directory) is trusted
+        for filename in filenames
+    ]
+
+
+def _explicit_config_candidate() -> Path | None:
+    """Return the explicit ``--config-file`` entry in ``config_files``, if any.
+
+    ``ConfigReader.load_config`` prepends an absolute path here when
+    ``--config-file`` names a file; a directory goes to ``config_searchpath``
+    instead and is covered by :func:`_config_candidates`. The entry is
+    explicit user intent, so it is trusted.
+    """
+    for filename in ConfigReader.config_files:
+        if os.path.isabs(filename):
+            return Path(filename)
+    return None
+
+
+def _trusted_domains() -> list[DefaultDomain] | None:
+    """Return the [domains] table from the first trusted config declaring one.
+
+    An explicit ``--config-file`` is checked ahead of the search-path
+    candidates. Declaring a table is what counts, not existing: a trusted
+    ``config.ini`` holding only ``[default]`` api settings must not mask a
+    ``[domains]`` section in a later candidate.
+    """
+    candidates = []
+    explicit = _explicit_config_candidate()
+    if explicit is not None:
+        candidates.append(explicit)
+    candidates.extend(_config_candidates(trusted=True))
+
+    for candidate in candidates:
+        domains = _domains_from_config(candidate)
+        if domains is not None:
+            return domains
+    return None
+
+
+def _read_domains_section(path: Path) -> configparser.SectionProxy | None:
+    """Return the ``[domains]`` section at `path`, or None if absent/unreadable.
+
+    ``[domains]`` maps arbitrary hostnames to formats, so its keys cannot be
+    declared as a click_configfile section schema the way ``[default]`` is; it
+    is read with configparser directly.
+
+    A domain table is data, not a template, so interpolation is off and a ``%``
+    in a format label is a literal.
+    """
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        read_files = parser.read(path, encoding="utf-8")
+    except (OSError, configparser.Error) as exc:
+        logger.debug("Failed to read config file %s: %s", path, exc)
+        return None
+
+    if not read_files or not parser.has_section("domains"):
+        return None
+    return parser["domains"]
+
+
+def _domains_from_config(path: Path) -> list[DefaultDomain] | None:
+    """Parse a [domains] section at `path`, or None if it declares no host.
+
+    A section whose every entry was skipped reads as no table at all rather
+    than as an empty one, so a wholly unusable declaration falls back to the
+    built-in hosts instead of leaving the caller with nothing to publish to.
+    """
+    section = _read_domains_section(path)
+    if section is None:
+        return None
+
+    domains = [
+        domain
+        for host, label in section.items()
+        if (domain := _domain_from_config_entry(host, label)) is not None
+    ]
+    return sorted(domains, key=lambda domain: domain.host) or None
+
+
+def load_default_domains(config_path: Path | str | None = None) -> list[DefaultDomain]:
+    """Return the default domain table, honouring a trusted config override.
+
+    `config_path` is read ahead of the trusted search locations rather than
+    instead of them, so a file holding only ``[default]`` api settings cannot
+    mask a deployment's ``[domains]`` table. The search locations are
+    ConfigReader's absolute ones, never the current working directory. A
+    malformed or unreadable file falls back to the built-in table.
+    """
+    domains = None
+    if config_path is not None:
+        domains = _domains_from_config(Path(config_path))
+    if domains is None:
+        domains = _trusted_domains()
+
+    if domains is None:
+        return list(BUILTIN_DOMAINS)
+
+    return domains
+
+
+def untrusted_config_declares_domains() -> bool:
+    """True if a directory-relative config.ini declares a [domains] section.
+
+    Such a section is ignored. config.ini is searched in the current working
+    directory first, so a repository can ship one, and this table decides which
+    hosts may receive a Cloudsmith token: honouring it would let a malicious
+    repo harvest a live credential, the same vector
+    ``_guard_untrusted_endpoints`` closes for api_host. The caller warns so the
+    omission is visible.
+    """
+    return any(
+        _read_domains_section(candidate) is not None
+        for candidate in _config_candidates(trusted=False)
+    )

--- a/cloudsmith_cli/credential_helpers/default_domains.py
+++ b/cloudsmith_cli/credential_helpers/default_domains.py
@@ -40,20 +40,18 @@ class DomainType(str, Enum):
     """What a Cloudsmith host is for.
 
     A host that serves a single package format speaks that format's native
-    protocol (``NATIVE_API``); the format-less hosts are the download CDN, the
-    generic upload endpoint, and the Cloudsmith API itself.
+    protocol (``NATIVE_API``); the format-less hosts are the download CDN and
+    the generic upload endpoint.
     """
 
     DOWNLOAD = "download"
     UPLOAD = "upload"
-    API = "api"
     NATIVE_API = "native_api"
 
 
 SERVER_DOMAIN_TYPES: dict[int, DomainType] = {
     0: DomainType.DOWNLOAD,
     1: DomainType.UPLOAD,
-    2: DomainType.API,
     3: DomainType.NATIVE_API,
 }
 
@@ -242,7 +240,7 @@ def _read_domains_section(path: Path) -> configparser.SectionProxy | None:
     parser = configparser.ConfigParser(interpolation=None)
     try:
         read_files = parser.read(path, encoding="utf-8")
-    except (OSError, configparser.Error) as exc:
+    except (OSError, UnicodeDecodeError, configparser.Error) as exc:
         logger.debug("Failed to read config file %s: %s", path, exc)
         return None
 

--- a/cloudsmith_cli/credential_helpers/docker/installer.py
+++ b/cloudsmith_cli/credential_helpers/docker/installer.py
@@ -131,11 +131,7 @@ class DockerInstaller:
 
         # --- Custom-domain auto-discovery (best-effort) ---
         if discover:
-            if dry_run:
-                # Discovery queries the API and refreshes the on-disk domain
-                # cache, neither of which a "no changes" preview may do.
-                actions.append("skipped custom-domain auto-discovery (dry run)")
-            elif org and credential and credential.api_key:
+            if org and credential and credential.api_key:
                 # Discovery boundary: network/SDK errors must never abort the
                 # default install.  ApiException is already handled inside
                 # get_format_domains; this broad catch is the deliberate outer

--- a/cloudsmith_cli/credential_helpers/docker/installer.py
+++ b/cloudsmith_cli/credential_helpers/docker/installer.py
@@ -131,7 +131,11 @@ class DockerInstaller:
 
         # --- Custom-domain auto-discovery (best-effort) ---
         if discover:
-            if org and credential and credential.api_key:
+            if dry_run:
+                # Discovery queries the API and refreshes the on-disk domain
+                # cache, neither of which a "no changes" preview may do.
+                actions.append("skipped custom-domain auto-discovery (dry run)")
+            elif org and credential and credential.api_key:
                 # Discovery boundary: network/SDK errors must never abort the
                 # default install.  ApiException is already handled inside
                 # get_format_domains; this broad catch is the deliberate outer

--- a/cloudsmith_cli/credential_helpers/docker/installer.py
+++ b/cloudsmith_cli/credential_helpers/docker/installer.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from ...core.cache_utils import merge_json_file
+from ...core.credentials.models import CredentialResult
 from ..backends import BackendKind
 from ..custom_domains import get_format_domains
 from ..launchers import is_on_path, remove_launcher, resolve_bin_dir, write_launcher
@@ -80,8 +81,7 @@ class DockerInstaller:
         discover: bool = True,
         refresh: bool = False,
         org: str | None = None,
-        api_key: str | None = None,
-        auth_type: str = "api_key",
+        credential: CredentialResult | None = None,
         api_host: str | None = None,
         dry_run: bool = False,
     ) -> list[str]:
@@ -107,10 +107,8 @@ class DockerInstaller:
             the API.  Only meaningful when *discover* is also ``True``.
         org:
             Cloudsmith organisation slug used for custom-domain discovery.
-        api_key:
-            API key used for custom-domain discovery.
-        auth_type:
-            Credential type: ``"api_key"`` (default) or ``"bearer"``.
+        credential:
+            Resolved credential used for custom-domain discovery.
         api_host:
             Cloudsmith API host URL override.
         dry_run:
@@ -133,7 +131,7 @@ class DockerInstaller:
 
         # --- Custom-domain auto-discovery (best-effort) ---
         if discover:
-            if org and api_key:
+            if org and credential:
                 # Discovery boundary: network/SDK errors must never abort the
                 # default install.  ApiException is already handled inside
                 # get_format_domains; this broad catch is the deliberate outer
@@ -144,8 +142,7 @@ class DockerInstaller:
                     discovered = get_format_domains(
                         org,
                         BackendKind.DOCKER,
-                        api_key=api_key,
-                        auth_type=auth_type,
+                        credential=credential,
                         api_host=api_host,
                         refresh=refresh,
                     )

--- a/cloudsmith_cli/credential_helpers/docker/runtime.py
+++ b/cloudsmith_cli/credential_helpers/docker/runtime.py
@@ -25,7 +25,7 @@ _REFUSAL_MESSAGE = (
 )
 
 
-def get_credentials(server_url, credential=None, api_host=None):
+def get_credentials(server_url, credential=None, api_host=None, org=None):
     """
     Get credentials for a Cloudsmith Docker registry.
 
@@ -36,6 +36,7 @@ def get_credentials(server_url, credential=None, api_host=None):
         server_url: The Docker registry server URL
         credential: Pre-resolved CredentialResult from the provider chain
         api_host: Cloudsmith API host URL
+        org: Organisation slug whose custom domains to match against
 
     Returns:
         dict: Credentials with 'Username' and 'Secret' keys, or None
@@ -48,20 +49,25 @@ def get_credentials(server_url, credential=None, api_host=None):
         credential=credential,
         api_host=api_host,
         backend_kind=BackendKind.DOCKER,
+        org=org,
     ):
         return None
 
     return {"Username": "token", "Secret": credential.api_key}
 
 
-def _execute_get(stdin, credential, api_host) -> tuple[int, str | None, str | None]:
+def _execute_get(
+    stdin, credential, api_host, org
+) -> tuple[int, str | None, str | None]:
     """Handle the 'get' operation of the Docker credential helper protocol."""
     try:
         server_url = stdin.read().strip()
         if not server_url:
             return (1, None, "Error: No server URL provided on stdin")
 
-        creds = get_credentials(server_url, credential=credential, api_host=api_host)
+        creds = get_credentials(
+            server_url, credential=credential, api_host=api_host, org=org
+        )
         if creds is None:
             return (1, None, _REFUSAL_MESSAGE)
 
@@ -78,7 +84,7 @@ def _execute_get(stdin, credential, api_host) -> tuple[int, str | None, str | No
 
 
 def execute(
-    operation, stdin, credential=None, api_host=None
+    operation, stdin, credential=None, api_host=None, org=None
 ) -> tuple[int, str | None, str | None]:
     """
     Execute a Docker credential helper protocol operation.
@@ -88,6 +94,7 @@ def execute(
         stdin: A file-like object to read the server URL from (for 'get')
         credential: Pre-resolved CredentialResult from the provider chain
         api_host: Cloudsmith API host URL
+        org: Organisation slug whose custom domains to match against
 
     Returns:
         A (exit_code, stdout_text, stderr_text) tuple.  Either text value may
@@ -106,7 +113,7 @@ def execute(
         return (0, "{}", None)
 
     if operation == "get":
-        return _execute_get(stdin, credential, api_host)
+        return _execute_get(stdin, credential, api_host, org)
 
     return (
         1,

--- a/cloudsmith_cli/credential_helpers/docker/runtime.py
+++ b/cloudsmith_cli/credential_helpers/docker/runtime.py
@@ -45,8 +45,7 @@ def get_credentials(server_url, credential=None, api_host=None):
 
     if not is_cloudsmith_domain(
         server_url,
-        api_key=credential.api_key,
-        auth_type=getattr(credential, "auth_type", "api_key"),
+        credential=credential,
         api_host=api_host,
         backend_kind=BackendKind.DOCKER,
     ):


### PR DESCRIPTION
# Description

Adds `cloudsmith domains list`, which emits a versioned JSON document listing
the hosts Cloudsmith can authenticate — built-in `*.cloudsmith.io` service hosts
plus an organisation's custom domains.

- **Filters on the domain list.** `--format` keeps the hosts usable for a package format: a host
  serving no single format serves every one, so the download CDN and the
  generic upload endpoint survive any `--format`. `--repo` keeps the hosts
  usable for a repository, most-preferred first. `--domain-type` is an exact match instead — a host has
  exactly one purpose — so pairing it with `--format` asks for a host
  speaking a format's own protocol.

- **`--org` is the name of the organisation option.** `--organization` and
  `--oidc-org` remain as aliases, and `org`, `organization` or `oidc_org` are
  all accepted in `config.ini`. `--oidc-org` named the setting after the first
  feature that wanted it; custom-domain discovery reads it too, so it is now
  named after what it is. `CLOUDSMITH_ORG` is unchanged, and
  `credential-helper install` no longer carries a separate `--org` of its own.

- **A replaceable domain table.** A dedicated deployment, serving packages from
  its own domains, can replace the built-in hosts via a `[domains]` section in
  `config.ini`. Each entry names the package format its host serves, or
  `download`/`upload` for the two endpoints no format names; an entry naming
  nothing recognisable is skipped with a warning rather than guessed at. This is
  honoured only from trusted configuration — your config directory,
  `~/.cloudsmith`, or an explicit `--config-file`. A `[domains]` section in a
  directory-relative `config.ini` is ignored with a warning, because that file
  can be committed to a repository and this list decides which hosts may receive
  a credential.

- **Server-matching precedence between overlapping domains.** A domain bound to
  the repository in hand beats an organisation-wide one, `primary` beats
  secondary, and the oldest breaks any remaining tie. With `--repo` the custom
  domains come back most-preferred first, so the first entry is the one
  Cloudsmith would bind for that repository.

- **A seven-day on-disk cache**, with `--refresh` to bypass it

- With no organisation configured, the command lists whatever custom domains an
  earlier run already cached, at no API cost, rather than enumerating every
  organisation the caller belongs to.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)
