### PR TITLE
docs: reference OpenChain CRA checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ cloudsmith download --help
 
 Arbitrary JSON metadata can be attached to any package — SBOMs, JFrog BuildInfo documents, or custom payloads. Metadata is validated against the declared content type and stays with the package for its lifetime.
 
+For teams mapping SBOM and vulnerability-handling evidence to EU Cyber Resilience Act (CRA) readiness, the [OpenChain CRA Compliance Requirements & Checklist](https://github.com/OpenChain-Project/CRA-Compliance) provides a community-maintained reference for organizing compliance evidence. This checklist is not legal advice or a conformity assessment.
+
 Metadata can be attached at push time with `cloudsmith push` (see [Attaching Metadata During Push](#attaching-metadata-during-push)) or managed afterwards with the `cloudsmith metadata` command group.
 
 To attach metadata to an existing package:


### PR DESCRIPTION
## Summary
- Adds a short related-resource note to the Package Metadata section for teams mapping SBOM and vulnerability-handling evidence to EU Cyber Resilience Act readiness.
- Links to the OpenChain CRA Compliance Requirements & Checklist as a community-maintained reference.
- Clarifies that the checklist is not legal advice or a conformity assessment.

## Context
OpenChain maintains Annex D as a living register of organizations and public resources that reference, use, evaluate, or rely on the checklist: https://github.com/OpenChain-Project/CRA-Compliance/blob/main/ANNEX_D_EXTERNAL_REFERENCES_AND_ADOPTION.md

## Testing
- Ran git diff --check.