### PR TITLE
perf: defer the rich, urllib3 and semver imports

### DIFF
--- a/cloudsmith_cli/__init__.py
+++ b/cloudsmith_cli/__init__.py
@@ -3,8 +3,6 @@
 import warnings
 
 import click
-import urllib3
 
 click.disable_unicode_literals_warning = True
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)

--- a/cloudsmith_cli/cli/tests/test_startup_imports.py
+++ b/cloudsmith_cli/cli/tests/test_startup_imports.py
@@ -9,7 +9,15 @@ import json
 import subprocess
 import sys
 
-HEAVY_PREFIXES = ("mcp", "httpx", "cloudsmith_api", "requests")
+HEAVY_PREFIXES = (
+    "mcp",
+    "httpx",
+    "cloudsmith_api",
+    "requests",
+    "rich",
+    "urllib3",
+    "semver",
+)
 
 
 def modules_loaded_by_import(module_name="cloudsmith_cli.cli.commands.main"):

--- a/cloudsmith_cli/cli/utils.py
+++ b/cloudsmith_cli/cli/utils.py
@@ -72,8 +72,6 @@ def pretty_print_table(headers, rows, title=None):
 
 def rich_print_table(headers, rows, title=None, show_lines=False):
     """Rich table from headers and rows."""
-    # rich costs ~35ms to import. Import it here so that only the
-    # commands that render a rich table pay that cost.
     from rich.console import Console
     from rich.table import Table
 

--- a/cloudsmith_cli/cli/utils.py
+++ b/cloudsmith_cli/cli/utils.py
@@ -7,8 +7,6 @@ from datetime import date, datetime
 
 import click
 from click_spinner import spinner
-from rich.console import Console
-from rich.table import Table
 
 from ..core.api.version import get_version as get_api_version
 from ..core.version import get_version as get_cli_version
@@ -74,6 +72,11 @@ def pretty_print_table(headers, rows, title=None):
 
 def rich_print_table(headers, rows, title=None, show_lines=False):
     """Rich table from headers and rows."""
+    # rich costs ~35ms to import. Import it here so that only the
+    # commands that render a rich table pay that cost.
+    from rich.console import Console
+    from rich.table import Table
+
     console = Console()
     table = Table(title=title, show_lines=show_lines)
 

--- a/cloudsmith_cli/core/api/version.py
+++ b/cloudsmith_cli/core/api/version.py
@@ -2,8 +2,6 @@
 
 import importlib.metadata
 
-import semver
-
 
 def get_version():
     """Get the raw/unparsed version of the API as a string."""
@@ -12,4 +10,7 @@ def get_version():
 
 def get_version_info():
     """Get the API version as VersionInfo object."""
+    # semver costs ~6ms to import and only version comparisons need it.
+    import semver
+
     return semver.parse_version_info(get_version())

--- a/cloudsmith_cli/core/api/version.py
+++ b/cloudsmith_cli/core/api/version.py
@@ -10,7 +10,6 @@ def get_version():
 
 def get_version_info():
     """Get the API version as VersionInfo object."""
-    # semver costs ~6ms to import and only version comparisons need it.
     import semver
 
     return semver.parse_version_info(get_version())

--- a/cloudsmith_cli/core/session.py
+++ b/cloudsmith_cli/core/session.py
@@ -4,8 +4,14 @@ import sys
 import time
 
 import requests
+import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+# Every insecure request (-S/--without-api-ssl-verify) flows through a
+# session from this module, so the warning filter applies here instead of
+# the package __init__, which must stay free of the urllib3 import.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class RetryWithCallback(Retry):

--- a/cloudsmith_cli/core/session.py
+++ b/cloudsmith_cli/core/session.py
@@ -8,9 +8,6 @@ import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-# Every insecure request (-S/--without-api-ssl-verify) flows through a
-# session from this module, so the warning filter applies here instead of
-# the package __init__, which must stay free of the urllib3 import.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 

--- a/cloudsmith_cli/core/version.py
+++ b/cloudsmith_cli/core/version.py
@@ -15,7 +15,6 @@ def get_version_info():
 
 def parse_version(version):
     """Get a version string as a VersionInfo object."""
-    # semver costs ~6ms to import and only version comparisons need it.
     import semver
 
     return semver.parse_version_info(version)

--- a/cloudsmith_cli/core/version.py
+++ b/cloudsmith_cli/core/version.py
@@ -1,7 +1,5 @@
 """Core version utilities."""
 
-import semver
-
 from . import utils
 
 
@@ -17,4 +15,7 @@ def get_version_info():
 
 def parse_version(version):
     """Get a version string as a VersionInfo object."""
+    # semver costs ~6ms to import and only version comparisons need it.
+    import semver
+
     return semver.parse_version_info(version)


### PR DESCRIPTION
# Description

Defer the last eager imports: `rich`, `urllib3` and `semver`.

- `cli/utils.py` imported `rich.console`/`rich.table` (~35 ms) at module level; only `rich_print_table` uses them.
- `cloudsmith_cli/__init__.py` imported `urllib3` (~20 ms with its `http.client` chain) only to install the `InsecureRequestWarning` filter. The filter moves to `core/session.py`: every insecure request (`-S/--without-api-ssl-verify`) flows through a session from that module, so the filter is installed before any request can warn.
- `core/version.py` and `core/api/version.py` imported `semver` (~6 ms) at module level; only the version parsers use it.

## Results

Measured on macOS (M-series), Python 3.14.7, `PYTHONDONTWRITEBYTECODE=1` (repo `.envrc` default). Baseline column = #376.

| Command | #376 | This PR | Delta |
| --- | --- | --- | --- |
| `cloudsmith --version` | 0.18 s | 0.12 s | **-33%** |
| `credential-helper docker get` | 0.30 s | 0.25 s | **-17%** |
| Total import time (`-X importtime`) | 60 ms | 22 ms of CLI code (88 ms incl. interpreter `site`) | — |

## Series summary (vs master)

| Command | master | after this stack | Delta |
| --- | --- | --- | --- |
| `cloudsmith --version` | 2.72 s | 0.12 s | **-96%** |
| `credential-helper docker get` | 2.94 s | 0.25 s | **-91%** |
| Import time (`-X importtime` total) | 2548 ms | 88 ms | **-97%** |

With warm bytecode caches (end-user installs; the dev `.envrc` sets `PYTHONDONTWRITEBYTECODE=1` which roughly triples the numbers): docker helper 0.80 s → ~0.10 s.

## Methodology (how to reproduce)

1. `python -X importtime -m cloudsmith_cli --version 2>&1 | sort -t'|' -k2 -n | tail -25` after #376 showed three chains left: `rich.console <- cli.utils <- cli.config <- decorators`, `urllib3 <- cloudsmith_cli` (package `__init__`), and `semver <- core.api.version <- commands.main`.
2. Confirm each name is unused at module scope (`rg` for call sites), then defer.
3. Regression guard: `HEAVY_PREFIXES` in `cli/tests/test_startup_imports.py` now includes `rich`, `urllib3` and `semver`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

## Additional Notes

- Warning-filter timing is preserved: `urllib3.disable_warnings` now runs when `core/session.py` is imported, which happens before any session (and therefore any insecure request) exists.




## Flame graphs

Probe: `cloudsmith --version`. Icicle charts from `python -X importtime`: parents above children, width = cumulative import time. Totals include the interpreter's own `site` imports and vary a few ms between runs.

**Before:**

![before](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_after_pr4.png)

**After:**

![after](https://raw.githubusercontent.com/cloudsmith-io/cloudsmith-cli/7b6a47f84134d7230dac532d8e6587973efe3cc6/flame_after_pr5.png)

