### PR TITLE
chore: ban module-level imports of startup-heavy modules

### DIFF
--- a/cloudsmith_cli/core/keyring.py
+++ b/cloudsmith_cli/core/keyring.py
@@ -2,9 +2,6 @@ import getpass
 import os
 from datetime import datetime, timedelta, timezone
 
-import keyring
-from keyring.errors import KeyringError
-
 ACCESS_TOKEN_KEY = "cloudsmith_cli-access_token-{api_host}"
 
 
@@ -81,6 +78,8 @@ def _prepare_keyring_backend():
     them through the library's own documented mechanism. Apply them here
     instead, once the backend has been resolved.
     """
+    import keyring
+
     _sync_keyring_backend_env()
     _sync_keyring_property_env()
     _sync_keyring_file_path_env()
@@ -90,6 +89,9 @@ def _prepare_keyring_backend():
 
 
 def _get_value(key):
+    import keyring
+    from keyring.errors import KeyringError
+
     _prepare_keyring_backend()
     username = _get_username()
     try:
@@ -99,6 +101,8 @@ def _get_value(key):
 
 
 def _set_value(key, value):
+    import keyring
+
     _prepare_keyring_backend()
     username = _get_username()
     keyring.set_password(key, username, value)
@@ -179,6 +183,9 @@ def store_sso_tokens(api_host, access_token, refresh_token):
 
 
 def _delete_value(key):
+    import keyring
+    from keyring.errors import KeyringError
+
     _prepare_keyring_backend()
     username = _get_username()
     try:
@@ -215,6 +222,8 @@ OIDC_TOKEN_KEY = "cloudsmith_cli-oidc_token-{api_host}-{org}-{service_slug}"
 
 def store_oidc_token(api_host, org, service_slug, token_data):
     """Store OIDC token in keyring if enabled."""
+    from keyring.errors import KeyringError
+
     if not should_use_keyring():
         return False
 

--- a/packaging/pyinstaller/entry.py
+++ b/packaging/pyinstaller/entry.py
@@ -4,8 +4,6 @@ import os
 import pkgutil
 import sys
 
-import keyring.backend
-
 import cloudsmith_cli
 from cloudsmith_cli.cli.commands.main import main
 
@@ -39,6 +37,8 @@ def _check_extra_keyring_backends(failed: list) -> None:
     absent from discovery rather than raising, so this checks the discovered
     class list explicitly instead of relying on an import error.
     """
+    import keyring.backend
+
     discovered = [type(b).__module__ for b in keyring.backend.get_all_keyring()]
     for module_prefix in ("keyrings.cryptfile", "keyrings.alt"):
         if not any(name.startswith(module_prefix) for name in discovered):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,35 @@ show_missing = true
 directory = "reports/coverage"
 
 [tool.ruff.lint]
-extend-select = ["FA", "TC"]
+extend-select = ["FA", "TC", "TID253"]
 ignore = ["TRY002", "BLE001"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# These modules dominate CLI startup time. Import them inside functions,
+# or add the file to the allowlist below when a module is itself loaded
+# lazily (see cli/commands/registry.py and cli/tests/test_startup_imports.py).
+banned-module-level-imports = [
+    "cloudsmith_api",
+    "httpx",
+    "keyring",
+    "mcp",
+    "requests",
+    "rich",
+    "semver",
+    "urllib3",
+]
 
 [tool.ruff.lint.per-file-ignores]
 '__init__.py' = ["F401"]
+# Lazy leaves: modules that are only imported when their command or code
+# path runs, so module-level imports of heavy modules are free at startup.
+'cloudsmith_cli/cli/commands/*' = ["TID253"]
+'cloudsmith_cli/cli/saml.py' = ["TID253"]
+'cloudsmith_cli/conftest.py' = ["TID253"]
+'cloudsmith_cli/core/api/*' = ["TID253"]
+'cloudsmith_cli/core/credentials/oidc/exchange.py' = ["TID253"]
+'cloudsmith_cli/core/download.py' = ["TID253"]
+'cloudsmith_cli/core/keyring.py' = ["TID253"]
+'cloudsmith_cli/core/mcp/*' = ["TID253"]
+'cloudsmith_cli/core/rest.py' = ["TID253"]
+'cloudsmith_cli/core/session.py' = ["TID253"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ banned-module-level-imports = [
 'cloudsmith_cli/core/api/*' = ["TID253"]
 'cloudsmith_cli/core/credentials/oidc/exchange.py' = ["TID253"]
 'cloudsmith_cli/core/download.py' = ["TID253"]
-'cloudsmith_cli/core/keyring.py' = ["TID253"]
 'cloudsmith_cli/core/mcp/*' = ["TID253"]
 'cloudsmith_cli/core/rest.py' = ["TID253"]
 'cloudsmith_cli/core/session.py' = ["TID253"]


### PR DESCRIPTION
# Description

The perf work in this stack got `mcp`, `httpx`, `cloudsmith_api`, `requests`, `rich`, `semver`, `urllib3` and `keyring` out of CLI startup. The startup tests guard the two main entry points, but someone could still add `import requests` to the top of any other eagerly-imported file and quietly hand every `docker pull` its ~30ms back.

This closes that gap with ruff's [banned-module-level-import rule (`TID253`)](https://docs.astral.sh/ruff/rules/banned-module-level-import/): the eight modules above can now only be imported inside functions. Files that are themselves loaded lazily — the command modules, the `core/api/*` call sites, the MCP server, and the session/rest/saml/download leaves — are allowlisted per file, so their existing top-level imports stay put. Anything new fails lint, in pre-commit and CI, via the existing ruff hook.

Turning the rule on immediately found two real problems:

1. The PyInstaller entrypoint (`packaging/pyinstaller/entry.py`) imported `keyring.backend` at module level, but only the packaging selftest uses it — every invocation of the frozen binary paid for an import it didn't need. It now lives inside the selftest helper. (Frozen imports are pre-compiled, so this one is below measurement noise — the binary clocks 0.26s before and after. Fixed because the rule is right, not because it's measurable.)
2. `core/keyring.py` imported the `keyring` library at module level, and that file *is* on the eager path (it's pulled in through the credential chain). My first instinct was to allowlist it; on review that was just papering over a real cost. The library is only used inside five functions, so the imports moved there — and `cloudsmith --version` dropped from 0.12s to 0.09s.

No flame graphs on this one — the only import-graph change is the small keyring subtree, and the numbers above tell the story. The real value is that the next accidental heavy import gets caught by the linter instead of a profiler.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

Lint guard for startup performance, plus the two import deferrals it flagged.

## Additional Notes

- Known hole: the allowlist covers `cli/commands/*` as a directory, which also exempts the eagerly-imported `main.py` and `registry.py`. The subprocess tests in `cli/tests/test_startup_imports.py` cover exactly that hole.
- The frozen binary was rebuilt and its packaging selftest passes (`SELFTEST: OK`, 129 modules).
- Full suite passes (801 passed, 40 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
