### PR TITLE
chore(no-ticket): refine ty config to not display all diagnostics

### DIFF
--- a/.github/workflows/ty-check.yml
+++ b/.github/workflows/ty-check.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --locked --group dev
-      - run: uv run ty check --warn all --output-format=github --exit-zero-on-warning
+      - run: uv run ty check --output-format=github --exit-zero


### PR DESCRIPTION

In a previous change, ty was firing warnings for every diagnostic available. To increase
the signal/noise ratio, the github action will be updated to produce errors on
default diagnostics, and exit on zero. This pipeline is still non-blocking
