### PR TITLE
fix: totp not hidden for 2fa

### DIFF
--- a/cloudsmith_cli/cli/tests/test_webserver.py
+++ b/cloudsmith_cli/cli/tests/test_webserver.py
@@ -378,6 +378,19 @@ class TestAuthenticationWebRequestHandlerTwoFactor:
                 == "access_token_123"
             )
 
+    def test_2fa_prompt_is_not_hidden(self, two_factor_handler):
+        """Verify the 2FA code is echoed (not hidden) so users can see typos."""
+        with self._patched(
+            two_factor_handler,
+            exchange_side_effect=[("access_token_123", "refresh_token_123")],
+            prompt_side_effect=["123456"],
+        ) as manager:
+            two_factor_handler.do_GET()
+
+            assert manager.prompt.call_count == 1
+            _, kwargs = manager.prompt.call_args
+            assert kwargs.get("hide_input", False) is False
+
     def test_user_can_abort_the_prompt(self, two_factor_handler):
         """Verify Ctrl-C at the prompt ends the command."""
         with self._patched(

--- a/cloudsmith_cli/cli/webserver.py
+++ b/cloudsmith_cli/cli/webserver.py
@@ -161,9 +161,7 @@ class AuthenticationWebRequestHandler(BaseHTTPRequestHandler):
         click.echo("Press Ctrl-C to give up.", err=True)
 
         while True:
-            totp_token = click.prompt(
-                "Please enter your 2FA code", hide_input=True, type=str, err=True
-            )
+            totp_token = click.prompt("Please enter your 2FA code", type=str, err=True)
 
             try:
                 return exchange_2fa_token(


### PR DESCRIPTION
# Description

TOTPs are safe to print, so give that feedback to the user as typing random numeric characters blind is more error prone than known alpha characters.

<img width="257" height="45" alt="image" src="https://github.com/user-attachments/assets/b26860dc-32f9-43c8-9276-3c6e307bb4bf" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

<!-- Any additional context or screenshots -->
