### PR TITLE
feat(no-ticket): normalize the API host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added an PNPM credential helper for Cloudsmith registries. `cloudsmith credential-helper install pnpm` installs an `pnpm-credential-cloudsmith` launcher binary and registers it in `~/.npmrc`, so npm authenticates to Cloudsmith registries automatically using your existing CLI credentials — no manual `npm login` required. Custom Cloudsmith registry domains are discovered via the API and cached locally; add extra hostnames with `--domain` (repeatable), disable discovery with `--no-discover`, or preview changes with `--dry-run`. Manage installed helpers with `cloudsmith credential-helper uninstall pnpm` and `cloudsmith credential-helper list`.
 
+### Changed
+
+- The API host is now normalised, so a loosely-written value works. The CLI removes surrounding whitespace and trailing slashes, and adds the `https` scheme when the value gives none. `api.cloudsmith.io`, `//api.cloudsmith.io/` and ` https://api.cloudsmith.io/ ` all resolve to `https://api.cloudsmith.io`. This applies to `--api-host`, `CLOUDSMITH_API_HOST` and the `api_host` config key, and it keeps the keyring token key stable between `cloudsmith auth` and `cloudsmith logout`. The allow-list check on `api_host` values from a directory-relative config file runs against the normalised value, so a scheme-less Cloudsmith host is no longer rejected.
+
 ## [1.24.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- The API host is now normalised, so a loosely-written value works. The CLI removes surrounding whitespace and trailing slashes, and adds the `https` scheme when the value gives none. `api.cloudsmith.io`, `//api.cloudsmith.io/` and ` https://api.cloudsmith.io/ ` all resolve to `https://api.cloudsmith.io`. This applies to `--api-host`, `CLOUDSMITH_API_HOST` and the `api_host` config key, and it keeps the keyring token key stable between `cloudsmith auth` and `cloudsmith logout`. The allow-list check on `api_host` values from a directory-relative config file runs against the normalised value, so a scheme-less Cloudsmith host is no longer rejected.
+- The API host is now normalised, so a loosely-written value works. The CLI removes surrounding whitespace and trailing slashes, and adds the `https` scheme when the value gives none. `api.cloudsmith.io`, `//api.cloudsmith.io/` and ` https://api.cloudsmith.io/ ` all resolve to `https://api.cloudsmith.io`. This applies to `--api-host`, `CLOUDSMITH_API_HOST` and the `api_host` config key, and it keeps the keyring token key stable between `cloudsmith auth` and `cloudsmith logout`. The allow-list check on `api_host` values from a directory-relative config file runs against the normalised value, so a scheme-less Cloudsmith host is no longer rejected. If your `api_host` had a trailing slash, the keyring key changes and you must run `cloudsmith auth` again.
 
 ## [1.24.0] - 2026-08-18
 

--- a/cloudsmith_cli/cli/commands/logout.py
+++ b/cloudsmith_cli/cli/commands/logout.py
@@ -7,7 +7,7 @@ import click
 import cloudsmith_api
 
 from ...core import keyring
-from .. import decorators, utils
+from .. import decorators, utils, validators
 from ..config import CredentialsReader
 from .main import main
 
@@ -117,8 +117,11 @@ def logout(ctx, opts, api_host, keyring_only, config_only, dry_run):
             "--keyring-only and --config-only are mutually exclusive."
         )
 
-    if api_host is None:
-        api_host = opts.api_host or cloudsmith_api.Configuration().host
+    api_host = (
+        validators.normalize_api_host(api_host)
+        or opts.api_host
+        or cloudsmith_api.Configuration().host
+    )
 
     use_stderr = utils.should_use_stderr(opts)
 

--- a/cloudsmith_cli/cli/commands/logout.py
+++ b/cloudsmith_cli/cli/commands/logout.py
@@ -87,7 +87,8 @@ def _collect_warnings(keyring_only, config_only):
     "--api-host",
     envvar="CLOUDSMITH_API_HOST",
     default=None,
-    help="The API host to clear keyring tokens for.",
+    help="The API host to clear keyring tokens for. If you do not give a "
+    "scheme, the CLI uses https.",
 )
 @click.option(
     "--keyring-only",

--- a/cloudsmith_cli/cli/commands/logout.py
+++ b/cloudsmith_cli/cli/commands/logout.py
@@ -87,8 +87,7 @@ def _collect_warnings(keyring_only, config_only):
     "--api-host",
     envvar="CLOUDSMITH_API_HOST",
     default=None,
-    help="The API host to clear keyring tokens for. If you do not give a "
-    "scheme, the CLI uses https.",
+    help="The API host to clear keyring tokens for."
 )
 @click.option(
     "--keyring-only",

--- a/cloudsmith_cli/cli/commands/logout.py
+++ b/cloudsmith_cli/cli/commands/logout.py
@@ -87,7 +87,7 @@ def _collect_warnings(keyring_only, config_only):
     "--api-host",
     envvar="CLOUDSMITH_API_HOST",
     default=None,
-    help="The API host to clear keyring tokens for."
+    help="The API host to clear keyring tokens for.",
 )
 @click.option(
     "--keyring-only",

--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -341,7 +341,7 @@ class Options:  # pylint: disable=too-many-public-methods
     @api_host.setter
     def api_host(self, value):
         """Set value for API host."""
-        self._set_option("api_host", value)
+        self._set_option("api_host", validators.normalize_api_host(value))
 
     @property
     def api_key(self):

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -312,7 +312,10 @@ def initialise_session(f):
     """Create a shared HTTP session with proxy/SSL/user-agent settings."""
 
     @click.option(
-        "--api-host", envvar="CLOUDSMITH_API_HOST", help="The API host to connect to."
+        "--api-host",
+        envvar="CLOUDSMITH_API_HOST",
+        help="The API host to connect to. If you do not give a scheme, "
+        "the CLI uses https.",
     )
     @click.option(
         "--api-proxy",

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -314,8 +314,7 @@ def initialise_session(f):
     @click.option(
         "--api-host",
         envvar="CLOUDSMITH_API_HOST",
-        help="The API host to connect to. If you do not give a scheme, "
-        "the CLI uses https.",
+        help="The API host to connect to",
     )
     @click.option(
         "--api-proxy",

--- a/cloudsmith_cli/cli/tests/commands/test_logout.py
+++ b/cloudsmith_cli/cli/tests/commands/test_logout.py
@@ -53,6 +53,14 @@ class TestLogoutCommand:
         assert "Removed credentials from:" in result.output
         assert "Removed SSO tokens from system keyring" in result.output
 
+    def test_misconfigured_api_host_is_normalized(self, runner, mock_deps):
+        _, mock_keyring = mock_deps
+
+        result = runner.invoke(logout, ["--api-host", " api.example.com/ "])
+
+        assert result.exit_code == 0
+        mock_keyring.delete_sso_tokens.assert_called_once_with(HOST)
+
     def test_dry_run(self, runner, mock_deps):
         mock_creds, mock_keyring = mock_deps
 

--- a/cloudsmith_cli/cli/tests/test_api_host_normalization.py
+++ b/cloudsmith_cli/cli/tests/test_api_host_normalization.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for api_host normalization."""
+
+import click
+import pytest
+
+from ..config import Options
+from ..decorators import _guard_untrusted_endpoints
+from ..validators import normalize_api_host
+from .test_api_host_validation import _FakeContext, _write_cwd_config
+
+
+class TestNormalizeApiHost:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("api.cloudsmith.io", "https://api.cloudsmith.io"),
+            ("api.cloudsmith.io/", "https://api.cloudsmith.io"),
+            ("api.cloudsmith.io:8080", "https://api.cloudsmith.io:8080"),
+            ("//api.cloudsmith.io", "https://api.cloudsmith.io"),
+            ("https://api.cloudsmith.io/", "https://api.cloudsmith.io"),
+            ("https://api.cloudsmith.io///", "https://api.cloudsmith.io"),
+            ("https://api.cloudsmith.io/v1/", "https://api.cloudsmith.io/v1"),
+            ("  https://api.cloudsmith.io  ", "https://api.cloudsmith.io"),
+            ("\thttps://api.cloudsmith.io\n", "https://api.cloudsmith.io"),
+            ("http://localhost:8000/", "http://localhost:8000"),
+            ("https://api.cloudsmith.io", "https://api.cloudsmith.io"),
+        ],
+    )
+    def test_host_is_normalized(self, value, expected):
+        assert normalize_api_host(value) == expected
+
+    @pytest.mark.parametrize("value", [None, "", "   "])
+    def test_empty_values_pass_through(self, value):
+        assert not normalize_api_host(value)
+
+
+class TestOptionsApiHost:
+    def test_setter_normalizes(self):
+        opts = Options()
+        opts.api_host = " api.cloudsmith.io/ "
+        assert opts.api_host == "https://api.cloudsmith.io"
+
+    def test_setter_accepts_none(self):
+        opts = Options()
+        opts.api_host = None
+        assert opts.api_host is None
+
+
+class TestGuardWithNormalizedHost:
+    def test_untrusted_host_without_scheme_still_raises(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = evil.example.com\n"
+        )
+        opts = Options()
+        opts.api_host = "evil.example.com"
+        with pytest.raises(click.UsageError):
+            _guard_untrusted_endpoints(_FakeContext({}), opts, (), ())
+
+    def test_trusted_host_without_scheme_passes(self, tmp_path, monkeypatch):
+        _write_cwd_config(
+            tmp_path, monkeypatch, "[default]\napi_host = api.cloudsmith.io/\n"
+        )
+        opts = Options()
+        opts.api_host = "api.cloudsmith.io/"
+        _guard_untrusted_endpoints(_FakeContext({}), opts, (), ())

--- a/cloudsmith_cli/cli/tests/test_api_host_normalization.py
+++ b/cloudsmith_cli/cli/tests/test_api_host_normalization.py
@@ -46,6 +46,12 @@ class TestOptionsApiHost:
         opts.api_host = None
         assert opts.api_host is None
 
+    def test_blank_value_keeps_the_current_host(self):
+        opts = Options()
+        opts.api_host = "https://api.internal.example"
+        opts.api_host = "   "
+        assert opts.api_host == "https://api.internal.example"
+
 
 class TestGuardWithNormalizedHost:
     def test_untrusted_host_without_scheme_still_raises(self, tmp_path, monkeypatch):

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -1,6 +1,7 @@
 """CLI - Validators."""
 
 import base64
+import re
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
@@ -13,6 +14,8 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 BAD_API_HEADERS = ("user-agent", "host")
 API_HEADER_TRANSFORMS = {}
 PUBLIC_API_HOST_SUFFIXES = ("cloudsmith.io", "cloudsmith.com")
+DEFAULT_API_HOST_SCHEME = "https"
+API_HOST_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
 
 
 class IntOrWildcard(click.ParamType):
@@ -84,6 +87,25 @@ def validate_api_headers(param, value):
         headers[k] = v
 
     return headers
+
+
+def normalize_api_host(value):
+    """Normalise a user-supplied API host into a canonical URL.
+
+    Removes surrounding whitespace and trailing slashes. Adds the https
+    scheme when the value does not give one.
+    """
+    if not isinstance(value, str):
+        return value
+
+    host = value.strip()
+    if not host:
+        return host
+
+    if not API_HOST_SCHEME_RE.match(host):
+        host = f"{DEFAULT_API_HOST_SCHEME}://{host.lstrip('/')}"
+
+    return host.rstrip("/")
 
 
 def host_matches_suffixes(url, suffixes):

--- a/cloudsmith_cli/cli/validators.py
+++ b/cloudsmith_cli/cli/validators.py
@@ -93,14 +93,15 @@ def normalize_api_host(value):
     """Normalise a user-supplied API host into a canonical URL.
 
     Removes surrounding whitespace and trailing slashes. Adds the https
-    scheme when the value does not give one.
+    scheme when the value does not give one. Returns None for a blank value,
+    so a blank value does not replace a host that is already set.
     """
     if not isinstance(value, str):
         return value
 
     host = value.strip()
     if not host:
-        return host
+        return None
 
     if not API_HOST_SCHEME_RE.match(host):
         host = f"{DEFAULT_API_HOST_SCHEME}://{host.lstrip('/')}"


### PR DESCRIPTION
# Description

A loosely-written API host used to fail with an error that hid the cause. A value with no scheme aborted before the request. A trailing slash returned a 404 with a hint that blamed the user or org, when only the punctuation was wrong.

Before, against `master`:

```
$ cloudsmith whoami --api-host api.cloudsmith.io
Detail: MissingSchema
Invalid URL 'api.cloudsmith.io/user/self/': No scheme supplied.

$ cloudsmith whoami --api-host https://api.cloudsmith.io/
Failed to retrieve your authentication status! (404 - Not Found)
Hint: This usually means the user/org is wrong or not visible.
```

Both now reach the API and return the real answer.

Normalize the API host so these values work. The CLI adds the https scheme when the value gives none. It also removes surrounding whitespace and trailing slashes. `api.cloudsmith.io`, `//api.cloudsmith.io/` and ` https://api.cloudsmith.io/ ` all resolve to `https://api.cloudsmith.io`.

This applies to `--api-host`, the `CLOUDSMITH_API_HOST` variable and the `api_host` config key.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

