### PR TITLE
fix(no-ticket): resolve AWS STS region and wire up --debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cloudsmith auth` no longer fails when it can't launch a browser. `webbrowser.open()` raises `webbrowser.Error` where no runnable browser is found (Cygwin, headless shells) and returns `False` on other launch failures; neither outcome was handled, so the command either crashed or silently waited on a callback the user had no way to trigger. Either outcome now prints the IDP URL with instructions to open it manually, and authentication continues against the same local callback.
 - `python -m cloudsmith_cli` now exits non-zero when a command fails. `AliasGroup.main` runs click with `standalone_mode=False` so click returns the exit code from `ctx.exit()` rather than raising `SystemExit`, and the module entrypoint discarded that return value — so a failed push, or an unauthorised request, exited 0. The `cloudsmith` console script and the standalone binaries already wrapped `main()` in `sys.exit()` and were unaffected.
 - The hint shown for a 401 when a credential is set no longer claims the cause is a missing permission. A 401 does not tell the CLI whether the credential is invalid, expired, or simply has no access to the resource, so the hint now names those possibilities and asks the user to check their credentials, instead of contradicting the `401 - Unauthorized` status it accompanies.
+- The AWS OIDC detector now resolves the AWS region for its STS client with the AWS CLI precedence: explicit session region, `AWS_REGION`, `AWS_DEFAULT_REGION`, the shared config file, then EC2 instance metadata. botocore's own session resolution does not read `AWS_REGION` and never consults instance metadata, so on hosts that configure the region only through those sources the client targeted the legacy global STS endpoint instead of the regional one.
+- `--debug` now prints the CLI's debug log records to stderr; previously the flag was recorded but no log handler was installed, so the records went nowhere. The flag is also honoured when set on the group (`cloudsmith -d <command>`) or through the config file, where the subcommand's own flag default used to overwrite it.
+
+### Changed
+
+- The minimum supported `click` version is now 8.2.
 
 ## [1.23.0] - 2026-08-14
 

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -1,6 +1,7 @@
 """CLI - Decorators."""
 
 import functools
+import logging
 import os
 
 import click
@@ -26,6 +27,27 @@ def report_retry(seconds, context=None):
         click.echo(
             f"Request was throttled (429): Retrying after {click.style(str(seconds), bold=True)} second(s) ... "
         )
+
+
+_DEBUG_LOG_HANDLER_NAME = "cloudsmith-cli-debug"
+
+
+def _configure_debug_logging(enabled):
+    """Install or remove the stderr handler for this package's debug records."""
+    package_logger = logging.getLogger("cloudsmith_cli")
+    for handler in list(package_logger.handlers):
+        if handler.name == _DEBUG_LOG_HANDLER_NAME:
+            package_logger.removeHandler(handler)
+    if not enabled:
+        package_logger.setLevel(logging.NOTSET)
+        package_logger.propagate = True
+        return
+    package_logger.setLevel(logging.DEBUG)
+    package_logger.propagate = False
+    handler = logging.StreamHandler()
+    handler.name = _DEBUG_LOG_HANDLER_NAME
+    handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+    package_logger.addHandler(handler)
 
 
 def _pop_boolean_flag(kwargs, name, invert=False):
@@ -158,7 +180,8 @@ def common_cli_output_options(f):
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
         opts = config.get_or_create_options(ctx)
-        opts.debug = kwargs.pop("debug")
+        opts.debug = kwargs.pop("debug") or opts.debug
+        _configure_debug_logging(opts.debug)
         opts.output = kwargs.pop("output_format")
         opts.verbose = kwargs.pop("verbose")
         kwargs["opts"] = opts

--- a/cloudsmith_cli/cli/tests/test_debug_logging.py
+++ b/cloudsmith_cli/cli/tests/test_debug_logging.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for the --debug flag enabling logger output."""
+
+import logging
+
+import click
+import pytest
+
+from ..config import OPTIONS
+from ..decorators import _DEBUG_LOG_HANDLER_NAME, common_cli_output_options
+
+
+def _debug_handlers():
+    package_logger = logging.getLogger("cloudsmith_cli")
+    return [
+        handler
+        for handler in package_logger.handlers
+        if handler.name == _DEBUG_LOG_HANDLER_NAME
+    ]
+
+
+@pytest.fixture
+def package_logger_state(monkeypatch):
+    """Reset the options and restore the package logger after the test."""
+    monkeypatch.delattr(OPTIONS, "value", raising=False)
+    package_logger = logging.getLogger("cloudsmith_cli")
+    original_level = package_logger.level
+    original_handlers = list(package_logger.handlers)
+    original_propagate = package_logger.propagate
+    yield package_logger
+    package_logger.setLevel(original_level)
+    package_logger.handlers = original_handlers
+    package_logger.propagate = original_propagate
+
+
+@pytest.fixture
+def logging_command(package_logger_state):
+    """A minimal command that emits one debug record from a package logger."""
+
+    @click.command()
+    @common_cli_output_options
+    @click.pass_context
+    def emit(ctx, opts):
+        logging.getLogger("cloudsmith_cli.cli.tests").debug("debug record")
+        logging.getLogger("third_party").debug("third-party record")
+
+    return emit
+
+
+@pytest.fixture
+def logging_group(package_logger_state):
+    """A group whose subcommand reports opts.debug and emits a debug record."""
+
+    @click.group()
+    @common_cli_output_options
+    @click.pass_context
+    def group(ctx, opts):
+        pass
+
+    @group.command()
+    @common_cli_output_options
+    @click.pass_context
+    def emit(ctx, opts):
+        click.echo(f"debug={opts.debug}")
+        logging.getLogger("cloudsmith_cli.cli.tests").debug("debug record")
+
+    return group
+
+
+def test_debug_flag_shows_package_debug_records(runner, logging_command):
+    result = runner.invoke(logging_command, ["--debug"])
+
+    assert result.exit_code == 0, result.output
+    assert "debug record" in result.stderr
+
+
+def test_debug_flag_does_not_enable_third_party_debug_records(runner, logging_command):
+    result = runner.invoke(logging_command, ["--debug"])
+
+    assert result.exit_code == 0, result.output
+    assert "third-party record" not in result.stderr
+
+
+def test_without_debug_flag_debug_records_stay_hidden(runner, logging_command):
+    result = runner.invoke(logging_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert "debug record" not in result.stderr
+    assert not _debug_handlers()
+
+
+def test_repeat_invocations_do_not_duplicate_records(runner, logging_command):
+    runner.invoke(logging_command, ["--debug"])
+    result = runner.invoke(logging_command, ["--debug"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr.count("debug record") == 1
+    assert len(_debug_handlers()) == 1
+
+
+def test_later_invocation_without_debug_flag_disables_debug_logging(
+    runner, logging_command, monkeypatch
+):
+    runner.invoke(logging_command, ["--debug"])
+    monkeypatch.delattr(OPTIONS, "value", raising=False)
+
+    result = runner.invoke(logging_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert not _debug_handlers()
+    assert logging.getLogger("cloudsmith_cli").getEffectiveLevel() > logging.DEBUG
+
+
+def test_group_level_debug_flag_reaches_the_subcommand(runner, logging_group):
+    result = runner.invoke(logging_group, ["-d", "emit"])
+
+    assert result.exit_code == 0, result.output
+    assert "debug=True" in result.output
+    assert "debug record" in result.stderr

--- a/cloudsmith_cli/core/credentials/oidc/detectors/aws.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/aws.py
@@ -20,6 +20,38 @@ logger = logging.getLogger(__name__)
 DEFAULT_AUDIENCE = "cloudsmith"
 
 
+def _resolve_region(session) -> str | None:
+    """Resolve the AWS region with the AWS CLI precedence.
+
+    The order is: explicit session config, AWS_REGION, AWS_DEFAULT_REGION,
+    the config file region, then EC2 instance metadata.
+    """
+    try:
+        # Lazy imports: botocore is an optional dependency (the aws extra).
+        from botocore.configprovider import ConfigChainFactory
+        from botocore.exceptions import BotoCoreError
+        from botocore.utils import BadIMDSRequestError, IMDSRegionProvider
+    except ImportError:
+        logger.debug("AWSDetector: region providers unavailable", exc_info=True)
+        return None
+
+    # No public accessor exists for the underlying botocore session.
+    botocore_session = session._session  # pylint: disable=protected-access
+    chain = ConfigChainFactory(session=botocore_session).create_config_chain(
+        instance_name="region",
+        env_var_names=["AWS_REGION", "AWS_DEFAULT_REGION"],
+        config_property_names="region",
+    )
+    region = chain.provide()
+    if region:
+        return region
+    try:
+        return IMDSRegionProvider(session=botocore_session).provide()
+    except (BotoCoreError, BadIMDSRequestError):
+        logger.debug("AWSDetector: IMDS region lookup failed", exc_info=True)
+        return None
+
+
 class AWSDetector(EnvironmentDetector):
     """Detects AWS environments and obtains a JWT via STS GetWebIdentityToken."""
 
@@ -71,7 +103,7 @@ class AWSDetector(EnvironmentDetector):
 
         audience = self.context.oidc_audience or DEFAULT_AUDIENCE
         session = self._session or boto3.Session()
-        sts = session.client("sts")
+        sts = session.client("sts", region_name=_resolve_region(session))
         response = sts.get_web_identity_token(
             Audience=[audience],
             SigningAlgorithm="RS256",

--- a/cloudsmith_cli/core/tests/test_aws_detector.py
+++ b/cloudsmith_cli/core/tests/test_aws_detector.py
@@ -49,6 +49,14 @@ class TestResolveRegion:
             session = boto3.Session()
             assert _resolve_region(session) == "us-west-2"
 
+    def test_falls_back_to_config_file_region(self, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text("[default]\nregion = eu-central-1\n")
+        env = _aws_env(AWS_CONFIG_FILE=str(config_file))
+        with mock.patch.dict("os.environ", env, clear=True):
+            session = boto3.Session()
+            assert _resolve_region(session) == "eu-central-1"
+
     def test_falls_back_to_imds_when_unset(self):
         with mock.patch.dict("os.environ", _aws_env(), clear=True):
             session = boto3.Session()

--- a/cloudsmith_cli/core/tests/test_aws_detector.py
+++ b/cloudsmith_cli/core/tests/test_aws_detector.py
@@ -1,0 +1,119 @@
+"""Tests for the AWS OIDC detector."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from cloudsmith_cli.core.credentials.models import CredentialContext
+from cloudsmith_cli.core.credentials.oidc.detectors.aws import (
+    AWSDetector,
+    _resolve_region,
+)
+
+boto3 = pytest.importorskip("boto3")
+MetadataRetrievalError = pytest.importorskip(
+    "botocore.exceptions"
+).MetadataRetrievalError
+BadIMDSRequestError = pytest.importorskip("botocore.utils").BadIMDSRequestError
+
+ISOLATED_AWS_ENV = {
+    "AWS_CONFIG_FILE": os.devnull,
+    "AWS_SHARED_CREDENTIALS_FILE": os.devnull,
+}
+
+
+def _aws_env(**overrides):
+    """Return an env dict that hides the host's AWS config files."""
+    return {**ISOLATED_AWS_ENV, **overrides}
+
+
+class TestResolveRegion:
+    def test_prefers_aws_region_env_var(self):
+        env = _aws_env(AWS_REGION="eu-west-1", AWS_DEFAULT_REGION="us-west-2")
+        with mock.patch.dict("os.environ", env, clear=True):
+            session = boto3.Session()
+            assert _resolve_region(session) == "eu-west-1"
+
+    def test_explicit_session_region_beats_aws_region_env_var(self):
+        with mock.patch.dict(
+            "os.environ", _aws_env(AWS_REGION="eu-west-1"), clear=True
+        ):
+            session = boto3.Session(region_name="ap-southeast-2")
+            assert _resolve_region(session) == "ap-southeast-2"
+
+    def test_falls_back_to_aws_default_region_env_var(self):
+        with mock.patch.dict(
+            "os.environ", _aws_env(AWS_DEFAULT_REGION="us-west-2"), clear=True
+        ):
+            session = boto3.Session()
+            assert _resolve_region(session) == "us-west-2"
+
+    def test_falls_back_to_imds_when_unset(self):
+        with mock.patch.dict("os.environ", _aws_env(), clear=True):
+            session = boto3.Session()
+            with mock.patch("botocore.utils.IMDSRegionProvider") as provider_cls:
+                provider_cls.return_value.provide.return_value = "sa-east-1"
+                assert _resolve_region(session) == "sa-east-1"
+
+    def test_returns_none_when_nothing_resolves(self):
+        with mock.patch.dict("os.environ", _aws_env(), clear=True):
+            session = boto3.Session()
+            with mock.patch("botocore.utils.IMDSRegionProvider") as provider_cls:
+                provider_cls.return_value.provide.side_effect = MetadataRetrievalError(
+                    error_msg="no imds"
+                )
+                assert _resolve_region(session) is None
+
+    def test_returns_none_when_imds_rejects_the_request(self):
+        with mock.patch.dict("os.environ", _aws_env(), clear=True):
+            session = boto3.Session()
+            with mock.patch("botocore.utils.IMDSRegionProvider") as provider_cls:
+                provider_cls.return_value.provide.side_effect = BadIMDSRequestError(
+                    request=None
+                )
+                assert _resolve_region(session) is None
+
+
+class TestGetToken:
+    def test_regional_region_name_produces_regional_endpoint(self):
+        with mock.patch.dict(
+            "os.environ", _aws_env(AWS_REGION="eu-west-1"), clear=True
+        ):
+            session = boto3.Session(
+                aws_access_key_id="test", aws_secret_access_key="test"
+            )
+            region = _resolve_region(session)
+            sts = session.client("sts", region_name=region)
+            assert sts.meta.endpoint_url == "https://sts.eu-west-1.amazonaws.com"
+            assert sts.meta.region_name != "aws-global"
+
+    @staticmethod
+    def _get_token_sts_region(env):
+        """Run get_token with a fake STS client and return the region it was given."""
+        detector = AWSDetector(context=CredentialContext())
+        fake_sts = mock.Mock()
+        fake_sts.get_web_identity_token.return_value = {"WebIdentityToken": "jwt"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            session = boto3.Session(
+                aws_access_key_id="test", aws_secret_access_key="test"
+            )
+            with mock.patch.object(detector, "_session", session):
+                with mock.patch.object(
+                    session, "client", return_value=fake_sts
+                ) as client:
+                    assert detector.get_token() == "jwt"
+        (service_name,), call_kwargs = client.call_args
+        assert service_name == "sts"
+        return call_kwargs["region_name"]
+
+    def test_passes_resolved_region_to_sts_client(self):
+        region = self._get_token_sts_region(_aws_env(AWS_REGION="eu-west-1"))
+        assert region == "eu-west-1"
+
+    def test_no_region_resolved_passes_none_region(self):
+        with mock.patch("botocore.utils.IMDSRegionProvider") as provider_cls:
+            provider_cls.return_value.provide.side_effect = MetadataRetrievalError(
+                error_msg="no imds"
+            )
+            assert self._get_token_sts_region(_aws_env()) is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "click>=8.1.8,!=8.3.0",
+    "click>=8.2,!=8.3.0",
     "click-configfile>=0.2.3",
     "click-didyoumean>=0.0.3",
     "click-spinner>=0.1.7",
@@ -72,6 +72,7 @@ Homepage = "https://github.com/cloudsmith-io/cloudsmith-cli"
 
 [dependency-groups]
 dev = [
+    "boto3[crt]>=1.26.0",
     "pre-commit",
     "pylint",
     "pytest-cov",

--- a/uv.lock
+++ b/uv.lock
@@ -559,6 +559,7 @@ binary = [
     { name = "wheel" },
 ]
 dev = [
+    { name = "boto3", extra = ["crt"] },
     { name = "bumpversion" },
     { name = "freezegun" },
     { name = "httpretty" },
@@ -578,7 +579,7 @@ release = [
 requires-dist = [
     { name = "boto3", extras = ["crt"], marker = "extra == 'all'", specifier = ">=1.26.0" },
     { name = "boto3", extras = ["crt"], marker = "extra == 'aws'", specifier = ">=1.26.0" },
-    { name = "click", specifier = ">=8.1.8,!=8.3.0" },
+    { name = "click", specifier = ">=8.2,!=8.3.0" },
     { name = "click-configfile", specifier = ">=0.2.3" },
     { name = "click-didyoumean", specifier = ">=0.0.3" },
     { name = "click-spinner", specifier = ">=0.1.7" },
@@ -606,6 +607,7 @@ binary = [
     { name = "wheel", specifier = "==0.47.0" },
 ]
 dev = [
+    { name = "boto3", extras = ["crt"], specifier = ">=1.26.0" },
     { name = "bumpversion" },
     { name = "freezegun" },
     { name = "httpretty" },


### PR DESCRIPTION
## Summary

- The AWS OIDC detector now resolves the AWS region with the AWS CLI precedence: explicit session region, `AWS_REGION`, `AWS_DEFAULT_REGION`, the shared config file, then EC2 instance metadata. botocore's own session resolution does not read `AWS_REGION` and never consults instance metadata, so the STS client targeted the legacy global endpoint on hosts that configure the region through those sources.
- `--debug` now prints the CLI's debug log records to stderr. Previously the flag was recorded but no log handler was installed. The flag is also honoured when set on the group (`cloudsmith -d <command>`) or through the config file, where the subcommand's flag default used to overwrite it. The handler is removed again on invocations without the flag, so state does not leak between in-process invocations.
- Raise the `click` floor to 8.2. The debug-logging tests read `CliRunner` stderr, which click captures separately from 8.2 on.
- Add `boto3[crt]` to the `dev` dependency group. The AWS detector tests used to skip in CI because no extra installs boto3 there; they now run.

## Test plan

- New tests: `cloudsmith_cli/core/tests/test_aws_detector.py` (region precedence, IMDS fallback and failure modes, regional endpoint selection) and `cloudsmith_cli/cli/tests/test_debug_logging.py` (handler install/removal, dedup, group-level flag propagation).
- Full suite locally: 650 passed; the only failures are the 9 pre-existing keyring failures also present on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)