### PR TITLE
fix: show pagination info in ents list output

### DIFF
--- a/cloudsmith_cli/cli/commands/entitlements.py
+++ b/cloudsmith_cli/cli/commands/entitlements.py
@@ -115,7 +115,9 @@ def list_entitlements(ctx, opts, owner_repo, page, page_size, show_tokens, page_
 
     click.secho("OK", fg="green", err=use_stderr)
 
-    print_entitlements(opts=opts, data=entitlements_, page_info=page_info)
+    print_entitlements(
+        opts=opts, data=entitlements_, page_info=page_info, page_all=page_all
+    )
 
 
 @entitlements.command(name="list", aliases=["ls"])
@@ -126,7 +128,7 @@ def list_(*args, **kwargs):  # pylint: disable=missing-docstring
     return list_entitlements(*args, **kwargs)
 
 
-def print_entitlements(opts, data, page_info=None, show_list_info=True):
+def print_entitlements(opts, data, page_info=None, show_list_info=True, page_all=False):
     """Print entitlements as a table or output in another format."""
     if utils.maybe_print_as_json(opts, data, page_info):
         return
@@ -163,11 +165,16 @@ def print_entitlements(opts, data, page_info=None, show_list_info=True):
 
     num_results = len(data)
     list_suffix = "entitlement%s" % ("s" if num_results != 1 else "")
-    utils.pretty_print_list_info(num_results=num_results, suffix=list_suffix)
+    utils.pretty_print_list_info(
+        num_results=num_results,
+        page_info=None if page_all else page_info,
+        suffix=f"{list_suffix} retrieved" if page_all else f"{list_suffix} visible",
+        page_all=page_all,
+    )
 
 
 def print_entitlements_with_restrictions(
-    opts, data, page_info=None, show_list_info=True
+    opts, data, page_info=None, show_list_info=True, page_all=False
 ):
     # pylint: disable=too-many-locals
     """Print entitlements (with restrictions) as a table or output in another format."""
@@ -276,7 +283,12 @@ def print_entitlements_with_restrictions(
 
     num_results = len(data)
     list_suffix = "entitlement%s" % ("s" if num_results != 1 else "")
-    utils.pretty_print_list_info(num_results=num_results, suffix=list_suffix)
+    utils.pretty_print_list_info(
+        num_results=num_results,
+        page_info=None if page_all else page_info,
+        suffix=f"{list_suffix} retrieved" if page_all else f"{list_suffix} visible",
+        page_all=page_all,
+    )
 
 
 @entitlements.command(aliases=["new"])

--- a/cloudsmith_cli/cli/tests/commands/test_entitlements.py
+++ b/cloudsmith_cli/cli/tests/commands/test_entitlements.py
@@ -1,6 +1,9 @@
 import pytest
 
+from ....core.pagination import PageInfo
 from ...commands.entitlements import list_ as list_entitlements
+from ...commands.entitlements import print_entitlements
+from ...config import Options
 
 
 @pytest.mark.usefixtures("set_api_key_env_var", "set_api_host_env_var")
@@ -18,3 +21,53 @@ def test_entitlements_list_with_show_all(runner, organization, tmp_repository):
     assert "Getting list of entitlements" in result.output
     assert "OK" in result.output
     assert "Invalid value for '--show-all'" not in result.output
+
+
+def _make_entitlement(name):
+    return {
+        "name": name,
+        "user": None,
+        "token": "abc123",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+        "slug_perm": "slugperm",
+    }
+
+
+def _make_page_info(count, page, page_size, page_total):
+    page_info = PageInfo()
+    page_info.count = count
+    page_info.page = page
+    page_info.page_size = page_size
+    page_info.page_total = page_total
+    return page_info
+
+
+def test_print_entitlements_includes_pagination_info(capsys):
+    """Paged output includes the range/page details like other list commands."""
+    opts = Options()
+    opts.output = "pretty"
+    data = [_make_entitlement(f"token-{i}") for i in range(30)]
+    page_info = _make_page_info(count=120, page=1, page_size=30, page_total=4)
+
+    print_entitlements(opts=opts, data=data, page_info=page_info)
+
+    output = capsys.readouterr().out
+    assert (
+        "Results: 1-30 (30) of 120 entitlements visible "
+        "(page: 1/4, page size: 30)" in output
+    )
+
+
+def test_print_entitlements_page_all_shows_retrieved_total(capsys):
+    """--page-all output reports the retrieved total instead of page details."""
+    opts = Options()
+    opts.output = "pretty"
+    data = [_make_entitlement(f"token-{i}") for i in range(120)]
+    page_info = _make_page_info(count=120, page=1, page_size=500, page_total=1)
+
+    print_entitlements(opts=opts, data=data, page_info=page_info, page_all=True)
+
+    output = capsys.readouterr().out
+    assert "Results: 120 entitlements retrieved" in output
+    assert "page size" not in output


### PR DESCRIPTION
# Description

`cloudsmith ents list` accepted `--page-all` but never showed pagination info. Similar implementation as in `cloudsmith repos get` 

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

<!-- Any additional context or screenshots -->
