### PR TITLE
perf: keep the SDK and requests out of startup

### DIFF
--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -9,14 +9,12 @@ from click.core import ParameterSource
 
 from cloudsmith_cli.cli import validators
 
-from ..core.api.init import initialise_api as _initialise_api
 from ..core.credentials.chain import CredentialProviderChain
 from ..core.credentials.models import CredentialContext
 from ..core.credentials.oidc.detectors import (
     disabled_detectors_from_env,
     registered_detectors,
 )
-from ..core.rest import create_requests_session as _create_session
 from . import config, utils
 
 
@@ -357,6 +355,10 @@ def initialise_session(f):
     @functools.wraps(f)
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
+        # The session module pulls in requests (~30ms). Import it here so
+        # that commands without a session skip that cost.
+        from ..core.session import create_requests_session as _create_session
+
         opts = config.get_or_create_options(ctx)
         host_suffixes = _parse_suffixes(kwargs.pop("allowed_api_host_suffixes"))
         proxy_suffixes = _parse_suffixes(kwargs.pop("allowed_api_proxy_suffixes"))
@@ -578,6 +580,10 @@ def initialise_api(f):
     @functools.wraps(f)
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
+        # The cloudsmith_api SDK costs ~70ms to import. Import it here so
+        # that only the commands that call the API pay that cost.
+        from ..core.api.init import initialise_api as _initialise_api
+
         opts = config.get_or_create_options(ctx)
         opts.rate_limit = _pop_boolean_flag(kwargs, "without_rate_limit", invert=True)
         opts.rate_limit_warning = kwargs.pop("rate_limit_warning")

--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -355,8 +355,6 @@ def initialise_session(f):
     @functools.wraps(f)
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
-        # The session module pulls in requests (~30ms). Import it here so
-        # that commands without a session skip that cost.
         from ..core.session import create_requests_session as _create_session
 
         opts = config.get_or_create_options(ctx)
@@ -580,8 +578,6 @@ def initialise_api(f):
     @functools.wraps(f)
     def wrapper(ctx, *args, **kwargs):
         # pylint: disable=missing-docstring
-        # The cloudsmith_api SDK costs ~70ms to import. Import it here so
-        # that only the commands that call the API pay that cost.
         from ..core.api.init import initialise_api as _initialise_api
 
         opts = config.get_or_create_options(ctx)

--- a/cloudsmith_cli/cli/tests/test_startup_imports.py
+++ b/cloudsmith_cli/cli/tests/test_startup_imports.py
@@ -9,7 +9,7 @@ import json
 import subprocess
 import sys
 
-HEAVY_PREFIXES = ("mcp", "httpx")
+HEAVY_PREFIXES = ("mcp", "httpx", "cloudsmith_api", "requests")
 
 
 def modules_loaded_by_cli_import():

--- a/cloudsmith_cli/core/api/files.py
+++ b/cloudsmith_cli/core/api/files.py
@@ -8,7 +8,7 @@ import requests
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 from .. import ratelimits
-from ..rest import create_requests_session
+from ..session import create_requests_session
 from ..utils import calculate_file_md5
 from .exceptions import ApiException, catch_raise_api_exception
 from .init import get_api_client

--- a/cloudsmith_cli/core/credentials/models.py
+++ b/cloudsmith_cli/core/credentials/models.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-import requests
+# requests costs ~30ms to import and is only used in annotations here.
+if TYPE_CHECKING:
+    import requests
 
 
 @dataclass

--- a/cloudsmith_cli/core/credentials/models.py
+++ b/cloudsmith_cli/core/credentials/models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-# requests costs ~30ms to import and is only used in annotations here.
 if TYPE_CHECKING:
     import requests
 

--- a/cloudsmith_cli/core/credentials/oidc/detectors/azure_devops.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/azure_devops.py
@@ -45,8 +45,6 @@ class AzureDevOpsDetector(EnvironmentDetector):
         separator = "&" if "?" in request_uri else "?"
         url = f"{request_uri}{separator}api-version={API_VERSION}"
 
-        # The session module pulls in requests (~30ms). Import it here
-        # so that only a detector match pays that cost.
         from ....session import create_requests_session as create_session
 
         session = self.context.session or create_session()

--- a/cloudsmith_cli/core/credentials/oidc/detectors/azure_devops.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/azure_devops.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 
-from ....rest import create_requests_session as create_session
 from .base import EnvironmentDetector
 
 API_VERSION = "7.1"
@@ -45,6 +44,10 @@ class AzureDevOpsDetector(EnvironmentDetector):
         # api-version (HTTP 400), so it must always be supplied.
         separator = "&" if "?" in request_uri else "?"
         url = f"{request_uri}{separator}api-version={API_VERSION}"
+
+        # The session module pulls in requests (~30ms). Import it here
+        # so that only a detector match pays that cost.
+        from ....session import create_requests_session as create_session
 
         session = self.context.session or create_session()
         try:

--- a/cloudsmith_cli/core/credentials/oidc/detectors/github_actions.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/github_actions.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import os
 from urllib.parse import quote
 
-from ....rest import create_requests_session as create_session
 from .base import EnvironmentDetector
 
 DEFAULT_AUDIENCE = "cloudsmith"
@@ -41,6 +40,10 @@ class GitHubActionsDetector(EnvironmentDetector):
         audience = self.context.oidc_audience or DEFAULT_AUDIENCE
         separator = "&" if "?" in request_url else "?"
         url = f"{request_url}{separator}audience={quote(audience, safe='')}"
+
+        # The session module pulls in requests (~30ms). Import it here
+        # so that only a detector match pays that cost.
+        from ....session import create_requests_session as create_session
 
         session = self.context.session or create_session()
         try:

--- a/cloudsmith_cli/core/credentials/oidc/detectors/github_actions.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/github_actions.py
@@ -41,8 +41,6 @@ class GitHubActionsDetector(EnvironmentDetector):
         separator = "&" if "?" in request_url else "?"
         url = f"{request_url}{separator}audience={quote(audience, safe='')}"
 
-        # The session module pulls in requests (~30ms). Import it here
-        # so that only a detector match pays that cost.
         from ....session import create_requests_session as create_session
 
         session = self.context.session or create_session()

--- a/cloudsmith_cli/core/credentials/oidc/exchange.py
+++ b/cloudsmith_cli/core/credentials/oidc/exchange.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import requests
 
-from ...rest import create_requests_session as create_session
+from ...session import create_requests_session as create_session
 
 if TYPE_CHECKING:
     from ... import CredentialContext

--- a/cloudsmith_cli/core/credentials/providers/keyring_provider.py
+++ b/cloudsmith_cli/core/credentials/providers/keyring_provider.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 
-from ....cli.saml import refresh_access_token
 from ....core import keyring
 from ..models import CredentialContext, CredentialResult
 from ..provider import CredentialProvider
@@ -34,6 +33,11 @@ class KeyringProvider(CredentialProvider):
                         "Session unavailable; skipping token refresh, using existing token"
                     )
                 else:
+                    # The saml module pulls in requests and the SDK
+                    # (~100ms). Import it here so that only the
+                    # token-refresh path pays that cost.
+                    from ....cli.saml import refresh_access_token
+
                     refresh_token = keyring.get_refresh_token(api_host)
                     new_access_token, new_refresh_token = refresh_access_token(
                         api_host,

--- a/cloudsmith_cli/core/credentials/providers/keyring_provider.py
+++ b/cloudsmith_cli/core/credentials/providers/keyring_provider.py
@@ -33,9 +33,6 @@ class KeyringProvider(CredentialProvider):
                         "Session unavailable; skipping token refresh, using existing token"
                     )
                 else:
-                    # The saml module pulls in requests and the SDK
-                    # (~100ms). Import it here so that only the
-                    # token-refresh path pays that cost.
                     from ....cli.saml import refresh_access_token
 
                     refresh_token = keyring.get_refresh_token(api_host)

--- a/cloudsmith_cli/core/download.py
+++ b/cloudsmith_cli/core/download.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from . import ratelimits, utils
 from .api.exceptions import catch_raise_api_exception
 from .api.packages import get_packages_api, list_packages
-from .rest import create_requests_session
+from .session import create_requests_session
 
 
 def resolve_auth(

--- a/cloudsmith_cli/core/rest.py
+++ b/cloudsmith_cli/core/rest.py
@@ -4,132 +4,15 @@ import io
 import json
 import logging
 import re
-import time
 from urllib.parse import urlencode
 
 import requests
 import requests.exceptions
-from cloudsmith_api.configuration import Configuration
 from cloudsmith_api.rest import ApiException, RESTClientObject
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from .session import create_requests_session
 
 logger = logging.getLogger(__name__)
-
-
-class RetryWithCallback(Retry):
-    """A urllib3 Retry with a callback on retries."""
-
-    def __init__(self, *args, **kwargs):
-        self.error_retry_cb = kwargs.pop("error_retry_cb", None)
-        super().__init__(*args, **kwargs)
-
-    def new(self, **kw):
-        kw["error_retry_cb"] = self.error_retry_cb
-        return super().new(**kw)
-
-    def sleep_for_retry(self, response=None):
-        retry_after = self.get_retry_after(response)
-        if retry_after:
-            self._sleep_with_callback(retry_after, context="retry-after")
-            return True
-
-        return False
-
-    def _sleep_backoff(self):
-        backoff = self.get_backoff_time()
-        if backoff <= 0:
-            return
-        self._sleep_with_callback(backoff, context="backoff")
-
-    def _sleep_with_callback(self, seconds, context=None):
-        """Sleep, but generate a callback before it."""
-        if self.error_retry_cb and callable(self.error_retry_cb):
-            self.error_retry_cb(seconds, context=context)
-        return time.sleep(seconds)
-
-
-def create_requests_session(
-    retries=None,
-    backoff_factor=None,
-    status_forcelist=None,
-    pools_size=4,
-    maxsize=4,
-    ssl_verify=None,
-    ssl_cert=None,
-    proxy=None,
-    session=None,
-    error_retry_cb=None,
-    respect_retry_after_header=True,
-    user_agent=None,
-    headers=None,
-):
-    """Create a requests session that retries some errors."""
-    # pylint: disable=too-many-branches
-    config = Configuration()
-
-    if retries is None:
-        retry_max = getattr(config, "error_retry_max", None)
-        retries = retry_max if retry_max is not None else 5
-
-    if backoff_factor is None:
-        retry_backoff = getattr(config, "error_retry_backoff", None)
-        backoff_factor = retry_backoff if retry_backoff is not None else 0.23
-
-    if status_forcelist is None:
-        retry_codes = getattr(config, "error_retry_codes", None)
-        status_forcelist = (
-            retry_codes if retry_codes is not None else [500, 502, 503, 504]
-        )
-
-    if ssl_verify is None:
-        ssl_verify = config.verify_ssl
-
-    if ssl_cert is None:
-        if config.cert_file and config.key_file:
-            ssl_cert = (config.cert_file, config.key_file)
-        elif config.cert_file:
-            ssl_cert = config.cert_file
-
-    if proxy is None:
-        proxy = Configuration().proxy
-
-    session = session or requests.Session()
-    session.verify = ssl_verify
-    session.cert = ssl_cert
-
-    if proxy:
-        session.proxies = {"http": proxy, "https": proxy}
-
-    retry = RetryWithCallback(
-        backoff_factor=backoff_factor,
-        connect=retries,
-        allowed_methods=False,
-        read=retries,
-        status_forcelist=tuple(status_forcelist),
-        status=retries,
-        total=retries,
-        error_retry_cb=error_retry_cb,
-        respect_retry_after_header=respect_retry_after_header,
-    )
-
-    adapter = HTTPAdapter(
-        max_retries=retry,
-        pool_connections=pools_size,
-        pool_maxsize=maxsize,
-        pool_block=True,
-    )
-
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-
-    if user_agent:
-        session.headers["User-Agent"] = user_agent
-
-    if headers:
-        session.headers.update(headers)
-
-    return session
 
 
 class RestResponse(io.IOBase):

--- a/cloudsmith_cli/core/session.py
+++ b/cloudsmith_cli/core/session.py
@@ -1,0 +1,139 @@
+"""HTTP session creation with retry support."""
+
+import sys
+import time
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+class RetryWithCallback(Retry):
+    """A urllib3 Retry with a callback on retries."""
+
+    def __init__(self, *args, **kwargs):
+        self.error_retry_cb = kwargs.pop("error_retry_cb", None)
+        super().__init__(*args, **kwargs)
+
+    def new(self, **kw):
+        kw["error_retry_cb"] = self.error_retry_cb
+        return super().new(**kw)
+
+    def sleep_for_retry(self, response=None):
+        retry_after = self.get_retry_after(response)
+        if retry_after:
+            self._sleep_with_callback(retry_after, context="retry-after")
+            return True
+
+        return False
+
+    def _sleep_backoff(self):
+        backoff = self.get_backoff_time()
+        if backoff <= 0:
+            return
+        self._sleep_with_callback(backoff, context="backoff")
+
+    def _sleep_with_callback(self, seconds, context=None):
+        """Sleep, but generate a callback before it."""
+        if self.error_retry_cb and callable(self.error_retry_cb):
+            self.error_retry_cb(seconds, context=context)
+        return time.sleep(seconds)
+
+
+def _sdk_configuration():
+    """Return the SDK configuration defaults, or None when the SDK is not loaded.
+
+    initialise_api() stores the CLI retry/SSL/proxy settings on
+    cloudsmith_api.Configuration via set_default(). When the SDK is not in
+    sys.modules, set_default() cannot have run, so the defaults equal the
+    fallback values in create_requests_session(). Skipping the import in
+    that case keeps the SDK out of commands that never call the API.
+    """
+    if "cloudsmith_api" not in sys.modules:
+        return None
+    from cloudsmith_api.configuration import Configuration
+
+    return Configuration()
+
+
+def create_requests_session(
+    retries=None,
+    backoff_factor=None,
+    status_forcelist=None,
+    pools_size=4,
+    maxsize=4,
+    ssl_verify=None,
+    ssl_cert=None,
+    proxy=None,
+    session=None,
+    error_retry_cb=None,
+    respect_retry_after_header=True,
+    user_agent=None,
+    headers=None,
+):
+    """Create a requests session that retries some errors."""
+    # pylint: disable=too-many-branches
+    config = _sdk_configuration()
+
+    if retries is None:
+        retry_max = getattr(config, "error_retry_max", None)
+        retries = retry_max if retry_max is not None else 5
+
+    if backoff_factor is None:
+        retry_backoff = getattr(config, "error_retry_backoff", None)
+        backoff_factor = retry_backoff if retry_backoff is not None else 0.23
+
+    if status_forcelist is None:
+        retry_codes = getattr(config, "error_retry_codes", None)
+        status_forcelist = (
+            retry_codes if retry_codes is not None else [500, 502, 503, 504]
+        )
+
+    if ssl_verify is None:
+        ssl_verify = config.verify_ssl if config is not None else True
+
+    if ssl_cert is None and config is not None:
+        if config.cert_file and config.key_file:
+            ssl_cert = (config.cert_file, config.key_file)
+        elif config.cert_file:
+            ssl_cert = config.cert_file
+
+    if proxy is None and config is not None:
+        proxy = config.proxy
+
+    session = session or requests.Session()
+    session.verify = ssl_verify
+    session.cert = ssl_cert
+
+    if proxy:
+        session.proxies = {"http": proxy, "https": proxy}
+
+    retry = RetryWithCallback(
+        backoff_factor=backoff_factor,
+        connect=retries,
+        allowed_methods=False,
+        read=retries,
+        status_forcelist=tuple(status_forcelist),
+        status=retries,
+        total=retries,
+        error_retry_cb=error_retry_cb,
+        respect_retry_after_header=respect_retry_after_header,
+    )
+
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=pools_size,
+        pool_maxsize=maxsize,
+        pool_block=True,
+    )
+
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    if user_agent:
+        session.headers["User-Agent"] = user_agent
+
+    if headers:
+        session.headers.update(headers)
+
+    return session

--- a/cloudsmith_cli/core/tests/test_rest.py
+++ b/cloudsmith_cli/core/tests/test_rest.py
@@ -2,7 +2,8 @@ import httpretty
 import pytest
 
 from ..api.init import initialise_api
-from ..rest import RestClient, create_requests_session
+from ..rest import RestClient
+from ..session import create_requests_session
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Description

Keep the `cloudsmith_api` SDK and `requests` out of CLI startup.

After #374, the shared `cli/decorators.py` chain was the last eager cost (145 ms of the remaining 153 ms). It pulled in the full SDK (`cloudsmith_api/__init__` imports every API class and ~200 model modules, ~70 ms) plus `requests` (~30 ms) on every invocation — including `--version` and credential-helper calls that never touch either.

Changes:

- `core/session.py` (new): `create_requests_session` moved out of `core/rest.py`. `core/rest.py` must import the SDK at module level (`RestClient` subclasses the generated `RESTClientObject`), so every importer of `create_requests_session` paid for the SDK. The session module reads the SDK `Configuration` defaults only when `cloudsmith_api` is already in `sys.modules` — `initialise_api()` is the only writer of those defaults (via `set_default()`), and it cannot have run if the SDK is not imported, so the literal fallbacks are exact.
- `cli/decorators.py`: import `core.api.init` inside the `initialise_api` wrapper and `core.session` inside the `initialise_session` wrapper.
- `keyring_provider`: import `cli.saml` (→ `requests` + SDK exceptions) only on the token-refresh path.
- OIDC detectors (`github_actions`, `azure_devops`): import the session module only on a detector match, per the existing lazy-optional-import convention in the detectors.
- `core/credentials/models.py`: `requests` is annotation-only → `TYPE_CHECKING`.

## Results

Measured on macOS (M-series), Python 3.14.7, `PYTHONDONTWRITEBYTECODE=1` (repo `.envrc` default). Baseline column = #374.

| Command | #374 | This PR | Delta |
| --- | --- | --- | --- |
| `cloudsmith --version` | 0.28 s | 0.18 s | **-36%** |
| `credential-helper docker get` | 0.36 s | 0.37 s | ±0 (see note) |
| Total import time (`-X importtime`) | 153 ms | 60 ms | **-61%** |

Note: the credential helper builds a requests session and reads the keyring at run time, so its `requests` import cost moves rather than disappears. It no longer loads the SDK at all (~70 ms saved is offset by run-time `requests`/`keyring` imports that were previously counted at startup). Its remaining wall time is dominated by the macOS keyring backend roundtrip (~0.19 s), a separate follow-up.

Cumulative vs master: `--version` 2.72 s → 0.18 s (**-93%**), `docker get` 2.94 s → 0.37 s (**-87%**).

## Methodology (how to reproduce)

1. Attribute the remaining import time after #374:

   ```sh
   python -X importtime -m cloudsmith_cli --version 2> importtime.txt
   sort -t'|' -k2 -n importtime.txt | tail -40
   ```

2. Walk the parent chain of each heavy module in the importtime tree (indentation = depth, children print before parents). The chains this PR breaks:

   ```
   cloudsmith_api <- core.api.init <- cli.decorators
   requests <- core.credentials.models <- core.credentials.chain <- cli.decorators
   requests <- cli.saml <- keyring_provider <- credentials chain
   requests <- core.session <- oidc.detectors.{github_actions,azure_devops}
   ```

   Note `from cloudsmith_api.rest import ApiException` runs the whole `cloudsmith_api/__init__` (parent packages import first) — importing "just the submodule" does not avoid the cost.

3. Guard against regression: `HEAVY_PREFIXES` in `cli/tests/test_startup_imports.py` now includes `cloudsmith_api` and `requests` (written first; failed with the full SDK loaded).

4. Verify behaviour: full suite (800 passed, 40 skipped) plus a live `cloudsmith whoami` (exercises `initialise_api` → `RestClient` → session defaults with the SDK loaded) and a live `credential-helper docker get`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

## Additional Notes

- `create_requests_session` keeps identical semantics when the SDK is loaded; when it is not, the fallback values it already contained apply.


## Flame graphs

Probe: `cloudsmith --version`. Icicle charts from `python -X importtime`: parents above children, width = cumulative import time. Totals include the interpreter's own `site` imports and vary a few ms between runs.

**Before:**

![before](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_after_pr2.png)

**After:**

![after](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_after_pr3.png)

