### PR TITLE
fix: write retry messages to stderr

### DIFF
--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -22,9 +22,10 @@ from . import config, utils
 
 def report_retry(seconds, context=None):
     if context == "retry-after":
-        click.echo()
+        click.echo(err=True)
         click.echo(
-            f"Request was throttled (429): Retrying after {click.style(str(seconds), bold=True)} second(s) ... "
+            f"Request was throttled (429): Retrying after {click.style(str(seconds), bold=True)} second(s) ... ",
+            err=True,
         )
 
 

--- a/cloudsmith_cli/cli/tests/test_decorators.py
+++ b/cloudsmith_cli/cli/tests/test_decorators.py
@@ -1,0 +1,16 @@
+import click
+import click.testing
+
+from ..decorators import report_retry
+
+
+def test_report_retry_writes_to_stderr():
+    @click.command()
+    def command():
+        click.echo('{"data": []}')
+        report_retry(30, context="retry-after")
+
+    result = click.testing.CliRunner().invoke(command, catch_exceptions=False)
+
+    assert result.stdout == '{"data": []}\n'
+    assert "Request was throttled (429)" in result.stderr


### PR DESCRIPTION
## Summary

- write throttling retry notices to stderr
- keep stdout clean for machine-readable output
- add a regression test

## Testing

- `pytest -q cloudsmith_cli/cli/tests/test_decorators.py`