### PR TITLE
feat(ENG-14323): add OIDC exchange diagnostics

### DIFF
--- a/cloudsmith_cli/cli/decorators.py
+++ b/cloudsmith_cli/cli/decorators.py
@@ -510,6 +510,7 @@ def resolve_credentials(f):
             oidc_discovery_disabled=opts.oidc_discovery_disabled,
             oidc_detector_order=opts.oidc_detector_order,
             oidc_disabled_detectors=oidc_disabled_detectors,
+            warning_writer=lambda message: click.echo(message, err=True),
         )
 
         chain = CredentialProviderChain()

--- a/cloudsmith_cli/cli/tests/test_org_option.py
+++ b/cloudsmith_cli/cli/tests/test_org_option.py
@@ -6,6 +6,8 @@
 for compatibility. All seven flags are one option.
 """
 
+from unittest.mock import patch
+
 import click
 import click.testing
 import pytest
@@ -132,3 +134,19 @@ def test_workspace_environment_takes_precedence(org_reporting_command, monkeypat
 
     assert result.exit_code == 0, result.output
     assert "org=preferred-workspace" in result.output
+
+
+def test_credential_warning_writer_uses_stderr_without_debug(org_reporting_command):
+    def emit_warning(context):
+        context.warning_writer("OIDC diagnostic")
+        return None
+
+    with patch(
+        "cloudsmith_cli.cli.decorators.CredentialProviderChain.resolve",
+        side_effect=emit_warning,
+    ):
+        result = click.testing.CliRunner().invoke(org_reporting_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "org=None\n"
+    assert result.stderr == "OIDC diagnostic\n"

--- a/cloudsmith_cli/core/credentials/models.py
+++ b/cloudsmith_cli/core/credentials/models.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import requests
 
 
@@ -33,6 +35,7 @@ class CredentialContext:
     oidc_discovery_disabled: bool = False
     oidc_detector_order: str | None = None
     oidc_disabled_detectors: frozenset[str] = frozenset()
+    warning_writer: Callable[[str], None] | None = None
 
 
 @dataclass

--- a/cloudsmith_cli/core/credentials/providers/oidc_provider.py
+++ b/cloudsmith_cli/core/credentials/providers/oidc_provider.py
@@ -2,12 +2,68 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from ..models import CredentialContext, CredentialResult
 from ..provider import CredentialProvider
 
 logger = logging.getLogger(__name__)
+
+
+def _warn(context: CredentialContext, message: str, *args: object) -> None:
+    """Write a user-facing warning to CLI stderr, falling back to logging."""
+    rendered = message % args if args else message
+    if context.warning_writer:
+        context.warning_writer(rendered)
+    else:
+        logger.warning("%s", rendered)
+
+
+def _log_exchange_diagnostics(
+    *,
+    context: CredentialContext,
+    detector_name: str,
+    org: str,
+    service_slug: str,
+    vendor_token: str,
+) -> None:
+    """Log the inputs needed to diagnose a failed exchange without the raw JWT."""
+    _warn(context, "OIDC exchange diagnostics:")
+    _warn(context, "  Workspace: %s", org)
+    _warn(context, "  Service slug: %s", service_slug)
+    _warn(context, "  Cloudsmith API host: %s", context.api_host)
+    _warn(context, "  Vendor detector: %s", detector_name)
+
+    try:
+        import jwt
+
+        header = jwt.get_unverified_header(vendor_token)
+        claims = jwt.decode(
+            vendor_token,
+            options={
+                "verify_signature": False,
+                "verify_exp": False,
+                "verify_aud": False,
+                "verify_iss": False,
+            },
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _warn(context, "  Vendor JWT could not be decoded: %s", exc)
+        return
+
+    _warn(context, "  Vendor issuer URL: %s", claims.get("iss", "<missing>"))
+    _warn(context, "  Vendor JWT KID: %s", header.get("kid", "<missing>"))
+    _warn(
+        context,
+        "  Vendor JWT header: %s",
+        json.dumps(header, sort_keys=True, default=str),
+    )
+    _warn(
+        context,
+        "  Vendor JWT claims: %s",
+        json.dumps(claims, sort_keys=True, default=str),
+    )
 
 
 class OidcProvider(CredentialProvider):
@@ -72,7 +128,8 @@ class OidcProvider(CredentialProvider):
         try:
             vendor_token = detector.get_token()
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning(
+            _warn(
+                context,
                 "OIDC: Failed to retrieve identity token from %s. "
                 "Use --debug for details.",
                 detector.name,
@@ -85,7 +142,11 @@ class OidcProvider(CredentialProvider):
             return None
 
         if not vendor_token:
-            logger.warning("OIDC: %s detector returned an empty token.", detector.name)
+            _warn(
+                context,
+                "OIDC: %s detector returned an empty token.",
+                detector.name,
+            )
             return None
 
         try:
@@ -96,13 +157,28 @@ class OidcProvider(CredentialProvider):
                 oidc_token=vendor_token,
             )
         except OidcExchangeError as exc:
-            logger.warning("OIDC: Token exchange failed: %s", exc)
+            _warn(context, "OIDC: Token exchange failed: %s", exc)
+            _log_exchange_diagnostics(
+                context=context,
+                detector_name=detector.name,
+                org=org,
+                service_slug=service_slug,
+                vendor_token=vendor_token,
+            )
             return None
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "OIDC: Token exchange failed unexpectedly. Use --debug for details."
+            _warn(
+                context,
+                "OIDC: Token exchange failed unexpectedly. Use --debug for details.",
             )
             logger.debug("OidcProvider: OIDC token exchange error", exc_info=True)
+            _log_exchange_diagnostics(
+                context=context,
+                detector_name=detector.name,
+                org=org,
+                service_slug=service_slug,
+                vendor_token=vendor_token,
+            )
             return None
 
         if not cloudsmith_token:

--- a/cloudsmith_cli/core/tests/test_oidc_provider.py
+++ b/cloudsmith_cli/core/tests/test_oidc_provider.py
@@ -1,8 +1,12 @@
 """Tests for the OIDC credential provider."""
 
+import logging
 from unittest.mock import Mock, patch
 
+import jwt
+
 from cloudsmith_cli.core.credentials.models import CredentialContext
+from cloudsmith_cli.core.credentials.oidc.exchange import OidcExchangeError
 from cloudsmith_cli.core.credentials.providers.oidc_provider import OidcProvider
 
 
@@ -52,3 +56,75 @@ def test_exchanged_oidc_token_is_a_bearer_credential():
 
     assert credential is not None
     assert credential.auth_type == "bearer"
+
+
+def test_failed_exchange_logs_vendor_jwt_diagnostics(caplog):
+    vendor_token = jwt.encode(
+        {
+            "iss": "https://token.actions.githubusercontent.com",
+            "aud": "cloudsmith",
+            "repository": "cloudsmith-io/cloudsmith-cli",
+        },
+        key="",
+        algorithm="none",
+        headers={"kid": "vendor-key-id"},
+    )
+    detector = Mock()
+    detector.name = "GitHub Actions"
+    detector.get_token.return_value = vendor_token
+
+    with (
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.cache.get_cached_token",
+            return_value=None,
+        ),
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.detectors.detect_environment",
+            return_value=detector,
+        ),
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.exchange.exchange_oidc_token",
+            side_effect=OidcExchangeError("service not found"),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        credential = OidcProvider().resolve(_context())
+
+    assert credential is None
+    assert "Workspace: cloudsmith" in caplog.text
+    assert "Service slug: github-actions" in caplog.text
+    assert "Cloudsmith API host: https://api.cloudsmith.io" in caplog.text
+    assert "Vendor detector: GitHub Actions" in caplog.text
+    assert (
+        "Vendor issuer URL: https://token.actions.githubusercontent.com" in caplog.text
+    )
+    assert "Vendor JWT KID: vendor-key-id" in caplog.text
+    assert '"repository": "cloudsmith-io/cloudsmith-cli"' in caplog.text
+    assert vendor_token not in caplog.text
+
+
+def test_failed_exchange_reports_undecodable_vendor_jwt(caplog):
+    detector = Mock()
+    detector.name = "Generic"
+    detector.get_token.return_value = "not-a-jwt"
+
+    with (
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.cache.get_cached_token",
+            return_value=None,
+        ),
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.detectors.detect_environment",
+            return_value=detector,
+        ),
+        patch(
+            "cloudsmith_cli.core.credentials.oidc.exchange.exchange_oidc_token",
+            side_effect=OidcExchangeError("unauthorized"),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        credential = OidcProvider().resolve(_context())
+
+    assert credential is None
+    assert "Vendor JWT could not be decoded" in caplog.text
+    assert "not-a-jwt" not in caplog.text


### PR DESCRIPTION
## Summary

- print detailed OIDC diagnostics when token exchange fails and no credential is resolved
- include the configured Workspace, service slug, API host, detected vendor, issuer URL, JWT KID, header, and claims
- write diagnostics directly to stderr without requiring `--debug`
- never print the raw vendor JWT or signature, and handle malformed JWTs safely

## Example stderr output

```text
OIDC: Token exchange failed: OIDC token exchange request failed: HTTPSConnectionPool(host='api.cloudsmith.io', port=443): Max retries exceeded
OIDC exchange diagnostics:
  Workspace: example-workspace
  Service slug: github-actions
  Cloudsmith API host: https://api.cloudsmith.io
  Vendor detector: GitHub Actions
  Vendor issuer URL: https://token.actions.githubusercontent.com
  Vendor JWT KID: example-key-id
  Vendor JWT header: {"alg": "RS256", "kid": "example-key-id", "typ": "JWT"}
  Vendor JWT claims: {"aud": "cloudsmith", "iss": "https://token.actions.githubusercontent.com", "repository": "example-org/example-repo", "sub": "repo:example-org/example-repo:ref:refs/heads/main"}
```

## Validation

- `pytest -q -m "not integration"` (1119 passed, 31 deselected)
- pre-commit hooks pass

[ENG-14323](https://linear.app/cloudsmith/issue/ENG-14323/cli-on-oidc-exchange-failure-provide-verbose-output)
