### PR TITLE
perf: skip the SDK import on custom-domain cache hits

### DIFF
--- a/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
+++ b/cloudsmith_cli/cli/tests/commands/test_credential_helper_install.py
@@ -810,7 +810,7 @@ def test_refresh_flag(tmp_path, monkeypatch, refresh):
         ]
 
     with patch(
-        "cloudsmith_cli.credential_helpers.custom_domains.list_custom_domains",
+        "cloudsmith_cli.core.api.orgs.list_custom_domains",
         _fake_list,
     ):
         result = get_custom_domains(

--- a/cloudsmith_cli/cli/tests/test_startup_imports.py
+++ b/cloudsmith_cli/cli/tests/test_startup_imports.py
@@ -12,10 +12,10 @@ import sys
 HEAVY_PREFIXES = ("mcp", "httpx", "cloudsmith_api", "requests")
 
 
-def modules_loaded_by_cli_import():
+def modules_loaded_by_import(module_name="cloudsmith_cli.cli.commands.main"):
     code = (
         "import json, sys\n"
-        "import cloudsmith_cli.cli.commands.main\n"
+        f"import {module_name}\n"
         "print(json.dumps(sorted(sys.modules)))\n"
     )
     result = subprocess.run(
@@ -27,14 +27,16 @@ def modules_loaded_by_cli_import():
     return json.loads(result.stdout)
 
 
-def test_cli_import_does_not_load_heavy_modules():
-    modules = modules_loaded_by_cli_import()
-    heavy = [
+def heavy_modules_in(modules):
+    return [
         name
         for name in modules
         if any(name == p or name.startswith(p + ".") for p in HEAVY_PREFIXES)
     ]
-    assert heavy == []
+
+
+def test_cli_import_does_not_load_heavy_modules():
+    assert heavy_modules_in(modules_loaded_by_import()) == []
 
 
 def test_cli_import_does_not_load_command_modules():
@@ -42,7 +44,12 @@ def test_cli_import_does_not_load_command_modules():
     allowed = {package + "main", package + "registry"}
     loaded = [
         name
-        for name in modules_loaded_by_cli_import()
+        for name in modules_loaded_by_import()
         if name.startswith(package) and name not in allowed
     ]
     assert loaded == []
+
+
+def test_docker_helper_import_does_not_load_heavy_modules():
+    modules = modules_loaded_by_import("cloudsmith_cli.credential_helpers.docker")
+    assert heavy_modules_in(modules) == []

--- a/cloudsmith_cli/credential_helpers/custom_domains.py
+++ b/cloudsmith_cli/credential_helpers/custom_domains.py
@@ -19,9 +19,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..cli.config import get_default_config_path
-from ..core.api.exceptions import ApiException
-from ..core.api.init import initialise_api
-from ..core.api.orgs import list_custom_domains
 from ..core.cache_utils import atomic_write_json
 from ..core.credentials.models import CredentialResult
 from .default_domains import DomainType, domain_type_from_server
@@ -304,6 +301,12 @@ def get_custom_domains(
         return cached
 
     logger.debug("Fetching custom domains from API for %s", org)
+
+    # The API modules pull in the cloudsmith_api SDK (~70ms). Import them
+    # here so that a cache hit skips that cost.
+    from ..core.api.exceptions import ApiException
+    from ..core.api.init import initialise_api
+    from ..core.api.orgs import list_custom_domains
 
     if configure_api:
         initialise_api(host=api_host, credential=credential)

--- a/cloudsmith_cli/credential_helpers/custom_domains.py
+++ b/cloudsmith_cli/credential_helpers/custom_domains.py
@@ -302,8 +302,6 @@ def get_custom_domains(
 
     logger.debug("Fetching custom domains from API for %s", org)
 
-    # The API modules pull in the cloudsmith_api SDK (~70ms). Import them
-    # here so that a cache hit skips that cost.
     from ..core.api.exceptions import ApiException
     from ..core.api.init import initialise_api
     from ..core.api.orgs import list_custom_domains


### PR DESCRIPTION
# Description

Skip the `cloudsmith_api` SDK import when the custom-domains cache is warm.

`credential_helpers/custom_domains.py` imported `core.api.exceptions`, `core.api.init` and `core.api.orgs` at module level, which loads the full SDK. The docker/pnpm helpers import this module on every invocation, but the SDK is only needed on a custom-domains cache miss — at most once every 7 days per org. Move the three imports after the cache check.

## Results

Measured on macOS (M-series), Python 3.14.7, `PYTHONDONTWRITEBYTECODE=1` (repo `.envrc` default). Baseline column = #375.

| Command | #375 | This PR | Delta |
| --- | --- | --- | --- |
| `credential-helper docker get` (warm cache) | 0.37 s | 0.30 s | **-19%** |

Cumulative vs master: 2.94 s → 0.30 s (**-90%**).

## Methodology (how to reproduce)

1. After #375, startup imports are clean, so profile the **run** phase in-process:

   ```python
   import cProfile, pstats, sys
   from cloudsmith_cli.cli.commands.main import main
   pr = cProfile.Profile(); pr.enable()
   main(args=["credential-helper", "docker", "get"], standalone_mode=False)
   pr.disable()
   pstats.Stats(pr, stream=sys.stderr).sort_stats("cumulative").print_stats(20)
   ```

   (Pipe `docker.cloudsmith.io` to stdin.) Top cost: `credential_helpers/custom_domains.py` module import at **141 ms** — the deferred-until-runtime SDK chain from #375 resurfacing through this module. Second: the keyring backend detection at ~76 ms (see Additional Notes).

2. Everything the three imports serve sits below the cache-hit early return in `get_custom_domains()`, so deferring them changes no behaviour on any path.

3. Regression guard: `test_startup_imports.py` now also probes `import cloudsmith_cli.credential_helpers.docker` in a subprocess and asserts no `cloudsmith_api`/`requests`/`mcp`/`httpx` module loads (written first, failed with the SDK loaded).

4. `test_credential_helper_install.py` patched `custom_domains.list_custom_domains`; the name no longer exists at module scope, so the patch target moves to the defining module `core.api.orgs` (the call-time import resolves through it).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

## Flame graphs

Probe: `import cloudsmith_cli.cli.commands.credential_helper` (what a docker helper invocation imports at run time). Icicle charts from `python -X importtime`: parents above children, width = cumulative import time. Totals include the interpreter's own `site` imports and vary a few ms between runs.

**Before:**

![before](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_helper_before_pr4.png)

**After:**

![after](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_helper_after_pr4.png)

