### PR TITLE
chore: enforce type-checking-only imports with ruff

### DIFF
--- a/cloudsmith_cli/core/cache_utils.py
+++ b/cloudsmith_cli/core/cache_utils.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _atomic_write_text(dest: str, text: str, *, mode: int = 0o600) -> None:

--- a/cloudsmith_cli/core/credentials/chain.py
+++ b/cloudsmith_cli/core/credentials/chain.py
@@ -7,9 +7,8 @@ credential sources sequentially and returns the first valid result.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
-from .models import CredentialContext, CredentialResult
-from .provider import CredentialProvider
 from .providers import (
     CLIFlagProvider,
     CredentialsFileProvider,
@@ -17,6 +16,10 @@ from .providers import (
     KeyringProvider,
     OidcProvider,
 )
+
+if TYPE_CHECKING:
+    from .models import CredentialContext, CredentialResult
+    from .provider import CredentialProvider
 
 logger = logging.getLogger(__name__)
 

--- a/cloudsmith_cli/core/credentials/oidc/detectors/__init__.py
+++ b/cloudsmith_cli/core/credentials/oidc/detectors/__init__.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from .aws import AWSDetector
 from .azure_devops import AzureDevOpsDetector
-from .base import EnvironmentDetector
 from .bitbucket_pipelines import BitbucketPipelinesDetector
 from .circleci import CircleCIDetector
 from .generic import GenericDetector
@@ -18,6 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from ... import CredentialContext
+    from .base import EnvironmentDetector
 
 logger = logging.getLogger(__name__)
 

--- a/cloudsmith_cli/core/credentials/provider.py
+++ b/cloudsmith_cli/core/credentials/provider.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from .models import CredentialContext, CredentialResult
+if TYPE_CHECKING:
+    from .models import CredentialContext, CredentialResult
 
 
 class CredentialProvider(ABC):

--- a/cloudsmith_cli/credential_helpers/docker/installer.py
+++ b/cloudsmith_cli/credential_helpers/docker/installer.py
@@ -13,12 +13,15 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ...core.cache_utils import merge_json_file
-from ...core.credentials.models import CredentialResult
 from ..backends import BackendKind
 from ..custom_domains import get_format_domains
 from ..launchers import is_on_path, remove_launcher, resolve_bin_dir, write_launcher
+
+if TYPE_CHECKING:
+    from ...core.credentials.models import CredentialResult
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ show_missing = true
 directory = "reports/coverage"
 
 [tool.ruff.lint]
+extend-select = ["FA", "TC"]
 ignore = ["TRY002", "BLE001"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
# Description

The perf work in this stack moved a lot of imports into `if TYPE_CHECKING:` blocks by hand — imports that are only needed for type annotations don't have to be paid for at runtime. This makes that a rule so it can't quietly regress.

Two ruff rule groups are now enabled:

- [flake8-type-checking (`TC`)](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) — if an import is only used in type annotations, it has to live in an `if TYPE_CHECKING:` block, which means the interpreter never actually imports it
- [flake8-future-annotations (`FA`)](https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa) — makes sure `from __future__ import annotations` is present where it's needed, so the moved imports stay safe without quoting every annotation

There's nothing to set up: the pre-commit ruff hook picks the rules up from `pyproject.toml`, and CI runs pre-commit, so both enforce it.

Turning the rules on found 8 leftover typing-only imports across 5 files, all moved in this PR. The only one that needed real thought was `EnvironmentDetector` in the OIDC detectors package `__init__` — moving it would break anything importing it from the package, but it turns out every subclass and test already imports it from `.base` directly, so the package-level name was dead weight.

This mirrors how the main `cloudsmith` repo configures ruff (it selects the same two groups). Its stdlib-`json`-to-`orjson` ban wasn't carried over: that's a binary dependency to speed up JSON payloads that are tiny here, and imports — not parsing — were the CLI's actual bottleneck.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

Lint enforcement; no behaviour change.

## Additional Notes

- Files that don't have `from __future__ import annotations` yet (e.g. `core/mcp/server.py`) are left alone — ruff only offers the move where it's provably safe, which is exactly what we want from a guard.
- The existing pre-commit excludes for the test directories still apply.
- Full suite passes (801 passed, 40 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
