### PR TITLE
Remove deprecated auth token option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `cloudsmith domains list` now includes the Workspace slug in a `workspace` field.
-- Removed `cloudsmith auth --token`; use `--request-api-key` instead.
+- Removed `cloudsmith auth --token` and `--force`; use `--request-api-key` instead.
 
 ## [1.26.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `cloudsmith domains list` now includes the Workspace slug in a `workspace` field.
-- Removed `cloudsmith auth --token` and `--force`; use `--request-api-key` instead.
+- Removed `cloudsmith auth --token`; use `--request-api-key` instead.
 
 ## [1.26.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `cloudsmith domains list` now includes the Workspace slug in a `workspace` field.
+- Removed `cloudsmith auth --token`; use `--request-api-key` instead.
 
 ## [1.26.0] - 2026-08-26
 

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -9,7 +9,7 @@ from ..exceptions import handle_api_exceptions
 from ..saml import create_configured_session, get_idp_url
 from ..webserver import AuthenticationWebRequestHandler, AuthenticationWebServer
 from .main import main
-from .tokens import create, request_api_key
+from .tokens import request_api_key
 
 # Authentication server configuration
 AUTH_SERVER_HOST = "127.0.0.1"
@@ -76,13 +76,6 @@ def _perform_saml_authentication(
 
 @main.command(aliases=["auth"])
 @click.option(
-    "-t",
-    "--token",
-    default=False,
-    is_flag=True,
-    help="[DEPRECATED: Use --request-api-key] Retrieve a user API token after successful authentication.",
-)
-@click.option(
     "-f",
     "--force",
     default=False,
@@ -123,7 +116,6 @@ def _perform_saml_authentication(
 def authenticate(
     ctx,
     opts,
-    token,
     force,
     save_config,
     json,
@@ -132,22 +124,14 @@ def authenticate(
 ):
     """Authenticate to Cloudsmith using the Workspace's SAML setup."""
     # Validate mutual exclusivity
-    if request_api_key_flag and (token or force):
+    if request_api_key_flag and force:
         raise click.UsageError(
-            "--request-api-key cannot be used with --token or --force. "
+            "--request-api-key cannot be used with --force. "
             "Use --request-api-key alone for fully automated token retrieval."
         )
 
     # Determine if we should redirect info messages to stderr
     use_stderr = request_api_key_flag or json or utils.should_use_stderr(opts)
-
-    if token:
-        click.secho(
-            "DEPRECATION WARNING: The `--token` flag is deprecated and will be removed in a future release. "
-            "Please use `--request-api-key` instead.",
-            fg="yellow",
-            err=True,
-        )
 
     if force:
         click.secho(
@@ -175,15 +159,12 @@ def authenticate(
         err=use_stderr,
     )
 
-    # Determine if we need to refresh API after SSO (required for token operations)
-    enable_token_creation = token or request_api_key_flag
-
     context_message = "Failed to authenticate via SSO!"
     with handle_api_exceptions(ctx, opts=opts, context_msg=context_message):
         _perform_saml_authentication(
             opts,
             workspace,
-            enable_token_creation=enable_token_creation,
+            enable_token_creation=request_api_key_flag,
             use_stderr=use_stderr,
             no_browser=no_browser,
             profile=ctx.meta.get("profile"),
@@ -204,7 +185,3 @@ def authenticate(
 
         # Default: output only the raw token value to stdout
         click.echo(new_token.key)
-        return
-
-    if token:
-        ctx.invoke(create, opts=opts, save_config=save_config, force=force, json=json)

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -76,6 +76,13 @@ def _perform_saml_authentication(
 
 @main.command(aliases=["auth"])
 @click.option(
+    "-f",
+    "--force",
+    default=False,
+    is_flag=True,
+    help="[DEPRECATED: Use --request-api-key] Force refresh of user API token without prompts.",
+)
+@click.option(
     "--save-config",
     default=False,
     is_flag=True,
@@ -109,14 +116,30 @@ def _perform_saml_authentication(
 def authenticate(
     ctx,
     opts,
+    force,
     save_config,
     json,
     request_api_key_flag,
     no_browser,
 ):
     """Authenticate to Cloudsmith using the Workspace's SAML setup."""
+    # Validate mutual exclusivity
+    if request_api_key_flag and force:
+        raise click.UsageError(
+            "--request-api-key cannot be used with --force. "
+            "Use --request-api-key alone for fully automated token retrieval."
+        )
+
     # Determine if we should redirect info messages to stderr
     use_stderr = request_api_key_flag or json or utils.should_use_stderr(opts)
+
+    if force:
+        click.secho(
+            "DEPRECATION WARNING: The `--force` flag is deprecated and will be removed in a future release. "
+            "Please use `--request-api-key` instead (force is implied).",
+            fg="yellow",
+            err=True,
+        )
 
     if json and not utils.should_use_stderr(opts):
         click.secho(

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -76,13 +76,6 @@ def _perform_saml_authentication(
 
 @main.command(aliases=["auth"])
 @click.option(
-    "-f",
-    "--force",
-    default=False,
-    is_flag=True,
-    help="[DEPRECATED: Use --request-api-key] Force refresh of user API token without prompts.",
-)
-@click.option(
     "--save-config",
     default=False,
     is_flag=True,
@@ -116,30 +109,14 @@ def _perform_saml_authentication(
 def authenticate(
     ctx,
     opts,
-    force,
     save_config,
     json,
     request_api_key_flag,
     no_browser,
 ):
     """Authenticate to Cloudsmith using the Workspace's SAML setup."""
-    # Validate mutual exclusivity
-    if request_api_key_flag and force:
-        raise click.UsageError(
-            "--request-api-key cannot be used with --force. "
-            "Use --request-api-key alone for fully automated token retrieval."
-        )
-
     # Determine if we should redirect info messages to stderr
     use_stderr = request_api_key_flag or json or utils.should_use_stderr(opts)
-
-    if force:
-        click.secho(
-            "DEPRECATION WARNING: The `--force` flag is deprecated and will be removed in a future release. "
-            "Please use `--request-api-key` instead (force is implied).",
-            fg="yellow",
-            err=True,
-        )
 
     if json and not utils.should_use_stderr(opts):
         click.secho(

--- a/cloudsmith_cli/cli/tests/commands/test_auth.py
+++ b/cloudsmith_cli/cli/tests/commands/test_auth.py
@@ -323,13 +323,30 @@ class TestRequestApiKeyFlag:
         assert '"key"' in result.output
         assert "ck_test123456" in result.output
 
-    @pytest.mark.parametrize("option", ["--token", "-t", "--force", "-f"])
-    def test_removed_options_are_rejected(self, runner, option):
-        """Verify the removed token-management options are rejected."""
-        result = runner.invoke(authenticate, [option])
+    def test_token_option_is_rejected(self, runner):
+        """Verify the removed --token option is rejected."""
+        result = runner.invoke(authenticate, ["--token"])
 
         assert result.exit_code != 0
-        assert "No such option" in result.output
+        assert "No such option '--token'" in result.output
+
+    def test_request_api_key_mutual_exclusion_with_force(
+        self,
+        runner,
+        mock_saml_session,
+        mock_get_idp_url,
+        mock_webbrowser,
+        mock_auth_server,
+    ):
+        """Verify --request-api-key cannot be used with --force."""
+        result = runner.invoke(
+            authenticate,
+            ["--owner", "testorg", "--request-api-key", "--force"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code != 0
+        assert "--request-api-key cannot be used with --force" in result.output
 
     def test_request_api_key_with_save_config(
         self,

--- a/cloudsmith_cli/cli/tests/commands/test_auth.py
+++ b/cloudsmith_cli/cli/tests/commands/test_auth.py
@@ -323,25 +323,12 @@ class TestRequestApiKeyFlag:
         assert '"key"' in result.output
         assert "ck_test123456" in result.output
 
-    def test_request_api_key_mutual_exclusion_with_token(
-        self,
-        runner,
-        mock_saml_session,
-        mock_get_idp_url,
-        mock_webbrowser,
-        mock_auth_server,
-    ):
-        """Verify --request-api-key cannot be used with --token."""
-        result = runner.invoke(
-            authenticate,
-            ["--owner", "testorg", "--request-api-key", "--token"],
-            catch_exceptions=False,
-        )
+    def test_token_option_is_rejected(self, runner):
+        """Verify the removed --token option is rejected."""
+        result = runner.invoke(authenticate, ["--token"])
 
         assert result.exit_code != 0
-        assert (
-            "--request-api-key cannot be used with --token or --force" in result.output
-        )
+        assert "No such option '--token'" in result.output
 
     def test_request_api_key_mutual_exclusion_with_force(
         self,
@@ -359,9 +346,7 @@ class TestRequestApiKeyFlag:
         )
 
         assert result.exit_code != 0
-        assert (
-            "--request-api-key cannot be used with --token or --force" in result.output
-        )
+        assert "--request-api-key cannot be used with --force" in result.output
 
     def test_request_api_key_with_save_config(
         self,

--- a/cloudsmith_cli/cli/tests/commands/test_auth.py
+++ b/cloudsmith_cli/cli/tests/commands/test_auth.py
@@ -323,30 +323,13 @@ class TestRequestApiKeyFlag:
         assert '"key"' in result.output
         assert "ck_test123456" in result.output
 
-    def test_token_option_is_rejected(self, runner):
-        """Verify the removed --token option is rejected."""
-        result = runner.invoke(authenticate, ["--token"])
+    @pytest.mark.parametrize("option", ["--token", "-t", "--force", "-f"])
+    def test_removed_options_are_rejected(self, runner, option):
+        """Verify the removed token-management options are rejected."""
+        result = runner.invoke(authenticate, [option])
 
         assert result.exit_code != 0
-        assert "No such option '--token'" in result.output
-
-    def test_request_api_key_mutual_exclusion_with_force(
-        self,
-        runner,
-        mock_saml_session,
-        mock_get_idp_url,
-        mock_webbrowser,
-        mock_auth_server,
-    ):
-        """Verify --request-api-key cannot be used with --force."""
-        result = runner.invoke(
-            authenticate,
-            ["--owner", "testorg", "--request-api-key", "--force"],
-            catch_exceptions=False,
-        )
-
-        assert result.exit_code != 0
-        assert "--request-api-key cannot be used with --force" in result.output
+        assert "No such option" in result.output
 
     def test_request_api_key_with_save_config(
         self,


### PR DESCRIPTION
## Summary
- remove the deprecated `--token` / `-t` option from `cloudsmith auth` and `authenticate`
- remove its warning, legacy token-creation path, and token-specific mutual-exclusion handling
- direct users to `--request-api-key` in the Unreleased changelog while preserving existing `--json` and `--force` behavior

## Testing
- `env -u CLOUDSMITH_WORKSPACE -u CLOUDSMITH_ORG pytest -q cloudsmith_cli/cli/tests/commands/test_auth.py`
- `pre-commit run --files CHANGELOG.md cloudsmith_cli/cli/commands/auth.py cloudsmith_cli/cli/tests/commands/test_auth.py`

Stack layer 1; targets `master`.