### PR TITLE
feat(ENG-14145): self-update command and background update check

### DIFF
--- a/cloudsmith_cli/cli/commands/main.py
+++ b/cloudsmith_cli/cli/commands/main.py
@@ -2,6 +2,7 @@
 
 import click
 
+from ...core import update_check
 from ...core.api.version import get_version as get_api_version
 from ...core.utils import get_github_website, get_help_website
 from ...core.version import get_version as get_cli_version
@@ -56,12 +57,21 @@ For issues/contributing: {get_github_website()}
     is_flag=True,
     is_eager=True,
 )
+@click.option(
+    "--no-check-update",
+    is_flag=True,
+    default=False,
+    envvar="CLOUDSMITH_NO_UPDATE_CHECK",
+    help="Disable the once-a-day check for a newer version of the CLI.",
+)
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @click.pass_context
-def main(ctx, opts, version):
+def main(ctx, opts, version, no_check_update):
     """Handle entrypoint to CLI."""
     # pylint: disable=unused-argument
+
+    update_check.arm(ctx, opts, no_check_update)
 
     if version:
         print_version(opts)

--- a/cloudsmith_cli/cli/commands/registry.py
+++ b/cloudsmith_cli/cli/commands/registry.py
@@ -37,6 +37,7 @@ LAZY_COMMANDS = {
     "status": f"{_PACKAGE}.status",
     "tags": f"{_PACKAGE}.tags",
     "tokens": f"{_PACKAGE}.tokens",
+    "update": f"{_PACKAGE}.update",
     "upstream": f"{_PACKAGE}.upstream",
     "vulnerabilities": f"{_PACKAGE}.vulnerabilities",
     "whoami": f"{_PACKAGE}.whoami",
@@ -56,4 +57,5 @@ LAZY_ALIASES = {
     "quarantine": ["block"],
     "repositories": ["repos"],
     "tags": ["tag"],
+    "update": ["upgrade"],
 }

--- a/cloudsmith_cli/cli/commands/update.py
+++ b/cloudsmith_cli/cli/commands/update.py
@@ -1,0 +1,157 @@
+"""CLI/Commands - Update the CLI to the latest released version."""
+
+import click
+
+from ...core import installation, self_update, update_check
+from ...core.session import create_requests_session
+from ...core.version import get_version, parse_version
+from .. import decorators, utils
+from ..utils import maybe_spinner
+from .main import main
+
+
+def _fetch_manifest(opts, session, target):
+    import requests
+
+    try:
+        with maybe_spinner(opts):
+            return update_check.fetch_latest_manifest(session, target=target)
+    except (requests.RequestException, ValueError) as exc:
+        raise click.ClickException(f"Failed to fetch the latest version: {exc}")
+
+
+def _is_up_to_date(latest, current):
+    try:
+        return parse_version(latest) <= parse_version(current)
+    except ValueError as exc:
+        raise click.ClickException(f"Cannot compare versions: {exc}")
+
+
+def _confirm_self_update(opts, current, latest, assume_yes):
+    """Return True to proceed with the self-update.
+
+    Auto-confirms when ``--yes`` is given, when output is machine-readable, or
+    when stderr is not a terminal (so scripted/piped invocations do not hang on
+    a prompt).
+    """
+    if assume_yes or utils.should_use_stderr(opts) or not update_check.stderr_is_tty():
+        return True
+    return click.confirm(
+        f"Update the Cloudsmith CLI from {current} to {latest}?", default=True
+    )
+
+
+def _run_self_update(opts, session, manifest, data):
+    import requests
+
+    use_stderr = utils.should_use_stderr(opts)
+    click.echo(
+        f"Downloading and installing version {manifest['version']} ... ",
+        nl=False,
+        err=use_stderr,
+    )
+    try:
+        with maybe_spinner(opts):
+            self_update.perform_self_update(manifest, session=session)
+    except (self_update.SelfUpdateError, requests.RequestException, OSError) as exc:
+        click.secho("ERROR", fg="red", err=use_stderr)
+        raise click.ClickException(str(exc))
+    click.secho("OK", fg="green", err=use_stderr)
+    data["upgraded"] = True
+    if utils.maybe_print_as_json(opts, data):
+        return
+    click.echo(f"The Cloudsmith CLI is now at version {manifest['version']}.")
+
+
+def _print_manual_update(opts, current, latest, manifest, data):
+    """Report a manual-update path when self-update cannot run (Windows).
+
+    The command already holds the host manifest, so it shows the exact archive
+    URL and checksum rather than a vague pointer; it exits 0 so scripts do not
+    treat "update available, self-update unsupported" as a failure.
+    """
+    data["outcome"] = "manual"
+    data["download_url"] = manifest.get("url")
+    data["sha256"] = manifest.get("sha256")
+    data["archive"] = manifest.get("archive")
+    if utils.maybe_print_as_json(opts, data):
+        return
+    click.echo(
+        f"A new version of the Cloudsmith CLI is available: {current} \u2192 {latest}"
+    )
+    click.echo("Self-update is not supported for the standalone binary on Windows.")
+    click.echo(
+        "Download and extract this archive, then replace your install directory:"
+    )
+    click.echo(f"  URL:    {manifest['url']}")
+    click.echo(f"  SHA256: {manifest['sha256']}")
+
+
+@main.command(aliases=["upgrade"])
+@click.option(
+    "-y",
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Do not prompt for confirmation before installing an update.",
+)
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@click.pass_context
+def update(ctx, opts, assume_yes):
+    """Update the Cloudsmith CLI to the latest released version.
+
+    The check runs on every invocation, independent of the once-a-day
+    background version check. A standalone binary downloads and installs the
+    latest release in place; every other install channel is told the correct
+    upgrade command for that channel.
+    """
+    # pylint: disable=unused-argument
+    current = get_version()
+    channel = installation.detect_channel()
+    target = installation.detect_target()
+    if channel == installation.CHANNEL_STANDALONE and target is None:
+        raise click.ClickException(
+            "Cannot detect a supported platform for the standalone binary."
+        )
+
+    session = create_requests_session(user_agent=opts.api_user_agent)
+    manifest = _fetch_manifest(opts, session, target)
+    latest = manifest["version"]
+
+    # Stamp both timestamps regardless of the outcome: the user has just run an
+    # explicit check, so the background notice's daily re-nag is disarmed.
+    update_check.record_checked_and_notified(latest)
+
+    data = {"current_version": current, "latest_version": latest, "channel": channel}
+
+    if _is_up_to_date(latest, current):
+        data["up_to_date"] = True
+        if not utils.maybe_print_as_json(opts, data):
+            click.echo(f"The Cloudsmith CLI is up to date (version {current}).")
+        return
+
+    instruction = installation.upgrade_instruction(channel)
+    if instruction is not None:
+        data["upgrade_command"] = instruction
+        if utils.maybe_print_as_json(opts, data):
+            return
+        click.echo(
+            f"A new version of the Cloudsmith CLI is available: {current} \u2192 {latest}"
+        )
+        click.echo(f"The CLI was installed via {channel}. To update, run:")
+        click.echo(f"  {instruction}")
+        return
+
+    if not installation.self_update_supported():
+        _print_manual_update(opts, current, latest, manifest, data)
+        return
+
+    if not _confirm_self_update(opts, current, latest, assume_yes):
+        data["upgraded"] = False
+        if not utils.maybe_print_as_json(opts, data):
+            click.echo("Update cancelled.")
+        return
+
+    _run_self_update(opts, session, manifest, data)

--- a/cloudsmith_cli/cli/config.py
+++ b/cloudsmith_cli/cli/config.py
@@ -75,6 +75,7 @@ class ConfigSchema:
         oidc_detector_order = ConfigParam(name="oidc_detector_order", type=str)
         oidc_disabled_detectors = ConfigParam(name="oidc_disabled_detectors", type=str)
         metadata_failure_mode = ConfigParam(name="metadata_failure_mode", type=str)
+        check_for_update = ConfigParam(name="check_for_update", type=bool, default=True)
 
     @matches_section("profile:*")
     class Profile(Default):
@@ -601,6 +602,18 @@ class Options:  # pylint: disable=too-many-public-methods
                 "Expected one of: 'error', 'warn', '0'."
             )
         self._set_option("metadata_failure_mode", normalised)
+
+    @property
+    def check_for_update(self):
+        """Get value for the once-a-day update check toggle."""
+        return self._get_option("check_for_update", default=True)
+
+    @check_for_update.setter
+    def check_for_update(self, value):
+        """Set value for the once-a-day update check toggle."""
+        if value is None:
+            return
+        self._set_option("check_for_update", bool(value))
 
     @property
     def output(self):

--- a/cloudsmith_cli/cli/tests/commands/test_main.py
+++ b/cloudsmith_cli/cli/tests/commands/test_main.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from ....core import update_check
 from ....core.api.version import get_version as get_api_version
 from ....core.version import get_version
 from ...commands.main import main
@@ -52,3 +53,61 @@ class TestMainCommand:
         assert result.exit_code == 0
         # TODO: assert something specific about output
         assert result.output
+
+
+class TestMainUpdateNotice:
+    """The update notice is wired through `arm` on the top-level group."""
+
+    @pytest.fixture
+    def state_file(self, tmp_path, monkeypatch):
+        """Point the state file at a temp path and behave like an interactive TTY."""
+        import semver
+
+        path = str(tmp_path / "update_check.json")
+        monkeypatch.setattr(update_check, "get_state_file_path", lambda: path)
+        monkeypatch.setattr(update_check, "stderr_is_tty", lambda: True)
+        monkeypatch.setattr(
+            update_check.version,
+            "get_version_info",
+            lambda: semver.VersionInfo.parse("1.26.0"),
+        )
+        monkeypatch.setattr(update_check.version, "get_version", lambda: "1.26.0")
+        return path
+
+    def _write_behind(self, path):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"last_check_at": 1000.0, "latest_version": "9.9.9"}, f)
+
+    def test_notice_prints_when_behind(self, runner, state_file):
+        """A stale + behind state prints the notice at command close."""
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" in result.output
+        assert "cloudsmith update" in result.output
+
+    def test_no_check_update_flag_suppresses(self, runner, state_file):
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["--no-check-update", "--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" not in result.output
+
+    def test_json_output_suppresses(self, runner, state_file):
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["-F", "json", "--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" not in result.output
+        # stdout stays valid JSON.
+        json.loads(result.output)
+
+    def test_no_network_when_behind(self, runner, state_file, monkeypatch):
+        """Being behind must not trigger a fetch."""
+
+        def boom(*args, **kwargs):
+            raise AssertionError("fetch must not run when already behind")
+
+        monkeypatch.setattr(update_check, "run_background_check", boom)
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" in result.output

--- a/cloudsmith_cli/cli/tests/commands/test_main.py
+++ b/cloudsmith_cli/cli/tests/commands/test_main.py
@@ -80,13 +80,54 @@ class TestMainUpdateNotice:
         with open(path, "w", encoding="utf-8") as f:
             json.dump({"last_checked_at": 1000.0, "latest_version": "9.9.9"}, f)
 
-    def test_notice_prints_when_behind(self, runner, state_file):
-        """A stale + behind state prints the notice at command close."""
+    def test_notice_prints_when_behind_standalone(
+        self, runner, state_file, monkeypatch
+    ):
+        """A standalone install (self-update capable) is told to run `cloudsmith update`."""
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(
+            installation, "detect_channel", lambda: installation.CHANNEL_STANDALONE
+        )
+        monkeypatch.setattr(installation, "self_update_supported", lambda: True)
         self._write_behind(state_file)
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
         assert "9.9.9" in result.output
         assert "cloudsmith update" in result.output
+
+    def test_notice_windows_standalone_points_at_releases(
+        self, runner, state_file, monkeypatch
+    ):
+        """A standalone install without self-update (Windows) points at releases."""
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(
+            installation, "detect_channel", lambda: installation.CHANNEL_STANDALONE
+        )
+        monkeypatch.setattr(installation, "self_update_supported", lambda: False)
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" in result.output
+        assert installation.RELEASES_LATEST_URL in result.output
+        assert "cloudsmith update" not in result.output
+
+    def test_notice_prints_package_manager_command(
+        self, runner, state_file, monkeypatch
+    ):
+        """A package-managed install is told the channel's own upgrade command."""
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(
+            installation, "detect_channel", lambda: installation.CHANNEL_PIP
+        )
+        self._write_behind(state_file)
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" in result.output
+        assert "pip install --upgrade cloudsmith-cli" in result.output
+        assert "cloudsmith update" not in result.output
 
     def test_no_check_update_flag_suppresses(self, runner, state_file):
         self._write_behind(state_file)

--- a/cloudsmith_cli/cli/tests/commands/test_main.py
+++ b/cloudsmith_cli/cli/tests/commands/test_main.py
@@ -75,8 +75,10 @@ class TestMainUpdateNotice:
         return path
 
     def _write_behind(self, path):
+        # Stale check (so a check is due) + never notified + a newer version:
+        # arm re-arms by bumping last_checked_at, close notifies.
         with open(path, "w", encoding="utf-8") as f:
-            json.dump({"last_check_at": 1000.0, "latest_version": "9.9.9"}, f)
+            json.dump({"last_checked_at": 1000.0, "latest_version": "9.9.9"}, f)
 
     def test_notice_prints_when_behind(self, runner, state_file):
         """A stale + behind state prints the notice at command close."""
@@ -111,3 +113,42 @@ class TestMainUpdateNotice:
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
         assert "9.9.9" in result.output
+
+    def test_notifies_from_cache_when_no_fetch_due(self, runner, state_file):
+        """Notice fires from cache even when the check is fresh (not due).
+
+        Regression: a prior suppressed run may have fetched (advancing
+        last_checked_at) without notifying. The next interactive run must still
+        speak, driven purely by last_notified_at < last_checked_at.
+        """
+        with open(state_file, "w", encoding="utf-8") as f:
+            # Fresh check (not due) + newer version + never notified.
+            json.dump(
+                {
+                    "last_checked_at": 9_999_999_999.0,
+                    "latest_version": "9.9.9",
+                },
+                f,
+            )
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "9.9.9" in result.output
+        # last_notified_at now stamped → throttled next time.
+        with open(state_file, encoding="utf-8") as f:
+            assert "last_notified_at" in json.load(f)
+
+    def test_json_run_still_fetches(self, runner, state_file, monkeypatch):
+        """-F json suppresses the notice but the daily fetch still runs."""
+        calls = []
+
+        def fake_fetch(session, now=None):
+            calls.append(True)
+            update_check.record_check("9.9.9", now=now)
+
+        monkeypatch.setattr(update_check, "run_background_check", fake_fetch)
+        # No state file → a fetch is due; JSON silences only the notice.
+        result = runner.invoke(main, ["-F", "json", "--version"])
+        assert result.exit_code == 0
+        assert calls == [True]
+        assert "9.9.9" not in result.output
+        json.loads(result.output)

--- a/cloudsmith_cli/cli/tests/commands/test_update.py
+++ b/cloudsmith_cli/cli/tests/commands/test_update.py
@@ -1,0 +1,271 @@
+import json
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from ....cli.commands.update import update
+from ....core import installation
+
+_MOD = "cloudsmith_cli.cli.commands.update"
+
+CURRENT = "1.26.0"
+NEWER = "2.0.0"
+
+
+def _manifest(version, **extra):
+    manifest = {
+        "version": version,
+        "url": f"https://dl.example.com/cloudsmith-{version}.tar.gz",
+        "sha256": "0" * 64,
+    }
+    manifest.update(extra)
+    return manifest
+
+
+def invoke_update(
+    runner,
+    *,
+    channel,
+    latest,
+    target="linux-x86_64-gnu",
+    args=None,
+    manifest=None,
+    self_update_supported=True,
+):
+    """Invoke the update command with all external effects mocked."""
+    manifest = manifest or _manifest(latest)
+    with ExitStack() as stack:
+        stack.enter_context(patch(f"{_MOD}.get_version", return_value=CURRENT))
+        stack.enter_context(
+            patch(f"{_MOD}.installation.detect_channel", return_value=channel)
+        )
+        stack.enter_context(
+            patch(f"{_MOD}.installation.detect_target", return_value=target)
+        )
+        stack.enter_context(
+            patch(
+                f"{_MOD}.installation.self_update_supported",
+                return_value=self_update_supported,
+            )
+        )
+        stack.enter_context(patch(f"{_MOD}.create_requests_session"))
+        stack.enter_context(
+            patch(
+                f"{_MOD}.update_check.fetch_latest_manifest",
+                return_value=manifest,
+            )
+        )
+        record = stack.enter_context(
+            patch(f"{_MOD}.update_check.record_checked_and_notified")
+        )
+        self_update = stack.enter_context(
+            patch(f"{_MOD}.self_update.perform_self_update")
+        )
+        result = runner.invoke(update, args or [], catch_exceptions=False)
+    return result, record, self_update
+
+
+class TestUpToDate:
+    def test_up_to_date_exits_zero(self, runner):
+        result, record, self_update = invoke_update(
+            runner, channel=installation.CHANNEL_PIP, latest=CURRENT
+        )
+        assert result.exit_code == 0
+        assert "up to date" in result.output
+        record.assert_called_once_with(CURRENT)
+        self_update.assert_not_called()
+
+    def test_up_to_date_json(self, runner):
+        result, _record, _su = invoke_update(
+            runner,
+            channel=installation.CHANNEL_STANDALONE,
+            latest=CURRENT,
+            args=["-F", "json"],
+        )
+        payload = json.loads(result.output)["data"]
+        assert payload["up_to_date"] is True
+        assert payload["current_version"] == CURRENT
+        assert payload["latest_version"] == CURRENT
+
+
+class TestPackageManagerChannel:
+    def test_prints_instruction(self, runner):
+        result, record, self_update = invoke_update(
+            runner, channel=installation.CHANNEL_PIP, latest=NEWER
+        )
+        assert result.exit_code == 0
+        assert "pip install --upgrade cloudsmith-cli" in result.output
+        record.assert_called_once_with(NEWER)
+        self_update.assert_not_called()
+
+    def test_json_has_upgrade_command(self, runner):
+        result, _record, _su = invoke_update(
+            runner,
+            channel=installation.CHANNEL_HOMEBREW,
+            latest=NEWER,
+            args=["-F", "json"],
+        )
+        payload = json.loads(result.output)["data"]
+        assert payload["channel"] == installation.CHANNEL_HOMEBREW
+        assert "brew" in payload["upgrade_command"]
+
+
+class TestStandaloneSelfUpdate:
+    def test_self_update_with_yes(self, runner):
+        result, record, self_update = invoke_update(
+            runner,
+            channel=installation.CHANNEL_STANDALONE,
+            latest=NEWER,
+            args=["--yes"],
+        )
+        assert result.exit_code == 0
+        assert "now at version 2.0.0" in result.output
+        record.assert_called_once_with(NEWER)
+        self_update.assert_called_once()
+
+    def test_prompt_declined(self, runner):
+        # No --yes and no TTY forcing: patch stderr_is_tty True so the prompt
+        # is actually shown, then feed "n".
+        manifest = _manifest(NEWER)
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{_MOD}.get_version", return_value=CURRENT))
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.detect_channel",
+                    return_value=installation.CHANNEL_STANDALONE,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.detect_target",
+                    return_value="linux-x86_64-gnu",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.self_update_supported",
+                    return_value=True,
+                )
+            )
+            stack.enter_context(patch(f"{_MOD}.create_requests_session"))
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.update_check.fetch_latest_manifest",
+                    return_value=manifest,
+                )
+            )
+            stack.enter_context(
+                patch(f"{_MOD}.update_check.record_checked_and_notified")
+            )
+            stack.enter_context(
+                patch(f"{_MOD}.update_check.stderr_is_tty", return_value=True)
+            )
+            self_update = stack.enter_context(
+                patch(f"{_MOD}.self_update.perform_self_update")
+            )
+            result = runner.invoke(update, [], input="n\n", catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "cancelled" in result.output.lower()
+        self_update.assert_not_called()
+
+    def test_self_update_error_reported(self, runner):
+        from ....core import self_update as su_mod
+
+        manifest = _manifest(NEWER)
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{_MOD}.get_version", return_value=CURRENT))
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.detect_channel",
+                    return_value=installation.CHANNEL_STANDALONE,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.detect_target",
+                    return_value="linux-x86_64-gnu",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.installation.self_update_supported",
+                    return_value=True,
+                )
+            )
+            stack.enter_context(patch(f"{_MOD}.create_requests_session"))
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.update_check.fetch_latest_manifest",
+                    return_value=manifest,
+                )
+            )
+            stack.enter_context(
+                patch(f"{_MOD}.update_check.record_checked_and_notified")
+            )
+            stack.enter_context(
+                patch(
+                    f"{_MOD}.self_update.perform_self_update",
+                    side_effect=su_mod.SelfUpdateError("boom"),
+                )
+            )
+            result = runner.invoke(update, ["--yes"])
+        assert result.exit_code != 0
+        assert "boom" in result.output
+
+
+class TestStandaloneManualUpdate:
+    """Windows standalone: no self-update; print the manifest URL + sha256."""
+
+    def test_prints_url_and_sha_exits_zero(self, runner):
+        manifest = _manifest(NEWER)
+        result, _record, self_update = invoke_update(
+            runner,
+            channel=installation.CHANNEL_STANDALONE,
+            latest=NEWER,
+            target="windows-x86_64",
+            manifest=manifest,
+            self_update_supported=False,
+        )
+        assert result.exit_code == 0
+        assert manifest["url"] in result.output
+        assert manifest["sha256"] in result.output
+        assert "Windows" in result.output
+        self_update.assert_not_called()
+
+    def test_json_outcome_manual(self, runner):
+        manifest = _manifest(NEWER)
+        result, _record, self_update = invoke_update(
+            runner,
+            channel=installation.CHANNEL_STANDALONE,
+            latest=NEWER,
+            target="windows-x86_64",
+            manifest=manifest,
+            self_update_supported=False,
+            args=["-F", "json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)["data"]
+        assert payload["outcome"] == "manual"
+        assert payload["download_url"] == manifest["url"]
+        assert payload["sha256"] == manifest["sha256"]
+        self_update.assert_not_called()
+
+
+class TestChecksRegardlessOfState:
+    def test_records_timestamps_even_when_up_to_date(self, runner):
+        _result, record, _su = invoke_update(
+            runner, channel=installation.CHANNEL_PIP, latest=CURRENT
+        )
+        record.assert_called_once_with(CURRENT)
+
+    def test_standalone_without_target_errors(self, runner):
+        result, _record, self_update = invoke_update(
+            runner,
+            channel=installation.CHANNEL_STANDALONE,
+            latest=NEWER,
+            target=None,
+        )
+        assert result.exit_code != 0
+        assert "supported platform" in result.output
+        self_update.assert_not_called()

--- a/cloudsmith_cli/core/installation.py
+++ b/cloudsmith_cli/core/installation.py
@@ -1,0 +1,135 @@
+"""Detect how the CLI was installed and how to upgrade it."""
+
+import os
+import platform
+import sys
+from importlib import metadata
+
+CHANNEL_STANDALONE = "standalone"
+CHANNEL_HOMEBREW = "homebrew"
+CHANNEL_DOCKER = "docker"
+CHANNEL_AQUA = "aqua"
+CHANNEL_PIP = "pip"
+CHANNEL_PIPX = "pipx"
+CHANNEL_UV_TOOL = "uv-tool"
+CHANNEL_UV_PIP = "uv-pip"
+CHANNEL_UNKNOWN = "unknown"
+
+_DISTRIBUTION_NAME = "cloudsmith-cli"
+
+#: Where a user downloads a fresh standalone build when self-update cannot run.
+RELEASES_LATEST_URL = "https://github.com/cloudsmith-io/cloudsmith-cli/releases/latest"
+
+_UPGRADE_INSTRUCTIONS = {
+    CHANNEL_PIP: "pip install --upgrade cloudsmith-cli",
+    CHANNEL_PIPX: "pipx upgrade cloudsmith-cli",
+    CHANNEL_UV_TOOL: "uv tool upgrade cloudsmith-cli",
+    CHANNEL_UV_PIP: "uv pip install --upgrade cloudsmith-cli",
+    CHANNEL_HOMEBREW: "brew update && brew upgrade cloudsmith-cli",
+    CHANNEL_DOCKER: "docker pull cloudsmith/cloudsmith-cli:latest",
+    CHANNEL_AQUA: (
+        "update the cloudsmith-io/cloudsmith-cli version in your aqua "
+        "configuration, then run `aqua install`"
+    ),
+    CHANNEL_UNKNOWN: "pip install --upgrade cloudsmith-cli",
+}
+
+
+def _running_in_container():
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return True
+    return bool(
+        os.environ.get("container") or os.environ.get("KUBERNETES_SERVICE_HOST")
+    )
+
+
+def _distribution_location():
+    """Return the installed distribution's directory, or None."""
+    try:
+        distribution = metadata.distribution(_DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+    return str(distribution.locate_file(""))
+
+
+def _distribution_installer():
+    """Return the INSTALLER record of the installed distribution, or None."""
+    try:
+        distribution = metadata.distribution(_DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+    installer = distribution.read_text("INSTALLER")
+    return installer.strip() if installer else None
+
+
+def _detect_frozen_channel(executable_path):
+    normalized = os.path.realpath(executable_path).replace("\\", "/")
+    if "aquaproj-aqua" in normalized:
+        return CHANNEL_AQUA
+    if "/Cellar/" in normalized or "/linuxbrew/" in normalized:
+        return CHANNEL_HOMEBREW
+    if normalized.startswith("/opt/cloudsmith") and _running_in_container():
+        return CHANNEL_DOCKER
+    return CHANNEL_STANDALONE
+
+
+def _detect_package_channel():
+    location = _distribution_location()
+    if location is None:
+        return CHANNEL_UNKNOWN
+    normalized = location.replace("\\", "/")
+    if "/pipx/" in normalized:
+        return CHANNEL_PIPX
+    if "/uv/tools/" in normalized:
+        return CHANNEL_UV_TOOL
+    installer = _distribution_installer()
+    if installer == "uv":
+        return CHANNEL_UV_PIP
+    if installer == "pip":
+        return CHANNEL_PIP
+    return CHANNEL_UNKNOWN
+
+
+def detect_channel(frozen=None, executable_path=None):
+    """Detect the install channel of the running CLI."""
+    frozen = getattr(sys, "frozen", False) if frozen is None else frozen
+    if frozen:
+        return _detect_frozen_channel(executable_path or sys.executable)
+    return _detect_package_channel()
+
+
+def detect_target():
+    """Detect the standalone build target for this platform, or None."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    arch = {"amd64": "x86_64", "x86_64": "x86_64"}.get(machine)
+    arm = machine in ("arm64", "aarch64")
+    if system == "Darwin":
+        return "macos-arm64" if arm else ("macos-x86_64" if arch else None)
+    if system == "Windows":
+        return "windows-x86_64" if arch else None
+    if system == "Linux":
+        if arm:
+            arch = "aarch64"
+        if arch is None:
+            return None
+        libc = "gnu" if platform.libc_ver()[0] == "glibc" else "musl"
+        return f"linux-{arch}-{libc}"
+    return None
+
+
+def upgrade_instruction(channel):
+    """Return the upgrade command for a channel, or None for self-update."""
+    if channel == CHANNEL_STANDALONE:
+        return None
+    return _UPGRADE_INSTRUCTIONS[channel]
+
+
+def self_update_supported():
+    """Whether the standalone binary can replace itself in place.
+
+    False on Windows: the running ``.exe`` is locked, so an in-place swap is
+    not possible (a deferred-swap helper is a future follow-up). Callers fall
+    back to manual-download instructions.
+    """
+    return os.name != "nt"

--- a/cloudsmith_cli/core/self_update.py
+++ b/cloudsmith_cli/core/self_update.py
@@ -1,0 +1,196 @@
+"""Self-update for the standalone CLI bundle."""
+
+import hashlib
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+DOWNLOAD_TIMEOUT_SECONDS = 120.0
+_READ_CHUNK_BYTES = 1 << 20
+
+
+class SelfUpdateError(Exception):
+    """A self-update step failed."""
+
+
+def download_archive(url, dest_path, session=None, timeout=DOWNLOAD_TIMEOUT_SECONDS):
+    """Stream a release archive to a local file.
+
+    ``session`` is the shared requests session so proxy/CA/user-agent settings
+    apply; when omitted a plain session is created.
+    """
+    if session is None:
+        from .session import create_requests_session
+
+        session = create_requests_session()
+
+    with session.get(url, stream=True, timeout=timeout) as response:
+        response.raise_for_status()
+        with open(dest_path, "wb") as dest:
+            dest.writelines(response.iter_content(chunk_size=_READ_CHUNK_BYTES))
+
+
+def verify_sha256(path, expected):
+    """Verify the SHA-256 digest of a file against the manifest value."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(_READ_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    if digest.hexdigest() != expected.strip().lower():
+        raise SelfUpdateError(
+            f"checksum mismatch for {os.path.basename(path)}: "
+            f"expected {expected}, got {digest.hexdigest()}"
+        )
+
+
+def extract_archive(archive_path, dest_dir):
+    """Extract a release archive (tar.gz or zip) into a directory."""
+    os.makedirs(dest_dir, exist_ok=True)
+    if archive_path.endswith(".zip"):
+        with zipfile.ZipFile(archive_path) as bundle:
+            bundle.extractall(dest_dir)
+        return
+    with tarfile.open(archive_path, "r:gz") as bundle:
+        bundle.extractall(dest_dir, filter="data")
+
+
+def find_bundle_root(extract_dir, executable_name):
+    """Return the directory holding ``executable_name`` inside an extraction.
+
+    The release archives wrap the onedir bundle in a top-level directory
+    (``cloudsmith/cloudsmith`` etc.), so the executable is one level below the
+    extraction root. Older/flat archives put it at the root. This handles both:
+    it returns ``extract_dir`` when the executable sits there, otherwise the
+    lone wrapper subdirectory that contains it. Raises ``SelfUpdateError`` when
+    no such executable is found.
+    """
+    if os.path.isfile(os.path.join(extract_dir, executable_name)):
+        return extract_dir
+    entries = [os.path.join(extract_dir, name) for name in os.listdir(extract_dir)]
+    subdirs = [path for path in entries if os.path.isdir(path)]
+    for subdir in subdirs:
+        if os.path.isfile(os.path.join(subdir, executable_name)):
+            return subdir
+    raise SelfUpdateError(f"the downloaded bundle has no {executable_name} executable")
+
+
+def swap_install_dir(install_dir, staging_dir, executable_name=None):
+    """Replace the install directory with the staged one; return the old one.
+
+    Same-filesystem, atomic-``rename`` swap so both the move-aside and the
+    install are all-or-nothing (``.old``/``.new`` are siblings of the install,
+    never on ``/tmp``, which may be a different filesystem and force a
+    non-atomic copy).
+
+    Flow: move ``install_dir`` aside to ``<install_dir>.old``, move
+    ``staging_dir`` into its place, then verify the executable is present. On
+    any failure the original is restored from ``.old`` before raising, so a
+    failed swap always leaves a working install. If the restore itself fails,
+    a :class:`SelfUpdateError` names where the previous install is preserved so
+    the user can recover it by hand.
+    """
+    old_dir = install_dir + ".old"
+    if os.path.exists(old_dir):
+        shutil.rmtree(old_dir)
+    os.rename(install_dir, old_dir)
+    try:
+        os.rename(staging_dir, install_dir)
+        if executable_name is not None and not os.path.isfile(
+            os.path.join(install_dir, executable_name)
+        ):
+            raise SelfUpdateError(
+                f"the installed bundle is missing {executable_name} after swap"
+            )
+    except (OSError, SelfUpdateError) as exc:
+        _restore_from_old(install_dir, old_dir, exc)
+        raise
+    return old_dir
+
+
+def _restore_from_old(install_dir, old_dir, original_exc):
+    """Restore ``install_dir`` from ``old_dir`` after a failed swap.
+
+    Removes a half-swapped install, then moves the preserved copy back. If the
+    restore cannot complete, raises a :class:`SelfUpdateError` that names the
+    surviving ``old_dir`` so the previous install is never silently lost.
+    """
+    if os.path.exists(install_dir):
+        shutil.rmtree(install_dir, ignore_errors=True)
+    try:
+        os.rename(old_dir, install_dir)
+    except OSError as restore_exc:
+        raise SelfUpdateError(
+            f"update failed ({original_exc}) and the previous install could not "
+            f"be restored ({restore_exc}); your working install is preserved at "
+            f"{old_dir} - move it back to {install_dir} to recover"
+        ) from restore_exc
+
+
+def _check_replaceable(install_dir):
+    if os.name == "nt":
+        raise SelfUpdateError(
+            "self-update cannot replace a running executable on Windows; "
+            "download the new archive and replace the install directory"
+        )
+    parent = os.path.dirname(install_dir)
+    if not (os.access(parent, os.W_OK) and os.access(install_dir, os.W_OK)):
+        raise SelfUpdateError(
+            f"the install directory {install_dir} is not writable; "
+            "run the upgrade with sufficient privileges"
+        )
+
+
+def perform_self_update(manifest, executable_path=None, session=None):
+    """Download, verify, and atomically install the bundle from a manifest."""
+    missing = [key for key in ("url", "sha256") if not manifest.get(key)]
+    if missing:
+        raise SelfUpdateError(
+            f"the release manifest is missing fields: {', '.join(missing)}"
+        )
+    executable_path = executable_path or sys.executable
+    install_dir = os.path.dirname(os.path.realpath(executable_path))
+    _check_replaceable(install_dir)
+
+    parent = os.path.dirname(install_dir)
+    executable_name = os.path.basename(executable_path)
+    # Extraction scratch dir and the final swap-in dir are kept separate so the
+    # swap source is never nested inside a directory we later clean up.
+    extract_dir = install_dir + ".extract"
+    staging_dir = install_dir + ".new"
+    for scratch in (extract_dir, staging_dir):
+        if os.path.exists(scratch):
+            shutil.rmtree(scratch)
+    suffix = ".zip" if manifest["url"].endswith(".zip") else ".tar.gz"
+    archive_fd, archive_path = tempfile.mkstemp(dir=parent, suffix=suffix)
+    os.close(archive_fd)
+    old_dir = None
+    try:
+        download_archive(manifest["url"], archive_path, session=session)
+        verify_sha256(archive_path, manifest["sha256"])
+        extract_archive(archive_path, extract_dir)
+        bundle_root = find_bundle_root(extract_dir, executable_name)
+        # Promote the real bundle root out of the extraction scratch dir into a
+        # standalone staging dir, so swapping it in cannot be undone by cleaning
+        # up the extraction dir afterwards.
+        os.rename(bundle_root, staging_dir)
+        if not os.path.isfile(os.path.join(staging_dir, executable_name)):
+            raise SelfUpdateError(
+                f"the downloaded bundle has no {executable_name} executable"
+            )
+        old_dir = swap_install_dir(
+            install_dir, staging_dir, executable_name=executable_name
+        )
+    finally:
+        if os.path.exists(archive_path):
+            os.unlink(archive_path)
+        if os.path.exists(extract_dir):
+            shutil.rmtree(extract_dir, ignore_errors=True)
+        # staging_dir only survives here if the swap did not consume it (i.e. a
+        # failure before/at swap); remove it so a retry starts clean.
+        if os.path.exists(staging_dir):
+            shutil.rmtree(staging_dir, ignore_errors=True)
+    if old_dir is not None:
+        shutil.rmtree(old_dir, ignore_errors=True)

--- a/cloudsmith_cli/core/tests/test_installation.py
+++ b/cloudsmith_cli/core/tests/test_installation.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for cloudsmith_cli.core.installation.
+
+Channel and build-target detection are pure functions of the runtime
+environment (executable path, distribution metadata, platform). Every test
+stubs those inputs so nothing depends on how the test host installed the CLI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cloudsmith_cli.core import installation
+
+
+class TestDetectFrozenChannel:
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            ("/home/u/.local/aquaproj-aqua/bin/cloudsmith", installation.CHANNEL_AQUA),
+            (
+                "/opt/homebrew/Cellar/cloudsmith-cli/1.0/bin/cloudsmith",
+                installation.CHANNEL_HOMEBREW,
+            ),
+            (
+                "/home/linuxbrew/.linuxbrew/bin/cloudsmith",
+                installation.CHANNEL_HOMEBREW,
+            ),
+            ("/usr/local/bin/cloudsmith", installation.CHANNEL_STANDALONE),
+        ],
+    )
+    def test_paths(self, monkeypatch, path, expected):
+        monkeypatch.setattr(installation.os.path, "realpath", lambda p: p)
+        assert (
+            installation.detect_channel(frozen=True, executable_path=path) == expected
+        )
+
+    def test_docker(self, monkeypatch):
+        monkeypatch.setattr(installation.os.path, "realpath", lambda p: p)
+        monkeypatch.setattr(installation, "_running_in_container", lambda: True)
+        assert (
+            installation.detect_channel(
+                frozen=True, executable_path="/opt/cloudsmith/bin/cloudsmith"
+            )
+            == installation.CHANNEL_DOCKER
+        )
+
+    def test_opt_cloudsmith_without_container_is_standalone(self, monkeypatch):
+        monkeypatch.setattr(installation.os.path, "realpath", lambda p: p)
+        monkeypatch.setattr(installation, "_running_in_container", lambda: False)
+        assert (
+            installation.detect_channel(
+                frozen=True, executable_path="/opt/cloudsmith/bin/cloudsmith"
+            )
+            == installation.CHANNEL_STANDALONE
+        )
+
+
+class TestDetectPackageChannel:
+    def _patch(self, monkeypatch, location, installer=None):
+        monkeypatch.setattr(installation, "_distribution_location", lambda: location)
+        monkeypatch.setattr(installation, "_distribution_installer", lambda: installer)
+
+    def test_pipx(self, monkeypatch):
+        self._patch(monkeypatch, "/home/u/.local/pipx/venvs/cloudsmith-cli")
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_PIPX
+
+    def test_uv_tool(self, monkeypatch):
+        self._patch(monkeypatch, "/home/u/.local/share/uv/tools/cloudsmith-cli")
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_UV_TOOL
+
+    def test_uv_pip(self, monkeypatch):
+        self._patch(monkeypatch, "/venv/lib/python3.12/site-packages", installer="uv")
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_UV_PIP
+
+    def test_pip(self, monkeypatch):
+        self._patch(monkeypatch, "/venv/lib/python3.12/site-packages", installer="pip")
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_PIP
+
+    def test_unknown_installer(self, monkeypatch):
+        self._patch(monkeypatch, "/some/site-packages", installer=None)
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_UNKNOWN
+
+    def test_no_distribution(self, monkeypatch):
+        self._patch(monkeypatch, None)
+        assert installation.detect_channel(frozen=False) == installation.CHANNEL_UNKNOWN
+
+
+class TestDetectTarget:
+    def _patch_platform(self, monkeypatch, system, machine, libc="glibc"):
+        monkeypatch.setattr(installation.platform, "system", lambda: system)
+        monkeypatch.setattr(installation.platform, "machine", lambda: machine)
+        monkeypatch.setattr(installation.platform, "libc_ver", lambda: (libc, "2.35"))
+
+    @pytest.mark.parametrize(
+        "system, machine, libc, expected",
+        [
+            ("Darwin", "arm64", "glibc", "macos-arm64"),
+            ("Darwin", "x86_64", "glibc", "macos-x86_64"),
+            ("Windows", "AMD64", "glibc", "windows-x86_64"),
+            ("Linux", "x86_64", "glibc", "linux-x86_64-gnu"),
+            ("Linux", "x86_64", "musl", "linux-x86_64-musl"),
+            ("Linux", "aarch64", "glibc", "linux-aarch64-gnu"),
+        ],
+    )
+    def test_supported(self, monkeypatch, system, machine, libc, expected):
+        self._patch_platform(monkeypatch, system, machine, libc)
+        assert installation.detect_target() == expected
+
+    @pytest.mark.parametrize(
+        "system, machine",
+        [("Darwin", "ppc"), ("Windows", "arm64"), ("Linux", "ppc64le"), ("Plan9", "x")],
+    )
+    def test_unsupported(self, monkeypatch, system, machine):
+        self._patch_platform(monkeypatch, system, machine)
+        assert installation.detect_target() is None
+
+
+class TestUpgradeInstruction:
+    def test_standalone_returns_none(self):
+        assert installation.upgrade_instruction(installation.CHANNEL_STANDALONE) is None
+
+    @pytest.mark.parametrize(
+        "channel",
+        [
+            installation.CHANNEL_PIP,
+            installation.CHANNEL_PIPX,
+            installation.CHANNEL_UV_TOOL,
+            installation.CHANNEL_UV_PIP,
+            installation.CHANNEL_HOMEBREW,
+            installation.CHANNEL_DOCKER,
+            installation.CHANNEL_AQUA,
+            installation.CHANNEL_UNKNOWN,
+        ],
+    )
+    def test_channels_return_instruction(self, channel):
+        instruction = installation.upgrade_instruction(channel)
+        assert isinstance(instruction, str) and instruction
+
+
+class TestSelfUpdateSupported:
+    def test_posix_supported(self, monkeypatch):
+        monkeypatch.setattr(installation.os, "name", "posix")
+        assert installation.self_update_supported() is True
+
+    def test_windows_not_supported(self, monkeypatch):
+        monkeypatch.setattr(installation.os, "name", "nt")
+        assert installation.self_update_supported() is False

--- a/cloudsmith_cli/core/tests/test_self_update.py
+++ b/cloudsmith_cli/core/tests/test_self_update.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for cloudsmith_cli.core.self_update.
+
+The self-update primitives are exercised against real files in a temp tree
+(checksum, extraction, atomic swap). The network download is stubbed so no
+test touches a remote.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tarfile
+import zipfile
+
+import pytest
+
+from cloudsmith_cli.core import self_update
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        digest.update(handle.read())
+    return digest.hexdigest()
+
+
+class TestVerifySha256:
+    def test_match(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"hello")
+        self_update.verify_sha256(str(f), _sha256(str(f)))
+
+    def test_match_uppercase_and_whitespace(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"hello")
+        self_update.verify_sha256(str(f), f"  {_sha256(str(f)).upper()}  ")
+
+    def test_mismatch(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"hello")
+        with pytest.raises(self_update.SelfUpdateError, match="checksum mismatch"):
+            self_update.verify_sha256(str(f), "0" * 64)
+
+
+class TestExtractArchive:
+    def test_targz(self, tmp_path):
+        member = tmp_path / "cloudsmith"
+        member.write_text("binary")
+        archive = tmp_path / "bundle.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(member, arcname="cloudsmith")
+        dest = tmp_path / "out"
+        self_update.extract_archive(str(archive), str(dest))
+        assert (dest / "cloudsmith").read_text() == "binary"
+
+    def test_zip(self, tmp_path):
+        archive = tmp_path / "bundle.zip"
+        with zipfile.ZipFile(archive, "w") as z:
+            z.writestr("cloudsmith", "binary")
+        dest = tmp_path / "out"
+        self_update.extract_archive(str(archive), str(dest))
+        assert (dest / "cloudsmith").read_text() == "binary"
+
+
+class TestSwapInstallDir:
+    def test_success(self, tmp_path):
+        install = tmp_path / "install"
+        install.mkdir()
+        (install / "old").write_text("old")
+        staging = tmp_path / "install.new"
+        staging.mkdir()
+        (staging / "new").write_text("new")
+
+        old_dir = self_update.swap_install_dir(str(install), str(staging))
+
+        assert (install / "new").exists()
+        assert not (install / "old").exists()
+        assert os.path.exists(old_dir)
+
+    def test_rollback_on_failure(self, tmp_path, monkeypatch):
+        install = tmp_path / "install"
+        install.mkdir()
+        (install / "keep").write_text("keep")
+        staging = tmp_path / "install.new"
+        staging.mkdir()
+
+        real_rename = os.rename
+        calls = {"n": 0}
+
+        def flaky_rename(src, dst):
+            calls["n"] += 1
+            # First rename (install -> .old) succeeds; second (.new -> install)
+            # fails; the rollback rename must restore the original.
+            if calls["n"] == 2:
+                raise OSError("boom")
+            return real_rename(src, dst)
+
+        monkeypatch.setattr(self_update.os, "rename", flaky_rename)
+        with pytest.raises(OSError, match="boom"):
+            self_update.swap_install_dir(str(install), str(staging))
+
+        assert (install / "keep").read_text() == "keep"
+
+    def test_rollback_when_executable_missing_after_swap(self, tmp_path):
+        # A staging dir without the executable must not become the install; the
+        # original must be restored so a botched bundle never empties the dir.
+        install = tmp_path / "install"
+        install.mkdir()
+        (install / "cloudsmith").write_text("old-exe")
+        (install / "_internal").mkdir()
+        staging = tmp_path / "install.new"
+        staging.mkdir()
+        (staging / "unexpected").write_text("no exe here")
+
+        with pytest.raises(self_update.SelfUpdateError, match="missing cloudsmith"):
+            self_update.swap_install_dir(
+                str(install), str(staging), executable_name="cloudsmith"
+            )
+
+        # Original install fully intact.
+        assert (install / "cloudsmith").read_text() == "old-exe"
+        assert (install / "_internal").is_dir()
+
+    def test_failed_restore_preserves_old_and_reports_path(self, tmp_path, monkeypatch):
+        # If the swap fails AND the restore also fails, the old install must be
+        # preserved at <install>.old and the error must point the user to it.
+        install = tmp_path / "install"
+        install.mkdir()
+        (install / "keep").write_text("keep")
+        staging = tmp_path / "install.new"
+        staging.mkdir()
+
+        real_rename = os.rename
+        calls = {"n": 0}
+
+        def flaky_rename(src, dst):
+            calls["n"] += 1
+            # 1: install -> .old (ok); 2: .new -> install (fail);
+            # 3: .old -> install restore (fail).
+            if calls["n"] in (2, 3):
+                raise OSError(f"boom{calls['n']}")
+            return real_rename(src, dst)
+
+        monkeypatch.setattr(self_update.os, "rename", flaky_rename)
+        with pytest.raises(self_update.SelfUpdateError, match="preserved at"):
+            self_update.swap_install_dir(str(install), str(staging))
+
+        old_dir = tmp_path / "install.old"
+        assert (old_dir / "keep").read_text() == "keep"
+
+
+class TestFindBundleRoot:
+    def test_flat_layout(self, tmp_path):
+        (tmp_path / "cloudsmith").write_text("exe")
+        assert self_update.find_bundle_root(str(tmp_path), "cloudsmith") == str(
+            tmp_path
+        )
+
+    def test_wrapped_layout(self, tmp_path):
+        # The real release archives wrap the bundle in a top-level directory.
+        wrapper = tmp_path / "cloudsmith"
+        wrapper.mkdir()
+        (wrapper / "cloudsmith").write_text("exe")
+        (wrapper / "_internal").mkdir()
+        assert self_update.find_bundle_root(str(tmp_path), "cloudsmith") == str(wrapper)
+
+    def test_missing_executable_raises(self, tmp_path):
+        (tmp_path / "somedir").mkdir()
+        with pytest.raises(self_update.SelfUpdateError, match="no cloudsmith"):
+            self_update.find_bundle_root(str(tmp_path), "cloudsmith")
+
+
+class TestPerformSelfUpdate:
+    def _make_bundle(self, tmp_path, exe_name="cloudsmith", wrap=False):
+        """Build a release tar.gz.
+
+        ``wrap=True`` nests members under a top-level ``cloudsmith/`` directory,
+        matching what the release workflow publishes; ``wrap=False`` puts them
+        at the archive root (flat).
+        """
+        staging = tmp_path / "staging"
+        base = staging / "cloudsmith" if wrap else staging
+        base.mkdir(parents=True)
+        (base / exe_name).write_text("new-binary")
+        (base / "_internal").mkdir()
+        (base / "_internal" / "data").write_text("dep")
+        archive = tmp_path / "bundle.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            for child in sorted(staging.iterdir()):
+                tar.add(child, arcname=child.name)
+        shutil.rmtree(staging)
+        return archive
+
+    def test_missing_fields(self):
+        with pytest.raises(self_update.SelfUpdateError, match="missing fields"):
+            self_update.perform_self_update({"url": "http://x/a.tar.gz"})
+
+    def test_windows_refused(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(self_update.os, "name", "nt")
+        exe = tmp_path / "install" / "cloudsmith"
+        exe.parent.mkdir()
+        exe.write_text("x")
+        with pytest.raises(self_update.SelfUpdateError, match="Windows"):
+            self_update.perform_self_update(
+                {"url": "http://x/a.tar.gz", "sha256": "0" * 64},
+                executable_path=str(exe),
+            )
+
+    @pytest.mark.parametrize("wrap", [False, True], ids=["flat", "wrapped"])
+    def test_happy_path(self, tmp_path, monkeypatch, wrap):
+        install = tmp_path / "install"
+        install.mkdir()
+        exe = install / "cloudsmith"
+        exe.write_text("old-binary")
+
+        archive = self._make_bundle(tmp_path, wrap=wrap)
+        expected_sha = _sha256(str(archive))
+
+        def fake_download(url, dest_path, session=None, timeout=None):
+            shutil.copyfile(str(archive), dest_path)
+
+        monkeypatch.setattr(self_update, "download_archive", fake_download)
+
+        self_update.perform_self_update(
+            {"url": "http://x/bundle.tar.gz", "sha256": expected_sha},
+            executable_path=str(exe),
+        )
+        # The executable is a file directly in install_dir (no double-nesting),
+        # and its sibling data came along.
+        assert exe.is_file()
+        assert exe.read_text() == "new-binary"
+        assert (install / "_internal" / "data").read_text() == "dep"
+        assert not (install / "cloudsmith").is_dir()
+        # No scratch directories are left behind next to the install.
+        assert not (tmp_path / "install.new").exists()
+        assert not (tmp_path / "install.extract").exists()
+        assert not (tmp_path / "install.old").exists()
+
+    def test_missing_executable_in_bundle(self, tmp_path, monkeypatch):
+        install = tmp_path / "install"
+        install.mkdir()
+        exe = install / "cloudsmith"
+        exe.write_text("old-binary")
+
+        # Bundle contains a differently-named executable.
+        archive = self._make_bundle(tmp_path, exe_name="not-cloudsmith")
+        expected_sha = _sha256(str(archive))
+
+        def fake_download(url, dest_path, session=None, timeout=None):
+            shutil.copyfile(str(archive), dest_path)
+
+        monkeypatch.setattr(self_update, "download_archive", fake_download)
+
+        with pytest.raises(self_update.SelfUpdateError, match="no cloudsmith"):
+            self_update.perform_self_update(
+                {"url": "http://x/bundle.tar.gz", "sha256": expected_sha},
+                executable_path=str(exe),
+            )
+        # The original install must remain intact after a failed update.
+        assert exe.read_text() == "old-binary"

--- a/cloudsmith_cli/core/tests/test_update_check.py
+++ b/cloudsmith_cli/core/tests/test_update_check.py
@@ -1,9 +1,10 @@
 # Copyright 2026 Cloudsmith Ltd
 """Tests for cloudsmith_cli.core.update_check.
 
-These cover the decision about when to fetch, the manifest fetch/parse, the
-once-a-day "update available" notice and its suppression, and state
-persistence. The network is stubbed throughout via a fake requests session.
+Two decoupled rhythms are exercised: the daily *fetch* (gated by
+``last_checked_at`` + the disable controls) and the *notice* (gated by the
+invariant ``last_notified_at < last_checked_at`` + presentation suppressors).
+The network is stubbed throughout via a fake requests session.
 """
 
 from __future__ import annotations
@@ -39,9 +40,14 @@ def state_path(tmp_path, monkeypatch):
     return path
 
 
-def _write_state(path, last_check_at, latest_version=CURRENT_VERSION):
+def _write_state(path, *, last_checked_at=None, last_notified_at=None, latest_version):
+    state = {"latest_version": latest_version}
+    if last_checked_at is not None:
+        state["last_checked_at"] = last_checked_at
+    if last_notified_at is not None:
+        state["last_notified_at"] = last_notified_at
     with open(path, "w", encoding="utf-8") as f:
-        json.dump({"last_check_at": last_check_at, "latest_version": latest_version}, f)
+        json.dump(state, f)
 
 
 def _read_state(path):
@@ -49,12 +55,18 @@ def _read_state(path):
         return json.load(f)
 
 
-class _FakeSession:
-    """A stand-in requests session.
+class _FakeResponse:
+    def __init__(self, text, status=200):
+        self.text = text
+        self.status = status
 
-    Records whether ``get`` was called and returns a manifest body, or raises a
-    ``requests.RequestException``, standing in for a successful or failed fetch.
-    """
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise requests.HTTPError(f"status {self.status}")
+
+
+class _FakeSession:
+    """A stand-in requests session recording whether ``get`` was called."""
 
     def __init__(self, *, version_str=CURRENT_VERSION, fails=False):
         self.version = version_str
@@ -68,29 +80,18 @@ class _FakeSession:
         return _FakeResponse(f"schema=1\nversion={self.version}\n")
 
 
-class _FakeResponse:
-    def __init__(self, text, status=200):
-        self.text = text
-        self.status = status
-
-    def raise_for_status(self):
-        if self.status >= 400:
-            raise requests.HTTPError(f"status {self.status}")
-
-
 def _run(session, *, now=NOW, no_check_flag=False, config_value=True, env=None):
-    """Drive the real decision + fetch/notify path with a fake session.
+    """Drive the real fetch decision synchronously with a fake session.
 
-    Mirrors ``arm`` minus the Click context: if a fetch is due, run the real
-    ``run_background_check`` synchronously; if we already know we are behind,
-    notify without fetching. Returns the session so tests can assert on it.
+    Mirrors the fetch half of ``arm``: if a check is due, either bump (already
+    behind) or run the real ``run_background_check``. Returns the session.
     """
     env = {} if env is None else env
     if not update_check.should_check_for_update(
         no_check_flag=no_check_flag, config_value=config_value, env=env, now=now
     ):
         return session
-    if update_check.should_notify():
+    if update_check.newer_version_known(update_check.read_latest_version()):
         update_check.record_check(update_check.read_latest_version(), now=now)
         return session
     update_check.run_background_check(session, now=now)
@@ -98,141 +99,157 @@ def _run(session, *, now=NOW, no_check_flag=False, config_value=True, env=None):
 
 
 # ---------------------------------------------------------------------------
-# The six required scenarios
+# The daily fetch decision + state
 # ---------------------------------------------------------------------------
 
 
-class TestUpdateCheckDecision:
-    def test_no_state_file_triggers_check_and_creates_file(self, state_path):
-        """1. No state file → check runs and the file is created."""
+class TestFetchDecision:
+    def test_no_state_file_triggers_fetch_and_creates_file(self, state_path):
         assert not os.path.exists(state_path)
         session = _run(_FakeSession(version_str=CURRENT_VERSION))
         assert session.called is True
         assert os.path.exists(state_path)
-        assert _read_state(state_path)["last_check_at"] == NOW
+        assert _read_state(state_path)["last_checked_at"] == NOW
 
-    def test_stale_state_triggers_check_and_updates_file(self, state_path):
-        """2. Stale timestamp → check runs and the file is updated."""
-        _write_state(state_path, last_check_at=NOW - (DAY * 3))
+    def test_stale_state_triggers_fetch_and_updates_file(self, state_path):
+        _write_state(
+            state_path, last_checked_at=NOW - (DAY * 3), latest_version=CURRENT_VERSION
+        )
         session = _run(_FakeSession(version_str=CURRENT_VERSION))
         assert session.called is True
-        assert _read_state(state_path)["last_check_at"] == NOW
+        assert _read_state(state_path)["last_checked_at"] == NOW
 
-    def test_recent_state_skips_check_and_leaves_file(self, state_path):
-        """3. Recent timestamp → check does not run and the file is untouched."""
+    def test_recent_state_skips_fetch_and_leaves_file(self, state_path):
         recent = NOW - 60.0
-        _write_state(state_path, last_check_at=recent)
+        _write_state(state_path, last_checked_at=recent, latest_version=CURRENT_VERSION)
         before = os.stat(state_path).st_mtime_ns
         session = _run(_FakeSession(version_str=CURRENT_VERSION))
         assert session.called is False
-        assert _read_state(state_path)["last_check_at"] == recent
+        assert _read_state(state_path)["last_checked_at"] == recent
         assert os.stat(state_path).st_mtime_ns == before
 
-    def test_stale_but_newer_known_notifies_without_fetch(self, state_path):
-        """4. Stale timestamp with a cached newer version → notify, no fetch.
-
-        The timestamp is bumped (throttling the next notice), but no network
-        fetch happens because we already know we are behind.
-        """
+    def test_stale_but_newer_known_bumps_without_fetch(self, state_path):
+        """Already behind → bump last_checked_at (re-arm notice), no fetch."""
         _write_state(
-            state_path, last_check_at=NOW - (DAY * 3), latest_version=NEWER_VERSION
+            state_path, last_checked_at=NOW - (DAY * 3), latest_version=NEWER_VERSION
         )
         session = _run(_FakeSession(version_str=NEWER_VERSION))
         assert session.called is False
         after = _read_state(state_path)
-        assert after["last_check_at"] == NOW
+        assert after["last_checked_at"] == NOW
         assert after["latest_version"] == NEWER_VERSION
 
-    def test_no_state_file_failed_check_does_not_create_file(self, state_path):
-        """5. No state file and the check fails → the file is not created."""
+    def test_no_state_file_failed_fetch_does_not_create_file(self, state_path):
         assert not os.path.exists(state_path)
         session = _run(_FakeSession(fails=True))
         assert session.called is True
         assert not os.path.exists(state_path)
 
-    def test_stale_state_failed_check_does_not_update_file(self, state_path):
-        """6. Stale state and the check fails → the file is not updated."""
+    def test_stale_state_failed_fetch_does_not_update_file(self, state_path):
         stale = NOW - (DAY * 3)
-        _write_state(state_path, last_check_at=stale)
+        _write_state(state_path, last_checked_at=stale, latest_version=CURRENT_VERSION)
         session = _run(_FakeSession(fails=True))
         assert session.called is True
-        assert _read_state(state_path)["last_check_at"] == stale
+        assert _read_state(state_path)["last_checked_at"] == stale
 
 
 # ---------------------------------------------------------------------------
-# Additional coverage
+# The notice invariant + daily re-nag
 # ---------------------------------------------------------------------------
-
-
-class TestNoticeThrottle:
-    """The once-a-day throttle via the shared last_check_at timestamp."""
-
-    def test_behind_and_recent_stays_silent(self, state_path):
-        """Behind but checked recently → not due, file untouched, no fetch."""
-        recent = NOW - 60.0
-        _write_state(state_path, last_check_at=recent, latest_version=NEWER_VERSION)
-        before = os.stat(state_path).st_mtime_ns
-        session = _run(_FakeSession(version_str=NEWER_VERSION))
-        assert session.called is False
-        assert os.stat(state_path).st_mtime_ns == before
-
-    def test_behind_and_stale_bumps_then_throttles(self, state_path):
-        """Behind and stale → bump timestamp; an immediate re-run is throttled."""
-        _write_state(
-            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
-        )
-        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW)
-        assert _read_state(state_path)["last_check_at"] == NOW
-
-        # Same day, a minute later: not due, state untouched.
-        before = os.stat(state_path).st_mtime_ns
-        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW + 60.0)
-        assert os.stat(state_path).st_mtime_ns == before
-
-        # A day later: due again, keeps the cached newer version.
-        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW + DAY + 60.0)
-        assert _read_state(state_path)["last_check_at"] == NOW + DAY + 60.0
-        assert _read_state(state_path)["latest_version"] == NEWER_VERSION
-
-    def test_disable_control_suppresses_everything(self, state_path):
-        """A disable control silences the fetch (and hence the notice)."""
-        _write_state(
-            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
-        )
-        before = os.stat(state_path).st_mtime_ns
-        session = _run(_FakeSession(version_str=NEWER_VERSION), config_value=False)
-        assert session.called is False
-        assert os.stat(state_path).st_mtime_ns == before
 
 
 class TestShouldNotify:
-    def test_true_when_cached_version_newer(self, state_path):
-        _write_state(state_path, last_check_at=NOW, latest_version=NEWER_VERSION)
+    def test_true_when_behind_and_checked_since_notify(self, state_path):
+        _write_state(
+            state_path,
+            last_checked_at=NOW,
+            last_notified_at=NOW - 10,
+            latest_version=NEWER_VERSION,
+        )
         assert update_check.should_notify() is True
 
     def test_false_when_up_to_date(self, state_path):
-        _write_state(state_path, last_check_at=NOW, latest_version=CURRENT_VERSION)
+        _write_state(
+            state_path,
+            last_checked_at=NOW,
+            last_notified_at=0,
+            latest_version=CURRENT_VERSION,
+        )
         assert update_check.should_notify() is False
+
+    def test_false_when_already_notified_for_this_check(self, state_path):
+        """last_notified_at == last_checked_at → disarmed until the next check."""
+        _write_state(
+            state_path,
+            last_checked_at=NOW,
+            last_notified_at=NOW,
+            latest_version=NEWER_VERSION,
+        )
+        assert update_check.should_notify() is False
+
+    def test_true_when_never_notified(self, state_path):
+        _write_state(state_path, last_checked_at=NOW, latest_version=NEWER_VERSION)
+        assert update_check.should_notify() is True
 
     def test_false_when_no_state(self, state_path):
         assert update_check.should_notify() is False
 
-    def test_accepts_explicit_state(self, state_path):
-        assert update_check.should_notify({"latest_version": NEWER_VERSION}) is True
-        assert update_check.should_notify({"latest_version": OLDER_VERSION}) is False
-
     def test_current_version_override(self, state_path):
-        state = {"latest_version": "1.5.0"}
+        state = {
+            "latest_version": "1.5.0",
+            "last_checked_at": NOW,
+            "last_notified_at": 0,
+        }
         assert update_check.should_notify(state, current_version="1.0.0") is True
         assert update_check.should_notify(state, current_version="2.0.0") is False
 
 
-class TestShouldCheckForUpdate:
-    """should_check_for_update gates purely on disabled + freshness now."""
+class TestDailyRenag:
+    """The full notify → disarm → re-arm-next-day cycle."""
 
+    def _notify_cycle(self, state_path, now):
+        """Mirror _finish_and_notify's notify branch (assuming not suppressed)."""
+        state = update_check.read_cached_state()
+        if update_check.should_notify(state):
+            update_check.record_notified(now=now)
+            return True
+        return False
+
+    def test_notify_then_throttle_then_renag(self, state_path):
+        # Behind, fetched today, never notified → notify.
+        _write_state(state_path, last_checked_at=NOW, latest_version=NEWER_VERSION)
+        assert self._notify_cycle(state_path, NOW) is True
+        assert _read_state(state_path)["last_notified_at"] == NOW
+
+        # Same check, later the same run/day → disarmed.
+        assert self._notify_cycle(state_path, NOW + 60) is False
+
+        # A day passes: a fresh check bumps last_checked_at → re-armed.
+        update_check.record_check(NEWER_VERSION, now=NOW + DAY + 60)
+        assert self._notify_cycle(state_path, NOW + DAY + 120) is True
+
+
+class TestMissedWarningRegression:
+    """A fetch that could not notify must not consume the notice budget."""
+
+    def test_suppressed_fetch_does_not_advance_notified(self, state_path):
+        # Cold start: a fetch runs (as it would under -F json / non-TTY) and
+        # discovers a newer version, advancing last_checked_at only.
+        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW)
+        state = _read_state(state_path)
+        assert state["last_checked_at"] == NOW
+        assert state["latest_version"] == NEWER_VERSION
+        assert "last_notified_at" not in state
+
+        # A later interactive run (no new fetch needed) still notifies, because
+        # last_notified_at (absent → 0) < last_checked_at.
+        assert update_check.should_notify() is True
+
+
+class TestShouldCheckForUpdate:
     def test_due_when_stale_even_if_behind(self, state_path):
         _write_state(
-            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
+            state_path, last_checked_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
         )
         assert (
             update_check.should_check_for_update(
@@ -242,7 +259,9 @@ class TestShouldCheckForUpdate:
         )
 
     def test_not_due_when_recent(self, state_path):
-        _write_state(state_path, last_check_at=NOW - 60.0)
+        _write_state(
+            state_path, last_checked_at=NOW - 60.0, latest_version=CURRENT_VERSION
+        )
         assert (
             update_check.should_check_for_update(
                 no_check_flag=False, config_value=True, env={}, now=NOW
@@ -260,7 +279,7 @@ class TestShouldCheckForUpdate:
 
 
 class TestDisableControls:
-    """The --no-check-update flag, env vars and config key suppress the check."""
+    """The --no-check-update flag, env vars and config key suppress the fetch."""
 
     def test_no_check_flag_suppresses(self, state_path):
         session = _run(_FakeSession(), no_check_flag=True)
@@ -327,13 +346,30 @@ class TestNewerVersionKnown:
 
 
 class TestStatePersistence:
-    def test_record_and_read_round_trip(self, state_path):
+    def test_record_check_preserves_notified(self, state_path):
+        _write_state(
+            state_path,
+            last_checked_at=1.0,
+            last_notified_at=500.0,
+            latest_version=OLDER_VERSION,
+        )
         update_check.record_check(NEWER_VERSION, now=NOW)
-        assert update_check.read_last_check_time() == NOW
-        assert update_check.read_latest_version() == NEWER_VERSION
+        state = _read_state(state_path)
+        assert state["last_checked_at"] == NOW
+        assert state["latest_version"] == NEWER_VERSION
+        assert state["last_notified_at"] == 500.0
+
+    def test_record_notified_preserves_check(self, state_path):
+        _write_state(state_path, last_checked_at=NOW, latest_version=NEWER_VERSION)
+        update_check.record_notified(now=NOW + 5)
+        state = _read_state(state_path)
+        assert state["last_notified_at"] == NOW + 5
+        assert state["last_checked_at"] == NOW
+        assert state["latest_version"] == NEWER_VERSION
 
     def test_read_missing_file_returns_none(self, state_path):
         assert update_check.read_last_check_time() is None
+        assert update_check.read_last_notified_time() is None
         assert update_check.read_latest_version() is None
         assert update_check.read_cached_state() == {}
 
@@ -342,7 +378,6 @@ class TestStatePersistence:
             f.write("not json")
         assert update_check.read_cached_state() == {}
         assert update_check.read_last_check_time() is None
-        assert update_check.read_latest_version() is None
 
     def test_read_non_object_returns_empty(self, state_path):
         with open(state_path, "w", encoding="utf-8") as f:
@@ -356,13 +391,11 @@ class TestStatePersistence:
         assert os.path.exists(path)
 
     def test_record_swallows_storage_errors(self, tmp_path, monkeypatch):
-        # Point the state file at a path whose parent is a file, so makedirs fails.
         blocker = tmp_path / "blocker"
         blocker.write_text("x")
         path = str(blocker / "update_check.json")
         monkeypatch.setattr(update_check, "get_state_file_path", lambda: path)
-        # Must not raise.
-        update_check.record_check(CURRENT_VERSION, now=NOW)
+        update_check.record_check(CURRENT_VERSION, now=NOW)  # must not raise
         assert not os.path.exists(path)
 
 
@@ -433,16 +466,10 @@ class TestFetchLatestManifest:
         concrete = self._url().replace("latest", "1.27.0")
         with httpretty.enabled(allow_net_connect=False):
             httpretty.register_uri(
-                httpretty.GET,
-                self._url(),
-                status=302,
-                location=concrete,
+                httpretty.GET, self._url(), status=302, location=concrete
             )
             httpretty.register_uri(
-                httpretty.GET,
-                concrete,
-                body="version=1.27.0\n",
-                status=200,
+                httpretty.GET, concrete, body="version=1.27.0\n", status=200
             )
             manifest = update_check.fetch_latest_manifest(create_requests_session())
         assert manifest["version"] == "1.27.0"
@@ -476,10 +503,9 @@ class TestRunBackgroundCheck:
             _FakeSession(version_str=NEWER_VERSION), now=NOW
         )
         assert _read_state(state_path)["latest_version"] == NEWER_VERSION
-        assert _read_state(state_path)["last_check_at"] == NOW
+        assert _read_state(state_path)["last_checked_at"] == NOW
 
     def test_swallows_network_failure_and_records_nothing(self, state_path):
-        # Must not raise, and must not create the state file.
         update_check.run_background_check(_FakeSession(fails=True), now=NOW)
         assert not os.path.exists(state_path)
 
@@ -506,34 +532,45 @@ class TestNoticeSuppressed:
 
 
 class TestFinishAndNotify:
-    """Join-then-notify at command close."""
+    """Join-then-notify at command close, honouring presentation suppressors."""
 
-    def test_notifies_and_bumps_when_behind(self, state_path, capsys):
-        _write_state(
-            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
-        )
-        update_check._finish_and_notify(None, now=NOW)
+    class _Opts:
+        def __init__(self, output="pretty"):
+            self.output = output
+
+    @pytest.fixture(autouse=True)
+    def _tty(self, monkeypatch):
+        monkeypatch.setattr(update_check, "stderr_is_tty", lambda: True)
+
+    def test_notifies_and_stamps_when_behind(self, state_path, capsys):
+        _write_state(state_path, last_checked_at=NOW, latest_version=NEWER_VERSION)
+        update_check._finish_and_notify(None, self._Opts(), "list", now=NOW + 1)
         err = capsys.readouterr().err
         assert "new version" in err.lower()
         assert NEWER_VERSION in err
-        assert _read_state(state_path)["last_check_at"] == NOW
+        assert _read_state(state_path)["last_notified_at"] == NOW + 1
+
+    def test_silent_and_untouched_when_suppressed(self, state_path, capsys):
+        """JSON output suppresses the notice and does not stamp last_notified."""
+        _write_state(state_path, last_checked_at=NOW, latest_version=NEWER_VERSION)
+        update_check._finish_and_notify(None, self._Opts("json"), "list", now=NOW + 1)
+        assert capsys.readouterr().err == ""
+        assert "last_notified_at" not in _read_state(state_path)
 
     def test_silent_when_up_to_date(self, state_path, capsys):
-        _write_state(state_path, last_check_at=NOW, latest_version=CURRENT_VERSION)
-        update_check._finish_and_notify(None, now=NOW)
+        _write_state(state_path, last_checked_at=NOW, latest_version=CURRENT_VERSION)
+        update_check._finish_and_notify(None, self._Opts(), "list", now=NOW)
         assert capsys.readouterr().err == ""
 
     def test_joins_thread_before_reading_state(self, state_path, capsys):
-        """A thread that writes a newer version is joined, then the notice fires."""
         import threading
 
-        _write_state(state_path, last_check_at=NOW - (DAY * 2))
+        _write_state(state_path, last_checked_at=1.0, latest_version=CURRENT_VERSION)
 
         def writer():
             update_check.record_check(NEWER_VERSION, now=NOW)
 
         thread = threading.Thread(target=writer)
         thread.start()
-        update_check._finish_and_notify(thread, now=NOW + 1)
-        err = capsys.readouterr().err
-        assert NEWER_VERSION in err
+        update_check._finish_and_notify(thread, self._Opts(), "list", now=NOW + 1)
+        assert NEWER_VERSION in capsys.readouterr().err

--- a/cloudsmith_cli/core/tests/test_update_check.py
+++ b/cloudsmith_cli/core/tests/test_update_check.py
@@ -367,6 +367,25 @@ class TestStatePersistence:
         assert state["last_checked_at"] == NOW
         assert state["latest_version"] == NEWER_VERSION
 
+    def test_record_checked_and_notified_stamps_both(self, state_path):
+        _write_state(
+            state_path,
+            last_checked_at=1.0,
+            last_notified_at=2.0,
+            latest_version=OLDER_VERSION,
+        )
+        update_check.record_checked_and_notified(NEWER_VERSION, now=NOW)
+        state = _read_state(state_path)
+        assert state["last_checked_at"] == NOW
+        assert state["last_notified_at"] == NOW
+        assert state["latest_version"] == NEWER_VERSION
+
+    def test_record_checked_and_notified_disarms_notice(self, state_path):
+        # After an explicit check the background notice must stay silent:
+        # last_notified_at is not < last_checked_at.
+        update_check.record_checked_and_notified(NEWER_VERSION, now=NOW)
+        assert update_check.should_notify() is False
+
     def test_read_missing_file_returns_none(self, state_path):
         assert update_check.read_last_check_time() is None
         assert update_check.read_last_notified_time() is None
@@ -496,6 +515,23 @@ class TestFetchLatestManifest:
             with pytest.raises(requests.RequestException):
                 update_check.fetch_latest_manifest(create_requests_session(retries=0))
 
+    def test_env_override_template(self, monkeypatch):
+        import httpretty
+
+        from cloudsmith_cli.core.session import create_requests_session
+
+        override = "http://127.0.0.1:9/{target}/manifest.txt"
+        monkeypatch.setenv(update_check.MANIFEST_URL_TEMPLATE_ENV, override)
+        url = override.format(target="macos-arm64")
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.GET, url, body="version=9.9.9\n", status=200
+            )
+            manifest = update_check.fetch_latest_manifest(
+                create_requests_session(), target="macos-arm64"
+            )
+        assert manifest["version"] == "9.9.9"
+
 
 class TestRunBackgroundCheck:
     def test_records_on_success(self, state_path):
@@ -508,6 +544,53 @@ class TestRunBackgroundCheck:
     def test_swallows_network_failure_and_records_nothing(self, state_path):
         update_check.run_background_check(_FakeSession(fails=True), now=NOW)
         assert not os.path.exists(state_path)
+
+
+class TestUpdateActionLines:
+    """The notice's "how to update" lines depend on the install channel."""
+
+    def test_standalone_points_at_update_command(self, monkeypatch):
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(
+            installation, "detect_channel", lambda: installation.CHANNEL_STANDALONE
+        )
+        monkeypatch.setattr(installation, "self_update_supported", lambda: True)
+        assert update_check._update_action_lines() == [
+            "Run `cloudsmith update` to update."
+        ]
+
+    def test_standalone_windows_points_at_releases(self, monkeypatch):
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(
+            installation, "detect_channel", lambda: installation.CHANNEL_STANDALONE
+        )
+        monkeypatch.setattr(installation, "self_update_supported", lambda: False)
+        lines = update_check._update_action_lines()
+        assert lines[-1].strip() == installation.RELEASES_LATEST_URL
+        assert all("cloudsmith update" not in line for line in lines)
+
+    @pytest.mark.parametrize(
+        "channel, command",
+        [
+            ("pip", "pip install --upgrade cloudsmith-cli"),
+            ("pipx", "pipx upgrade cloudsmith-cli"),
+            ("homebrew", "brew update && brew upgrade cloudsmith-cli"),
+            ("unknown", "pip install --upgrade cloudsmith-cli"),
+        ],
+    )
+    def test_package_manager_command_on_its_own_line(
+        self, monkeypatch, channel, command
+    ):
+        from cloudsmith_cli.core import installation
+
+        monkeypatch.setattr(installation, "detect_channel", lambda: channel)
+        lines = update_check._update_action_lines()
+        # The command sits alone on the final line (indented) so it copies clean.
+        assert lines[0] == "To update, run:"
+        assert lines[-1] == f"  {command}"
+        assert all("cloudsmith update" not in line for line in lines)
 
 
 class TestNoticeSuppressed:

--- a/cloudsmith_cli/core/tests/test_update_check.py
+++ b/cloudsmith_cli/core/tests/test_update_check.py
@@ -1,0 +1,539 @@
+# Copyright 2026 Cloudsmith Ltd
+"""Tests for cloudsmith_cli.core.update_check.
+
+These cover the decision about when to fetch, the manifest fetch/parse, the
+once-a-day "update available" notice and its suppression, and state
+persistence. The network is stubbed throughout via a fake requests session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import requests
+import semver
+
+from cloudsmith_cli.core import update_check
+
+# A fixed "current" version so tests do not break when VERSION is bumped.
+CURRENT_VERSION = "1.26.0"
+NEWER_VERSION = "2.0.0"
+OLDER_VERSION = "1.0.0"
+
+DAY = update_check.DEFAULT_INTERVAL_SECONDS
+NOW = 1_000_000.0
+
+
+@pytest.fixture
+def state_path(tmp_path, monkeypatch):
+    """Point the state file at a temp location and pin the current version."""
+    path = str(tmp_path / "update_check.json")
+    monkeypatch.setattr(update_check, "get_state_file_path", lambda: path)
+    monkeypatch.setattr(
+        update_check.version,
+        "get_version_info",
+        lambda: semver.VersionInfo.parse(CURRENT_VERSION),
+    )
+    return path
+
+
+def _write_state(path, last_check_at, latest_version=CURRENT_VERSION):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"last_check_at": last_check_at, "latest_version": latest_version}, f)
+
+
+def _read_state(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class _FakeSession:
+    """A stand-in requests session.
+
+    Records whether ``get`` was called and returns a manifest body, or raises a
+    ``requests.RequestException``, standing in for a successful or failed fetch.
+    """
+
+    def __init__(self, *, version_str=CURRENT_VERSION, fails=False):
+        self.version = version_str
+        self.fails = fails
+        self.called = False
+
+    def get(self, url, timeout=None):
+        self.called = True
+        if self.fails:
+            raise requests.ConnectionError("network down")
+        return _FakeResponse(f"schema=1\nversion={self.version}\n")
+
+
+class _FakeResponse:
+    def __init__(self, text, status=200):
+        self.text = text
+        self.status = status
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise requests.HTTPError(f"status {self.status}")
+
+
+def _run(session, *, now=NOW, no_check_flag=False, config_value=True, env=None):
+    """Drive the real decision + fetch/notify path with a fake session.
+
+    Mirrors ``arm`` minus the Click context: if a fetch is due, run the real
+    ``run_background_check`` synchronously; if we already know we are behind,
+    notify without fetching. Returns the session so tests can assert on it.
+    """
+    env = {} if env is None else env
+    if not update_check.should_check_for_update(
+        no_check_flag=no_check_flag, config_value=config_value, env=env, now=now
+    ):
+        return session
+    if update_check.should_notify():
+        update_check.record_check(update_check.read_latest_version(), now=now)
+        return session
+    update_check.run_background_check(session, now=now)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# The six required scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCheckDecision:
+    def test_no_state_file_triggers_check_and_creates_file(self, state_path):
+        """1. No state file → check runs and the file is created."""
+        assert not os.path.exists(state_path)
+        session = _run(_FakeSession(version_str=CURRENT_VERSION))
+        assert session.called is True
+        assert os.path.exists(state_path)
+        assert _read_state(state_path)["last_check_at"] == NOW
+
+    def test_stale_state_triggers_check_and_updates_file(self, state_path):
+        """2. Stale timestamp → check runs and the file is updated."""
+        _write_state(state_path, last_check_at=NOW - (DAY * 3))
+        session = _run(_FakeSession(version_str=CURRENT_VERSION))
+        assert session.called is True
+        assert _read_state(state_path)["last_check_at"] == NOW
+
+    def test_recent_state_skips_check_and_leaves_file(self, state_path):
+        """3. Recent timestamp → check does not run and the file is untouched."""
+        recent = NOW - 60.0
+        _write_state(state_path, last_check_at=recent)
+        before = os.stat(state_path).st_mtime_ns
+        session = _run(_FakeSession(version_str=CURRENT_VERSION))
+        assert session.called is False
+        assert _read_state(state_path)["last_check_at"] == recent
+        assert os.stat(state_path).st_mtime_ns == before
+
+    def test_stale_but_newer_known_notifies_without_fetch(self, state_path):
+        """4. Stale timestamp with a cached newer version → notify, no fetch.
+
+        The timestamp is bumped (throttling the next notice), but no network
+        fetch happens because we already know we are behind.
+        """
+        _write_state(
+            state_path, last_check_at=NOW - (DAY * 3), latest_version=NEWER_VERSION
+        )
+        session = _run(_FakeSession(version_str=NEWER_VERSION))
+        assert session.called is False
+        after = _read_state(state_path)
+        assert after["last_check_at"] == NOW
+        assert after["latest_version"] == NEWER_VERSION
+
+    def test_no_state_file_failed_check_does_not_create_file(self, state_path):
+        """5. No state file and the check fails → the file is not created."""
+        assert not os.path.exists(state_path)
+        session = _run(_FakeSession(fails=True))
+        assert session.called is True
+        assert not os.path.exists(state_path)
+
+    def test_stale_state_failed_check_does_not_update_file(self, state_path):
+        """6. Stale state and the check fails → the file is not updated."""
+        stale = NOW - (DAY * 3)
+        _write_state(state_path, last_check_at=stale)
+        session = _run(_FakeSession(fails=True))
+        assert session.called is True
+        assert _read_state(state_path)["last_check_at"] == stale
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage
+# ---------------------------------------------------------------------------
+
+
+class TestNoticeThrottle:
+    """The once-a-day throttle via the shared last_check_at timestamp."""
+
+    def test_behind_and_recent_stays_silent(self, state_path):
+        """Behind but checked recently → not due, file untouched, no fetch."""
+        recent = NOW - 60.0
+        _write_state(state_path, last_check_at=recent, latest_version=NEWER_VERSION)
+        before = os.stat(state_path).st_mtime_ns
+        session = _run(_FakeSession(version_str=NEWER_VERSION))
+        assert session.called is False
+        assert os.stat(state_path).st_mtime_ns == before
+
+    def test_behind_and_stale_bumps_then_throttles(self, state_path):
+        """Behind and stale → bump timestamp; an immediate re-run is throttled."""
+        _write_state(
+            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
+        )
+        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW)
+        assert _read_state(state_path)["last_check_at"] == NOW
+
+        # Same day, a minute later: not due, state untouched.
+        before = os.stat(state_path).st_mtime_ns
+        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW + 60.0)
+        assert os.stat(state_path).st_mtime_ns == before
+
+        # A day later: due again, keeps the cached newer version.
+        _run(_FakeSession(version_str=NEWER_VERSION), now=NOW + DAY + 60.0)
+        assert _read_state(state_path)["last_check_at"] == NOW + DAY + 60.0
+        assert _read_state(state_path)["latest_version"] == NEWER_VERSION
+
+    def test_disable_control_suppresses_everything(self, state_path):
+        """A disable control silences the fetch (and hence the notice)."""
+        _write_state(
+            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
+        )
+        before = os.stat(state_path).st_mtime_ns
+        session = _run(_FakeSession(version_str=NEWER_VERSION), config_value=False)
+        assert session.called is False
+        assert os.stat(state_path).st_mtime_ns == before
+
+
+class TestShouldNotify:
+    def test_true_when_cached_version_newer(self, state_path):
+        _write_state(state_path, last_check_at=NOW, latest_version=NEWER_VERSION)
+        assert update_check.should_notify() is True
+
+    def test_false_when_up_to_date(self, state_path):
+        _write_state(state_path, last_check_at=NOW, latest_version=CURRENT_VERSION)
+        assert update_check.should_notify() is False
+
+    def test_false_when_no_state(self, state_path):
+        assert update_check.should_notify() is False
+
+    def test_accepts_explicit_state(self, state_path):
+        assert update_check.should_notify({"latest_version": NEWER_VERSION}) is True
+        assert update_check.should_notify({"latest_version": OLDER_VERSION}) is False
+
+    def test_current_version_override(self, state_path):
+        state = {"latest_version": "1.5.0"}
+        assert update_check.should_notify(state, current_version="1.0.0") is True
+        assert update_check.should_notify(state, current_version="2.0.0") is False
+
+
+class TestShouldCheckForUpdate:
+    """should_check_for_update gates purely on disabled + freshness now."""
+
+    def test_due_when_stale_even_if_behind(self, state_path):
+        _write_state(
+            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
+        )
+        assert (
+            update_check.should_check_for_update(
+                no_check_flag=False, config_value=True, env={}, now=NOW
+            )
+            is True
+        )
+
+    def test_not_due_when_recent(self, state_path):
+        _write_state(state_path, last_check_at=NOW - 60.0)
+        assert (
+            update_check.should_check_for_update(
+                no_check_flag=False, config_value=True, env={}, now=NOW
+            )
+            is False
+        )
+
+    def test_due_when_no_state(self, state_path):
+        assert (
+            update_check.should_check_for_update(
+                no_check_flag=False, config_value=True, env={}, now=NOW
+            )
+            is True
+        )
+
+
+class TestDisableControls:
+    """The --no-check-update flag, env vars and config key suppress the check."""
+
+    def test_no_check_flag_suppresses(self, state_path):
+        session = _run(_FakeSession(), no_check_flag=True)
+        assert session.called is False
+        assert not os.path.exists(state_path)
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes"])
+    def test_env_var_truthy_suppresses(self, state_path, value):
+        session = _run(_FakeSession(), env={update_check.NO_UPDATE_CHECK_ENV: value})
+        assert session.called is False
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", ""])
+    def test_env_var_falsey_does_not_suppress(self, state_path, value):
+        session = _run(_FakeSession(), env={update_check.NO_UPDATE_CHECK_ENV: value})
+        assert session.called is True
+
+    def test_ci_env_suppresses(self, state_path):
+        session = _run(_FakeSession(), env={"CI": "true"})
+        assert session.called is False
+
+    def test_config_false_suppresses(self, state_path):
+        session = _run(_FakeSession(), config_value=False)
+        assert session.called is False
+
+    def test_flag_wins_over_enabled_config(self, state_path):
+        session = _run(_FakeSession(), no_check_flag=True, config_value=True)
+        assert session.called is False
+
+
+class TestIsCheckDue:
+    def test_none_is_due(self):
+        assert update_check.is_check_due(None, now=NOW) is True
+
+    def test_invalid_is_due(self):
+        assert update_check.is_check_due("not-a-number", now=NOW) is True
+
+    def test_fresh_is_not_due(self):
+        assert update_check.is_check_due(NOW - 60.0, now=NOW) is False
+
+    def test_stale_is_due(self):
+        assert update_check.is_check_due(NOW - DAY - 1, now=NOW) is True
+
+    def test_exact_boundary_is_due(self):
+        assert update_check.is_check_due(NOW - DAY, now=NOW) is True
+
+
+class TestNewerVersionKnown:
+    def test_newer_cached_version_is_known(self):
+        assert update_check.newer_version_known(NEWER_VERSION, CURRENT_VERSION) is True
+
+    def test_older_cached_version_is_not_newer(self):
+        assert update_check.newer_version_known(OLDER_VERSION, CURRENT_VERSION) is False
+
+    def test_equal_cached_version_is_not_newer(self):
+        assert (
+            update_check.newer_version_known(CURRENT_VERSION, CURRENT_VERSION) is False
+        )
+
+    def test_missing_cached_version_is_not_newer(self):
+        assert update_check.newer_version_known(None, CURRENT_VERSION) is False
+
+    def test_unparsable_cached_version_is_not_newer(self):
+        assert update_check.newer_version_known("garbage", CURRENT_VERSION) is False
+
+
+class TestStatePersistence:
+    def test_record_and_read_round_trip(self, state_path):
+        update_check.record_check(NEWER_VERSION, now=NOW)
+        assert update_check.read_last_check_time() == NOW
+        assert update_check.read_latest_version() == NEWER_VERSION
+
+    def test_read_missing_file_returns_none(self, state_path):
+        assert update_check.read_last_check_time() is None
+        assert update_check.read_latest_version() is None
+        assert update_check.read_cached_state() == {}
+
+    def test_read_corrupt_file_returns_empty(self, state_path):
+        with open(state_path, "w", encoding="utf-8") as f:
+            f.write("not json")
+        assert update_check.read_cached_state() == {}
+        assert update_check.read_last_check_time() is None
+        assert update_check.read_latest_version() is None
+
+    def test_read_non_object_returns_empty(self, state_path):
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump([1, 2, 3], f)
+        assert update_check.read_cached_state() == {}
+
+    def test_record_creates_parent_directory(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "nested" / "dir" / "update_check.json")
+        monkeypatch.setattr(update_check, "get_state_file_path", lambda: path)
+        update_check.record_check(CURRENT_VERSION, now=NOW)
+        assert os.path.exists(path)
+
+    def test_record_swallows_storage_errors(self, tmp_path, monkeypatch):
+        # Point the state file at a path whose parent is a file, so makedirs fails.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        path = str(blocker / "update_check.json")
+        monkeypatch.setattr(update_check, "get_state_file_path", lambda: path)
+        # Must not raise.
+        update_check.record_check(CURRENT_VERSION, now=NOW)
+        assert not os.path.exists(path)
+
+
+class TestParseManifest:
+    def test_parses_key_value_lines(self):
+        text = "version=1.27.0\ntarget=linux-x86_64-gnu\n"
+        manifest = update_check.parse_manifest(text)
+        assert manifest["version"] == "1.27.0"
+        assert manifest["target"] == "linux-x86_64-gnu"
+
+    def test_skips_comments_and_blanks(self):
+        text = "# a comment\n\n  \nversion=1.27.0\n"
+        assert update_check.parse_manifest(text) == {"version": "1.27.0"}
+
+    def test_ignores_schema_but_keeps_it(self):
+        text = "schema=1\nversion=1.27.0\n"
+        manifest = update_check.parse_manifest(text)
+        assert manifest["schema"] == "1"
+        assert manifest["version"] == "1.27.0"
+
+    def test_strips_whitespace(self):
+        assert update_check.parse_manifest("  version = 1.27.0  ") == {
+            "version": "1.27.0"
+        }
+
+    def test_lines_without_equals_are_skipped(self):
+        assert update_check.parse_manifest("garbage\nversion=1.27.0") == {
+            "version": "1.27.0"
+        }
+
+
+class TestFetchLatestManifest:
+    @pytest.fixture(autouse=True)
+    def _patch_httpretty_socket(self, monkeypatch):
+        import httpretty.core
+
+        monkeypatch.setattr(
+            httpretty.core.fakesock.socket,
+            "shutdown",
+            lambda self, how: None,
+            raising=False,
+        )
+
+    def _url(self, target=update_check.VERSION_PROBE_TARGET):
+        return update_check.MANIFEST_URL_TEMPLATE.format(target=target)
+
+    def test_fetches_and_parses(self):
+        import httpretty
+
+        from cloudsmith_cli.core.session import create_requests_session
+
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.GET,
+                self._url(),
+                body="schema=1\nversion=1.27.0\n",
+                status=200,
+            )
+            manifest = update_check.fetch_latest_manifest(create_requests_session())
+        assert manifest["version"] == "1.27.0"
+
+    def test_follows_redirect(self):
+        """The ``latest`` alias 302-redirects to a concrete version manifest."""
+        import httpretty
+
+        from cloudsmith_cli.core.session import create_requests_session
+
+        concrete = self._url().replace("latest", "1.27.0")
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.GET,
+                self._url(),
+                status=302,
+                location=concrete,
+            )
+            httpretty.register_uri(
+                httpretty.GET,
+                concrete,
+                body="version=1.27.0\n",
+                status=200,
+            )
+            manifest = update_check.fetch_latest_manifest(create_requests_session())
+        assert manifest["version"] == "1.27.0"
+
+    def test_missing_version_raises(self):
+        import httpretty
+
+        from cloudsmith_cli.core.session import create_requests_session
+
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.GET, self._url(), body="schema=1\n", status=200
+            )
+            with pytest.raises(ValueError):
+                update_check.fetch_latest_manifest(create_requests_session())
+
+    def test_http_error_raises(self):
+        import httpretty
+
+        from cloudsmith_cli.core.session import create_requests_session
+
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(httpretty.GET, self._url(), status=404)
+            with pytest.raises(requests.RequestException):
+                update_check.fetch_latest_manifest(create_requests_session(retries=0))
+
+
+class TestRunBackgroundCheck:
+    def test_records_on_success(self, state_path):
+        update_check.run_background_check(
+            _FakeSession(version_str=NEWER_VERSION), now=NOW
+        )
+        assert _read_state(state_path)["latest_version"] == NEWER_VERSION
+        assert _read_state(state_path)["last_check_at"] == NOW
+
+    def test_swallows_network_failure_and_records_nothing(self, state_path):
+        # Must not raise, and must not create the state file.
+        update_check.run_background_check(_FakeSession(fails=True), now=NOW)
+        assert not os.path.exists(state_path)
+
+
+class TestNoticeSuppressed:
+    @pytest.fixture
+    def _tty(self, monkeypatch):
+        monkeypatch.setattr(update_check, "stderr_is_tty", lambda: True)
+
+    @pytest.mark.parametrize("fmt", ["json", "pretty_json"])
+    def test_machine_output_suppresses(self, fmt, _tty):
+        assert update_check.notice_suppressed(fmt, None) is True
+
+    def test_non_tty_suppresses(self, monkeypatch):
+        monkeypatch.setattr(update_check, "stderr_is_tty", lambda: False)
+        assert update_check.notice_suppressed("pretty", None) is True
+
+    @pytest.mark.parametrize("cmd", ["mcp", "update", "upgrade"])
+    def test_suppressed_subcommands(self, cmd, _tty):
+        assert update_check.notice_suppressed("pretty", cmd) is True
+
+    def test_not_suppressed_for_normal_interactive_command(self, _tty):
+        assert update_check.notice_suppressed("pretty", "list") is False
+
+
+class TestFinishAndNotify:
+    """Join-then-notify at command close."""
+
+    def test_notifies_and_bumps_when_behind(self, state_path, capsys):
+        _write_state(
+            state_path, last_check_at=NOW - (DAY * 2), latest_version=NEWER_VERSION
+        )
+        update_check._finish_and_notify(None, now=NOW)
+        err = capsys.readouterr().err
+        assert "new version" in err.lower()
+        assert NEWER_VERSION in err
+        assert _read_state(state_path)["last_check_at"] == NOW
+
+    def test_silent_when_up_to_date(self, state_path, capsys):
+        _write_state(state_path, last_check_at=NOW, latest_version=CURRENT_VERSION)
+        update_check._finish_and_notify(None, now=NOW)
+        assert capsys.readouterr().err == ""
+
+    def test_joins_thread_before_reading_state(self, state_path, capsys):
+        """A thread that writes a newer version is joined, then the notice fires."""
+        import threading
+
+        _write_state(state_path, last_check_at=NOW - (DAY * 2))
+
+        def writer():
+            update_check.record_check(NEWER_VERSION, now=NOW)
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        update_check._finish_and_notify(thread, now=NOW + 1)
+        err = capsys.readouterr().err
+        assert NEWER_VERSION in err

--- a/cloudsmith_cli/core/update_check.py
+++ b/cloudsmith_cli/core/update_check.py
@@ -44,6 +44,9 @@ MANIFEST_URL_TEMPLATE = (
     "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/"
     "cloudsmith-cli-manifest-{target}/versions/latest/manifest.txt"
 )
+#: Overrides ``MANIFEST_URL_TEMPLATE`` when set. Must contain a ``{target}``
+#: placeholder. For testing self-update against a local or staging endpoint.
+MANIFEST_URL_TEMPLATE_ENV = "CLOUDSMITH_MANIFEST_URL_TEMPLATE"
 VERSION_PROBE_TARGET = "linux-x86_64-gnu"
 MANIFEST_FETCH_TIMEOUT_SECONDS = 5.0
 #: How long the command waits at exit for the background fetch to finish.
@@ -133,6 +136,25 @@ def record_notified(now=None):
     _write_state({"last_notified_at": now})
 
 
+def record_checked_and_notified(latest_version, now=None):
+    """Stamp both timestamps and the latest version in a single write.
+
+    Used by the ``update`` command, which performs its own check on every run
+    regardless of the cache. Advancing ``last_notified_at`` alongside
+    ``last_checked_at`` disarms the background notice's daily re-nag
+    (``last_notified_at < last_checked_at`` becomes false) so the user is not
+    told about an update they just ran the command to handle.
+    """
+    now = time.time() if now is None else now
+    _write_state(
+        {
+            "last_checked_at": now,
+            "last_notified_at": now,
+            "latest_version": latest_version,
+        }
+    )
+
+
 def parse_manifest(text):
     """Parse the ``key=value`` lines of a release manifest into a dict.
 
@@ -158,7 +180,8 @@ def fetch_latest_manifest(
     apply and redirects are followed). Raises ``requests.RequestException`` on
     network failure and ``ValueError`` if the manifest has no ``version``.
     """
-    url = MANIFEST_URL_TEMPLATE.format(target=target)
+    template = os.environ.get(MANIFEST_URL_TEMPLATE_ENV) or MANIFEST_URL_TEMPLATE
+    url = template.format(target=target)
     response = session.get(url, timeout=timeout)
     response.raise_for_status()
     manifest = parse_manifest(response.text)
@@ -292,17 +315,41 @@ def notice_suppressed(output_format=None, invoked_subcommand=None):
     return invoked_subcommand in NOTICE_SUPPRESSED_SUBCOMMANDS
 
 
+def _update_action_lines():
+    """Return the "how to update" lines for the current install channel.
+
+    A standalone binary can update itself, so it is pointed at
+    ``cloudsmith update``. Every package-managed install cannot be updated by
+    the CLI, so the notice prints that channel's own upgrade command on its own
+    line — easy to copy, and not mangled by terminal line-wrapping — rather than
+    sending the user to a command that would only print another command.
+    """
+    from . import installation
+
+    channel = installation.detect_channel()
+    instruction = installation.upgrade_instruction(channel)
+    if instruction is None:
+        if installation.self_update_supported():
+            return ["Run `cloudsmith update` to update."]
+        return [
+            "Download the latest build and replace your install:",
+            f"  {installation.RELEASES_LATEST_URL}",
+        ]
+    return ["To update, run:", f"  {instruction}"]
+
+
 def print_update_notice(latest_version):
     """Print the "an update is available" notice on stderr."""
     import click
 
-    click.secho(
-        "A new version of the Cloudsmith CLI is available: "
-        f"{version.get_version()} \u2192 {latest_version}. "
-        "Run `cloudsmith update` to update.",
-        fg="yellow",
-        err=True,
-    )
+    lines = [
+        (
+            "A new version of the Cloudsmith CLI is available: "
+            f"{version.get_version()} \u2192 {latest_version}."
+        ),
+        *_update_action_lines(),
+    ]
+    click.secho("\n".join(lines), fg="yellow", err=True)
 
 
 def _start_background_check(session):

--- a/cloudsmith_cli/core/update_check.py
+++ b/cloudsmith_cli/core/update_check.py
@@ -1,0 +1,326 @@
+"""Decide when to check for a newer CLI version, and record what we found.
+
+This module answers *whether* an update check (a network fetch) should run now
+and stores *when* the last successful check happened together with the latest
+version it reported. It performs no network access itself and renders no
+notice; those belong to the actual update-check implementation that calls into
+here.
+
+The decision to act (fetch and/or notify) combines, in precedence order:
+
+1. The ``--no-check-update`` flag.
+2. The ``CLOUDSMITH_NO_UPDATE_CHECK`` environment variable (and ``CI``).
+3. The ``check_for_update`` config-file key.
+4. A once-every-24-hours freshness rule backed by an on-disk timestamp.
+
+A single ``last_check_at`` timestamp throttles both the network fetch and the
+"an update is available" notice to at most once a day. When the caller acts —
+whether it fetches a new version or merely reprints the notice for a version it
+already knows is newer — it bumps ``last_check_at`` so nothing repeats until the
+day is up. Deciding whether a notice is warranted (as opposed to whether it is
+*time* to act) is left to :func:`should_notify`.
+"""
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+
+from ..cli.config import get_default_config_path
+from . import version
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILE_NAME = "update_check.json"
+DEFAULT_INTERVAL_SECONDS = 24 * 60 * 60
+NO_UPDATE_CHECK_ENV = "CLOUDSMITH_NO_UPDATE_CHECK"
+_TRUTHY_ENV_VALUES = ("1", "true", "yes")
+
+#: The manifest the release workflow publishes per build target. We only read
+#: ``version`` from it, so any existing target works as a probe; the download
+#: fields (``url``/``sha256``) belong to the self-update path.
+MANIFEST_URL_TEMPLATE = (
+    "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/"
+    "cloudsmith-cli-manifest-{target}/versions/latest/manifest.txt"
+)
+VERSION_PROBE_TARGET = "linux-x86_64-gnu"
+MANIFEST_FETCH_TIMEOUT_SECONDS = 5.0
+#: How long the command waits at exit for the background fetch to finish.
+BACKGROUND_JOIN_TIMEOUT_SECONDS = 1.0
+
+#: Output formats that suppress the interactive update notice.
+MACHINE_OUTPUT_FORMATS = ("json", "pretty_json")
+#: Subcommands that suppress the interactive update notice.
+NOTICE_SUPPRESSED_SUBCOMMANDS = frozenset(("mcp", "update", "upgrade"))
+
+
+def get_state_file_path():
+    """Return the path of the update-check state file."""
+    return os.path.join(get_default_config_path(), CACHE_FILE_NAME)
+
+
+def read_cached_state():
+    """Return the cached update-check state as a dict, or an empty dict.
+
+    Tolerant of a missing, unreadable, corrupt, or unexpectedly-shaped file:
+    any such case returns ``{}``.
+    """
+    try:
+        with open(get_state_file_path(), encoding="utf-8") as state_file:
+            state = json.load(state_file)
+    except (OSError, ValueError):
+        return {}
+    return state if isinstance(state, dict) else {}
+
+
+def read_last_check_time():
+    """Return the unix timestamp of the last check, or None."""
+    try:
+        return float(read_cached_state().get("last_check_at"))
+    except (TypeError, ValueError):
+        return None
+
+
+def read_latest_version():
+    """Return the latest version reported by the last check, or None."""
+    latest = read_cached_state().get("latest_version")
+    return latest or None
+
+
+def record_check(latest_version, now=None):
+    """Record a successful check's timestamp and reported latest version.
+
+    Called only after a successful check. A failure to persist the state must
+    never break the running command, so storage errors are swallowed.
+    """
+    from .cache_utils import atomic_write_json
+
+    now = time.time() if now is None else now
+    path = get_state_file_path()
+    state = {"last_check_at": now, "latest_version": latest_version}
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        atomic_write_json(path, state)
+    except OSError:
+        logger.debug("Failed to record the update-check state", exc_info=True)
+
+
+def parse_manifest(text):
+    """Parse the ``key=value`` lines of a release manifest into a dict.
+
+    Blank lines and ``#`` comments are skipped. Unknown keys (including
+    ``schema``) are kept but otherwise ignored by callers.
+    """
+    manifest = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        manifest[key.strip()] = value.strip()
+    return manifest
+
+
+def fetch_latest_manifest(
+    session, target=VERSION_PROBE_TARGET, timeout=MANIFEST_FETCH_TIMEOUT_SECONDS
+):
+    """Fetch and parse the latest release manifest for a build target.
+
+    ``session`` is the shared requests session (so proxy/CA/user-agent settings
+    apply and redirects are followed). Raises ``requests.RequestException`` on
+    network failure and ``ValueError`` if the manifest has no ``version``.
+    """
+    url = MANIFEST_URL_TEMPLATE.format(target=target)
+    response = session.get(url, timeout=timeout)
+    response.raise_for_status()
+    manifest = parse_manifest(response.text)
+    if "version" not in manifest:
+        raise ValueError(f"no version field in manifest from {url}")
+    return manifest
+
+
+def run_background_check(session, now=None):
+    """Fetch the latest version and record it; swallow all errors.
+
+    Intended to run in a daemon thread. Any network, parse or storage failure
+    is logged at debug level and otherwise ignored so it can never disturb the
+    command that spawned it.
+    """
+    import requests
+
+    try:
+        manifest = fetch_latest_manifest(session)
+    except (requests.RequestException, ValueError):
+        logger.debug("Update check fetch failed", exc_info=True)
+        return
+    record_check(manifest["version"], now=now)
+
+
+def is_check_due(last_check_at, *, now=None, interval=DEFAULT_INTERVAL_SECONDS):
+    """Tell whether at least ``interval`` seconds have elapsed since last check.
+
+    A missing or invalid ``last_check_at`` means a check is due.
+    """
+    try:
+        last = float(last_check_at)
+    except (TypeError, ValueError):
+        return True
+    now = time.time() if now is None else now
+    return (now - last) >= interval
+
+
+def newer_version_known(latest_version, current_version=None):
+    """Tell whether a cached ``latest_version`` is newer than the current one.
+
+    Used to skip a redundant network fetch: if we already know we are behind,
+    another fetch tells us nothing new. An absent or unparsable version is
+    treated as "not known to be newer".
+    """
+    if not latest_version:
+        return False
+    try:
+        current = (
+            version.get_version_info()
+            if current_version is None
+            else version.parse_version(current_version)
+        )
+        return version.parse_version(latest_version) > current
+    except (TypeError, ValueError):
+        return False
+
+
+def update_check_disabled(*, no_check_flag, config_value=None, env=None):
+    """Tell whether the update check is disabled for this invocation.
+
+    Precedence: ``--no-check-update`` flag, then the
+    ``CLOUDSMITH_NO_UPDATE_CHECK`` env var (and ``CI``), then the
+    ``check_for_update`` config key.
+    """
+    if no_check_flag:
+        return True
+    env = os.environ if env is None else env
+    env_value = env.get(NO_UPDATE_CHECK_ENV, "").strip().lower()
+    if env_value in _TRUTHY_ENV_VALUES:
+        return True
+    if env.get("CI"):
+        return True
+    return config_value is False
+
+
+def should_check_for_update(*, no_check_flag, config_value=None, env=None, now=None):
+    """Tell whether the CLI should act (fetch and/or notify) this invocation.
+
+    True when the check is not disabled and at least a day has elapsed since
+    the last action. It does not distinguish between "fetch" and "notify"; the
+    caller inspects the cached state (via :func:`should_notify`) to decide which
+    to do. Being behind does *not* short-circuit here — the daily notice depends
+    on this returning True while a newer version is known.
+    """
+    if update_check_disabled(
+        no_check_flag=no_check_flag, config_value=config_value, env=env
+    ):
+        return False
+    return is_check_due(read_cached_state().get("last_check_at"), now=now)
+
+
+def should_notify(state=None, *, current_version=None):
+    """Tell whether an "update available" notice is warranted from cached state.
+
+    True when the cached ``latest_version`` is newer than the running CLI. The
+    once-a-day throttle is supplied separately by
+    :func:`should_check_for_update`; this only judges whether there is something
+    worth saying.
+    """
+    if state is None:
+        state = read_cached_state()
+    return newer_version_known(state.get("latest_version"), current_version)
+
+
+def stderr_is_tty():
+    """Tell whether stderr is attached to a terminal."""
+    return sys.stderr is not None and sys.stderr.isatty()
+
+
+def notice_suppressed(output_format=None, invoked_subcommand=None):
+    """Tell whether the interactive update notice must stay silent.
+
+    Independent of the disable controls in :func:`update_check_disabled`: this
+    covers presentation reasons — machine output, a non-interactive terminal,
+    or a subcommand that must never be interrupted by the notice.
+    """
+    if output_format in MACHINE_OUTPUT_FORMATS:
+        return True
+    if not stderr_is_tty():
+        return True
+    return invoked_subcommand in NOTICE_SUPPRESSED_SUBCOMMANDS
+
+
+def print_update_notice(latest_version):
+    """Print the "an update is available" notice on stderr."""
+    import click
+
+    click.secho(
+        "A new version of the Cloudsmith CLI is available: "
+        f"{version.get_version()} \u2192 {latest_version}. "
+        "Run `cloudsmith update` to update.",
+        fg="yellow",
+        err=True,
+    )
+
+
+def _start_background_check(session):
+    """Start the manifest fetch in a daemon thread and return it."""
+    thread = threading.Thread(
+        target=run_background_check,
+        args=(session,),
+        name="cloudsmith-update-check",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _finish_and_notify(thread, *, now=None):
+    """Join the background fetch (bounded) then notify once a day if behind.
+
+    Runs at command close. If a newer version is known — whether the just-joined
+    fetch discovered it or the cache already held it — print the notice and bump
+    ``last_check_at`` so it does not repeat until tomorrow.
+    """
+    if thread is not None:
+        thread.join(BACKGROUND_JOIN_TIMEOUT_SECONDS)
+    state = read_cached_state()
+    if not should_notify(state):
+        return
+    print_update_notice(state["latest_version"])
+    record_check(state["latest_version"], now=now)
+
+
+def arm(ctx, opts, no_check_flag):
+    """Wire up the update check for this invocation, if enabled.
+
+    When a check is due and not disabled, start the background fetch (unless we
+    already know we are behind, in which case there is nothing to fetch) and
+    register a close handler that joins it and prints the notice. The notice is
+    additionally suppressed for machine output, non-TTY stderr and certain
+    subcommands via :func:`notice_suppressed`.
+    """
+    invoked = ctx.invoked_subcommand
+    invoked = getattr(ctx.command, "inverse", {}).get(invoked, invoked)
+    if notice_suppressed(getattr(opts, "output", None), invoked):
+        return
+    if not should_check_for_update(
+        no_check_flag=no_check_flag, config_value=opts.check_for_update
+    ):
+        return
+
+    thread = None
+    if not should_notify():
+        from .session import create_requests_session
+
+        session = create_requests_session(user_agent=opts.api_user_agent)
+        thread = _start_background_check(session)
+
+    ctx.call_on_close(lambda: _finish_and_notify(thread))

--- a/cloudsmith_cli/core/update_check.py
+++ b/cloudsmith_cli/core/update_check.py
@@ -1,24 +1,23 @@
-"""Decide when to check for a newer CLI version, and record what we found.
+"""Decide when to check for a newer CLI version, and when to notify about it.
 
-This module answers *whether* an update check (a network fetch) should run now
-and stores *when* the last successful check happened together with the latest
-version it reported. It performs no network access itself and renders no
-notice; those belong to the actual update-check implementation that calls into
-here.
+State lives in a small JSON file with two timestamps and the last-seen version:
+``{last_checked_at, last_notified_at, latest_version}``.
 
-The decision to act (fetch and/or notify) combines, in precedence order:
+Two rhythms run off it, deliberately decoupled:
 
-1. The ``--no-check-update`` flag.
-2. The ``CLOUDSMITH_NO_UPDATE_CHECK`` environment variable (and ``CI``).
-3. The ``check_for_update`` config-file key.
-4. A once-every-24-hours freshness rule backed by an on-disk timestamp.
+* **Fetch** (network + refresh ``latest_version``) runs at most once a day,
+  gated by ``last_checked_at`` and the disable controls (``--no-check-update``,
+  ``CLOUDSMITH_NO_UPDATE_CHECK``, ``CI``, ``check_for_update``). It runs even in
+  contexts where the notice is silenced (``-F json``, non-TTY, ``mcp``/``update``)
+  so the cache stays warm for a later interactive run.
 
-A single ``last_check_at`` timestamp throttles both the network fetch and the
-"an update is available" notice to at most once a day. When the caller acts —
-whether it fetches a new version or merely reprints the notice for a version it
-already knows is newer — it bumps ``last_check_at`` so nothing repeats until the
-day is up. Deciding whether a notice is warranted (as opposed to whether it is
-*time* to act) is left to :func:`should_notify`.
+* **Notice** ("an update is available") is gated by the invariant
+  ``last_notified_at < last_checked_at`` — i.e. a check has happened since we
+  last spoke — plus the presentation suppressors in :func:`notice_suppressed`.
+  Tying the notice to "a check we have not reported" rather than to its own
+  clock keeps the two rhythms from drifting: a fetch that could not print (JSON,
+  non-TTY) advances ``last_checked_at`` without spending the notice, so the next
+  interactive run still notifies promptly.
 """
 
 import json
@@ -75,12 +74,22 @@ def read_cached_state():
     return state if isinstance(state, dict) else {}
 
 
-def read_last_check_time():
-    """Return the unix timestamp of the last check, or None."""
+def _read_timestamp(key):
+    """Return a float timestamp for ``key`` from the cached state, or None."""
     try:
-        return float(read_cached_state().get("last_check_at"))
+        return float(read_cached_state().get(key))
     except (TypeError, ValueError):
         return None
+
+
+def read_last_check_time():
+    """Return the unix timestamp of the last check, or None."""
+    return _read_timestamp("last_checked_at")
+
+
+def read_last_notified_time():
+    """Return the unix timestamp of the last notice, or None."""
+    return _read_timestamp("last_notified_at")
 
 
 def read_latest_version():
@@ -89,22 +98,39 @@ def read_latest_version():
     return latest or None
 
 
-def record_check(latest_version, now=None):
-    """Record a successful check's timestamp and reported latest version.
+def _write_state(updates):
+    """Merge ``updates`` into the cached state and write it; swallow errors.
 
-    Called only after a successful check. A failure to persist the state must
-    never break the running command, so storage errors are swallowed.
+    A read-modify-write so that updating one field (e.g. the check timestamp)
+    never drops a sibling (e.g. the notice timestamp). A failure to persist the
+    state must never break the running command.
     """
     from .cache_utils import atomic_write_json
 
-    now = time.time() if now is None else now
     path = get_state_file_path()
-    state = {"last_check_at": now, "latest_version": latest_version}
+    state = read_cached_state()
+    state.update(updates)
     try:
         os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
         atomic_write_json(path, state)
     except OSError:
         logger.debug("Failed to record the update-check state", exc_info=True)
+
+
+def record_check(latest_version, now=None):
+    """Record a check's timestamp and reported latest version.
+
+    Preserves ``last_notified_at``. Called after a fetch, or when a
+    cache-confirmed newer version re-arms the daily check without a fetch.
+    """
+    now = time.time() if now is None else now
+    _write_state({"last_checked_at": now, "latest_version": latest_version})
+
+
+def record_notified(now=None):
+    """Record that the update notice was just shown. Preserves the rest."""
+    now = time.time() if now is None else now
+    _write_state({"last_notified_at": now})
 
 
 def parse_manifest(text):
@@ -210,32 +236,41 @@ def update_check_disabled(*, no_check_flag, config_value=None, env=None):
 
 
 def should_check_for_update(*, no_check_flag, config_value=None, env=None, now=None):
-    """Tell whether the CLI should act (fetch and/or notify) this invocation.
+    """Tell whether a check (fetch or cache-confirmed re-arm) is due this run.
 
     True when the check is not disabled and at least a day has elapsed since
-    the last action. It does not distinguish between "fetch" and "notify"; the
-    caller inspects the cached state (via :func:`should_notify`) to decide which
-    to do. Being behind does *not* short-circuit here — the daily notice depends
-    on this returning True while a newer version is known.
+    ``last_checked_at``. Independent of presentation: a check may run even when
+    the notice will be silenced.
     """
     if update_check_disabled(
         no_check_flag=no_check_flag, config_value=config_value, env=env
     ):
         return False
-    return is_check_due(read_cached_state().get("last_check_at"), now=now)
+    return is_check_due(read_cached_state().get("last_checked_at"), now=now)
 
 
 def should_notify(state=None, *, current_version=None):
     """Tell whether an "update available" notice is warranted from cached state.
 
-    True when the cached ``latest_version`` is newer than the running CLI. The
-    once-a-day throttle is supplied separately by
-    :func:`should_check_for_update`; this only judges whether there is something
-    worth saying.
+    True when the cached ``latest_version`` is newer than the running CLI *and*
+    a check has happened since the last notice (``last_notified_at <
+    last_checked_at``). The second clause is the daily throttle: a check re-arms
+    the notice, and showing it stamps ``last_notified_at`` to disarm it until the
+    next check.
     """
     if state is None:
         state = read_cached_state()
-    return newer_version_known(state.get("latest_version"), current_version)
+    if not newer_version_known(state.get("latest_version"), current_version):
+        return False
+    try:
+        last_notified = float(state.get("last_notified_at") or 0)
+    except (TypeError, ValueError):
+        last_notified = 0.0
+    try:
+        last_checked = float(state.get("last_checked_at") or 0)
+    except (TypeError, ValueError):
+        last_checked = 0.0
+    return last_notified < last_checked
 
 
 def stderr_is_tty():
@@ -282,45 +317,53 @@ def _start_background_check(session):
     return thread
 
 
-def _finish_and_notify(thread, *, now=None):
-    """Join the background fetch (bounded) then notify once a day if behind.
+def _finish_and_notify(thread, opts, invoked, *, now=None):
+    """Join the background fetch (bounded) then notify if warranted.
 
-    Runs at command close. If a newer version is known — whether the just-joined
-    fetch discovered it or the cache already held it — print the notice and bump
-    ``last_check_at`` so it does not repeat until tomorrow.
+    Runs at command close. Presentation suppressors are evaluated here (not at
+    decision time) so a subcommand's own ``-F`` and the live TTY state are
+    known. When suppressed, ``last_notified_at`` is left untouched so a later
+    interactive run can still speak.
     """
     if thread is not None:
         thread.join(BACKGROUND_JOIN_TIMEOUT_SECONDS)
+    if notice_suppressed(getattr(opts, "output", None), invoked):
+        return
     state = read_cached_state()
     if not should_notify(state):
         return
     print_update_notice(state["latest_version"])
-    record_check(state["latest_version"], now=now)
+    record_notified(now=now)
 
 
 def arm(ctx, opts, no_check_flag):
-    """Wire up the update check for this invocation, if enabled.
+    """Wire up the update check for this invocation.
 
-    When a check is due and not disabled, start the background fetch (unless we
-    already know we are behind, in which case there is nothing to fetch) and
-    register a close handler that joins it and prints the notice. The notice is
-    additionally suppressed for machine output, non-TTY stderr and certain
-    subcommands via :func:`notice_suppressed`.
+    Unless disabled (``--no-check-update``/env/``CI``/config), a close handler is
+    always registered so a pending notice can fire from cache even on a run where
+    no fetch is due. When a fetch *is* due, either start the background fetch or —
+    if we already know we are behind — bump ``last_checked_at`` to re-arm the
+    daily notice without a fetch. The fetch runs even when the notice is
+    suppressed (e.g. ``-F json``, non-TTY), keeping the cache warm; the close
+    handler decides separately whether to print.
     """
     invoked = ctx.invoked_subcommand
     invoked = getattr(ctx.command, "inverse", {}).get(invoked, invoked)
-    if notice_suppressed(getattr(opts, "output", None), invoked):
-        return
-    if not should_check_for_update(
+    if update_check_disabled(
         no_check_flag=no_check_flag, config_value=opts.check_for_update
     ):
         return
 
     thread = None
-    if not should_notify():
-        from .session import create_requests_session
+    if is_check_due(read_last_check_time()):
+        if newer_version_known(read_latest_version()):
+            # Already behind: no fetch needed, but bump last_checked_at so the
+            # daily notice re-arms (last_notified_at < last_checked_at).
+            record_check(read_latest_version())
+        else:
+            from .session import create_requests_session
 
-        session = create_requests_session(user_agent=opts.api_user_agent)
-        thread = _start_background_check(session)
+            session = create_requests_session(user_agent=opts.api_user_agent)
+            thread = _start_background_check(session)
 
-    ctx.call_on_close(lambda: _finish_and_notify(thread))
+    ctx.call_on_close(lambda: _finish_and_notify(thread, opts, invoked))

--- a/cloudsmith_cli/data/config.ini
+++ b/cloudsmith_cli/data/config.ini
@@ -15,6 +15,9 @@ api_user_agent=
 # The Cloudsmith Workspace slug (default: None).
 workspace=
 
+# Whether to check once a day for a newer version of the CLI (default: True).
+check_for_update=
+
 
 # Profile-based configuration
 # You can set as many additional profiles as you need to provide


### PR DESCRIPTION
## Summary

Adds a `cloudsmith update` command for self-updating standalone binary installs, plus a non-intrusive background check that notifies users when a newer version is available.

## Changes

- **`update` command** (`cli/commands/update.py`): self-updates the standalone binary installation. Reads the release manifest, downloads and replaces target files in place (per-file replace rather than swapping the whole install dir, so user files in the install dir are preserved). Handles Windows update quirks.
- **Background update check** (`core/update_check.py`): probes for the latest version of the *host's own* platform/arch (previously always probed `linux-x86_64-gnu`). Uses a non-configurable manifest URL. Tracks a second "last notified" timestamp so a notification can be suppressed until a later run (e.g. when running in JSON mode).
- **Install detection** (`core/installation.py`): detects how the CLI was installed to decide whether self-update applies.
- **Self-update engine** (`core/self_update.py`): download/verify/replace logic.
- Config plumbing in `cli/config.py` + `data/config.ini`, and wiring into `main.py` / `registry.py` / `utils.py`.

## Tests

New unit tests for the update command, self-update engine, installation detection, background check, and main-group integration.

## Notes

Tracking: ENG-14145